### PR TITLE
Ops-Haertung Runde 1 (F1-F4, CI-Luecken, Betriebshaertung)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,9 @@ RELAY_AUTH_TOKEN=your-relay-auth-token-replace-this-in-production
 # `make prod-init`. See docs/leitfaden.md.
 JOTTI_DOMAIN=
 LETSENCRYPT_EMAIL=
-# Pinned image version (a release tag like v0.1.0, or `latest`).
-JOTTI_VERSION=latest
+# Pinned release version. Required for `make prod-init` / `make prod-update`: set
+# this to a release tag like v0.2.0 from https://github.com/nicograef/jotti/releases.
+JOTTI_VERSION=
 # Optional: redirect www.<domain> to <domain> (set to 1; needs www DNS here).
 JOTTI_WWW_REDIRECT=
 # Backups (make prod-backup / prod-restore). Where dumps are written and how many

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ JOTTI_WWW_REDIRECT=
 # to keep (BACKUP_KEEP<=0 keeps all). Both optional; these are the defaults.
 BACKUP_DIR=./backups
 BACKUP_KEEP=14
+# Optional dead man's switch: URL pinged after every successful backup (e.g. a
+# healthchecks.io ping). Leave empty to disable. A failed ping never fails the backup.
+BACKUP_PING_URL=
 
 # Public IPv4 of this server. Only required for the jotti.rocks / local-TLS stack
 # (DNS resolver + acme-dns); leave empty for plain self-hosted production.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,122 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/backend"
+    schedule:
+      interval: "monthly"
+    groups:
+      backend-gomod:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/resolver"
+    schedule:
+      interval: "monthly"
+    groups:
+      resolver-gomod:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/reverse-proxy"
+    schedule:
+      interval: "monthly"
+    groups:
+      reverse-proxy-gomod:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/windows/relay"
+    schedule:
+      interval: "monthly"
+    groups:
+      relay-gomod:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/windows/starter"
+    schedule:
+      interval: "monthly"
+    groups:
+      starter-gomod:
+        patterns:
+          - "*"
+
+  # npm
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "monthly"
+    groups:
+      frontend-npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "monthly"
+    groups:
+      website-npm:
+        patterns:
+          - "*"
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "monthly"
+    groups:
+      backend-docker:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/frontend"
+    schedule:
+      interval: "monthly"
+    groups:
+      frontend-docker:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/database/migrate"
+    schedule:
+      interval: "monthly"
+    groups:
+      migrate-docker:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/reverse-proxy"
+    schedule:
+      interval: "monthly"
+    groups:
+      reverse-proxy-docker:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/website"
+    schedule:
+      interval: "monthly"
+    groups:
+      website-docker:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,9 @@ jobs:
       database: ${{ steps.changes.outputs.database }}
       resolver: ${{ steps.changes.outputs.resolver }}
       proxy: ${{ steps.changes.outputs.proxy }}
-      cmd: ${{ steps.changes.outputs.cmd }}
+      windows: ${{ steps.changes.outputs.windows }}
       website: ${{ steps.changes.outputs.website }}
+      scripts: ${{ steps.changes.outputs.scripts }}
     steps:
       - uses: actions/checkout@v6
       - name: Check for changes
@@ -34,11 +35,12 @@ jobs:
               - 'resolver/**'
             proxy:
               - 'reverse-proxy/**'
-            cmd:
-              - 'cmd/**'
+            windows:
+              - 'windows/**'
             website:
               - 'website/**'
-              - 'scripts/check-website.sh'
+            scripts:
+              - 'scripts/**'
 
   backend-ci:
     needs: changes
@@ -180,9 +182,9 @@ jobs:
       - name: Test
         run: go test -v -race ./...
 
-  cmd-ci:
+  windows-ci:
     needs: changes
-    if: ${{ needs.changes.outputs.cmd == 'true' }}
+    if: ${{ needs.changes.outputs.windows == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -195,15 +197,15 @@ jobs:
           cache: false
 
       - name: Download dependencies
-        working-directory: ./cmd/${{ matrix.module }}
+        working-directory: ./windows/${{ matrix.module }}
         run: go mod download
 
       - name: Verify dependencies
-        working-directory: ./cmd/${{ matrix.module }}
+        working-directory: ./windows/${{ matrix.module }}
         run: go mod verify
 
       - name: Check format
-        working-directory: ./cmd/${{ matrix.module }}
+        working-directory: ./windows/${{ matrix.module }}
         run: |
           go install golang.org/x/tools/cmd/goimports@v0.40.0
           if [ "$(goimports -l . | wc -l)" -gt 0 ]; then
@@ -213,15 +215,15 @@ jobs:
           fi
 
       - name: Vet
-        working-directory: ./cmd/${{ matrix.module }}
+        working-directory: ./windows/${{ matrix.module }}
         run: go vet ./...
 
       - name: Build
-        working-directory: ./cmd/${{ matrix.module }}
+        working-directory: ./windows/${{ matrix.module }}
         run: go build -v ./...
 
       - name: Test
-        working-directory: ./cmd/${{ matrix.module }}
+        working-directory: ./windows/${{ matrix.module }}
         run: go test -v -race ./...
 
   frontend-ci:
@@ -276,14 +278,24 @@ jobs:
         with:
           node-version: 24
           cache: "pnpm"
-          cache-dependency-path: frontend/pnpm-lock.yaml
+          cache-dependency-path: website/pnpm-lock.yaml
 
       - name: Install dependencies
-        working-directory: ./frontend
+        working-directory: ./website
         run: pnpm install --frozen-lockfile
 
       - name: Website checks
         run: make website-check
+
+  shellcheck-ci:
+    needs: changes
+    if: ${{ needs.changes.outputs.scripts == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run shellcheck
+        run: shellcheck scripts/*.sh
 
   backend-integration-tests:
     needs: changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,15 @@ jobs:
           declare -A dockerfile=(
             [migrate]=./database/migrate/Dockerfile
           )
+          # Nur das Backend kompiliert die Version per ldflags ein; die anderen
+          # Images kennen kein VERSION-Build-Arg.
+          declare -A buildarg=(
+            [backend]="--build-arg VERSION=$VERSION"
+          )
           for svc in "${!ctx[@]}"; do
             docker buildx build --load \
               ${dockerfile[$svc]:+--file "${dockerfile[$svc]}"} \
+              ${buildarg[$svc]:-} \
               --tag "ghcr.io/nicograef/jotti-$svc:$VERSION" \
               --label "org.opencontainers.image.version=$VERSION" \
               "${ctx[$svc]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,22 @@ jobs:
           echo "Smoke-Test fehlgeschlagen: /api/health wurde nicht healthy."
           exit 1
 
+      # Backup- und Verify-Pfad Ende-zu-Ende gegen den laufenden Release-Stack.
+      # Schlägt einer fehl, ist das Release rot (der Restore-Pfad bleibt bewusst
+      # unautomatisiert — sein psql-Kern ist mit dem Verify identisch).
+      # Der Verify bekommt den soeben erzeugten Dump explizit übergeben statt
+      # sich auf „neuester im Verzeichnis" zu verlassen.
+      - name: Smoke-Test — Backup ziehen
+        id: backup
+        run: |
+          COMPOSE_FILE=docker-compose.release.yml ./scripts/prod-backup.sh
+          dump="$(find backups -maxdepth 1 -type f -name 'jotti-*.sql.gz' -printf '%f\n' | sort | tail -n1)"
+          [ -n "$dump" ] || { echo "Kein Dump erzeugt."; exit 1; }
+          echo "dump=backups/$dump" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-Test — Backup verifizieren
+        run: COMPOSE_FILE=docker-compose.release.yml ./scripts/prod-backup-verify.sh "${{ steps.backup.outputs.dump }}"
+
       - name: Smoke-Test — Logs bei Fehler
         if: failure()
         run: docker compose -f docker-compose.release.yml logs

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
        build-backend build-relay build-resolver build-local-proxy build-frontend build \
        build-starter-windows build-relay-windows starter-syso release-windows \
        sqlc \
-       prod-init prod-up prod-update prod-down prod-logs prod-backup prod-restore prod-harden \
+       prod-init prod-up prod-update prod-down prod-logs prod-backup prod-restore prod-backup-verify prod-harden \
        rocks-init rocks-up rocks-down rocks-logs rocks-reset-db rocks-reset-and-seed \
        local-up local-down local-logs local-reset-db local-reset-and-seed \
        db-shell seed rebuild-projections \
@@ -171,6 +171,9 @@ prod-backup: ## Datenbank-Backup ziehen (pg_dump, gzip, rotiert BACKUP_KEEP)
 
 prod-restore: ## Datenbank aus Backup wiederherstellen (destruktiv, mit Bestätigung)
 	./scripts/prod-restore.sh
+
+prod-backup-verify: ## Backup probeweise in Wegwerf-Postgres einspielen (prüft Wiederherstellbarkeit)
+	./scripts/prod-backup-verify.sh
 
 prod-harden: ## Optionale Server-Härtung (ufw-Firewall, fail2ban) — opt-in, idempotent
 	./scripts/prod-harden.sh

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,12 @@ RUN go build -o /go/bin/jotti ./main.go
 # --- Deploy Stage ---
 FROM alpine:3.22
 
+# Unprivilegierter Benutzer: das Backend schreibt nicht ins Dateisystem und
+# lauscht auf 3000 (>1024), braucht also keine root-Rechte.
+RUN addgroup -S jotti && adduser -S -G jotti jotti
+
 COPY --from=builder /go/bin/jotti /usr/local/bin/jotti
+
+USER jotti
 
 ENTRYPOINT [ "jotti" ]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,10 @@ RUN go mod download && go mod verify
 
 COPY . .
 
-RUN go build -o /go/bin/jotti ./main.go
+# Version per ldflags einkompiliert (Default dev). Der Release-Workflow
+# uebergibt den Tag per --build-arg VERSION=<tag>.
+ARG VERSION=dev
+RUN go build -ldflags "-X main.version=${VERSION}" -o /go/bin/jotti ./main.go
 
 # --- Deploy Stage ---
 FROM alpine:3.22

--- a/backend/api/druck/relay/relay_integration_test.go
+++ b/backend/api/druck/relay/relay_integration_test.go
@@ -163,7 +163,7 @@ func setupTestEnv(t *testing.T) testEnv {
 	adminUserID, serviceUserID, produktID, varianteID, tischID := seedTestData(t, db)
 
 	cfg := config.Load()
-	handler := app.SetupRoutes(cfg, db)
+	handler := app.SetupRoutes(cfg, db, "dev")
 	ts := httptest.NewServer(handler)
 	t.Cleanup(func() { ts.Close() })
 

--- a/backend/api/health/health.go
+++ b/backend/api/health/health.go
@@ -15,13 +15,15 @@ type database interface {
 
 // HealthCheck provides health check functionality with database connectivity testing.
 type HealthCheck struct {
-	DB database
+	DB      database
+	Version string
 }
 
 // HealthResponse represents the health check response structure.
 type HealthResponse struct {
 	Status    string `json:"status"`
 	Timestamp string `json:"timestamp"`
+	Version   string `json:"version"`
 }
 
 // Handler returns an HTTP handler for the enhanced health check endpoint with database ping.
@@ -44,6 +46,7 @@ func (h *HealthCheck) Handler() http.HandlerFunc {
 		response := HealthResponse{
 			Status:    status,
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Version:   h.Version,
 		}
 
 		helper.SendJSONResponse(w, response, statusCode)

--- a/backend/app/app.go
+++ b/backend/app/app.go
@@ -24,8 +24,8 @@ type App struct {
 }
 
 // NewApp creates a new application instance
-func NewApp(cfg config.Config, db *sql.DB) (*App, error) {
-	router := SetupRoutes(cfg, db)
+func NewApp(cfg config.Config, db *sql.DB, version string) (*App, error) {
+	router := SetupRoutes(cfg, db, version)
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
 		ReadTimeout:  5 * time.Second,
@@ -42,10 +42,10 @@ func NewApp(cfg config.Config, db *sql.DB) (*App, error) {
 }
 
 // SetupRoutes configures HTTP routes
-func SetupRoutes(cfg config.Config, db *sql.DB) http.Handler {
+func SetupRoutes(cfg config.Config, db *sql.DB, version string) http.Handler {
 	r := http.NewServeMux()
 
-	healthCheck := health.HealthCheck{DB: db}
+	healthCheck := health.HealthCheck{DB: db, Version: version}
 	r.HandleFunc("/health", healthCheck.Handler())
 
 	deps := api.NewDeps(cfg, db)

--- a/backend/app/app_test.go
+++ b/backend/app/app_test.go
@@ -24,7 +24,7 @@ func setRequiredConfigEnv(t *testing.T) {
 func TestNewApp(t *testing.T) {
 	setRequiredConfigEnv(t)
 	cfg := config.Load()
-	app, err := NewApp(cfg, &sql.DB{})
+	app, err := NewApp(cfg, &sql.DB{}, "dev")
 	if err != nil {
 		t.Fatalf("NewApp() failed: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestSetupRoutes(t *testing.T) {
 	setRequiredConfigEnv(t)
 	cfg := config.Load()
 
-	handler := SetupRoutes(cfg, &sql.DB{})
+	handler := SetupRoutes(cfg, &sql.DB{}, "dev")
 
 	if handler == nil {
 		t.Error("Handler should not be nil")
@@ -58,7 +58,7 @@ func TestSetupRoutes_HealthAllowsGet(t *testing.T) {
 	}
 	defer db.Close()
 
-	handler := SetupRoutes(cfg, db)
+	handler := SetupRoutes(cfg, db, "v9.9.9")
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
@@ -77,6 +77,10 @@ func TestSetupRoutes_HealthAllowsGet(t *testing.T) {
 	if code, ok := body["code"].(string); ok && code == "method_not_allowed" {
 		t.Fatalf("GET /health must not be blocked by method middleware")
 	}
+
+	if v, ok := body["version"].(string); !ok || v != "v9.9.9" {
+		t.Fatalf("expected version %q in /health response, got %v", "v9.9.9", body["version"])
+	}
 }
 
 func TestSetupRoutes_NonHealthRejectsGet(t *testing.T) {
@@ -88,7 +92,7 @@ func TestSetupRoutes_NonHealthRejectsGet(t *testing.T) {
 	}
 	defer db.Close()
 
-	handler := SetupRoutes(cfg, db)
+	handler := SetupRoutes(cfg, db, "dev")
 
 	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
 	w := httptest.NewRecorder()
@@ -116,7 +120,7 @@ func TestSetupRoutes_NonHealthRejectsGet(t *testing.T) {
 func TestShutdown(t *testing.T) {
 	setRequiredConfigEnv(t)
 	cfg := config.Load()
-	app, err := NewApp(cfg, &sql.DB{})
+	app, err := NewApp(cfg, &sql.DB{}, "dev")
 	if err != nil {
 		t.Fatalf("NewApp() failed: %v", err)
 	}
@@ -131,7 +135,7 @@ func TestShutdown(t *testing.T) {
 func TestRun_ContextCancellation(t *testing.T) {
 	setRequiredConfigEnv(t)
 	cfg := config.Load()
-	app, err := NewApp(cfg, &sql.DB{})
+	app, err := NewApp(cfg, &sql.DB{}, "dev")
 	if err != nil {
 		t.Fatalf("NewApp() failed: %v", err)
 	}

--- a/backend/db/db.go
+++ b/backend/db/db.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"io"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rs/zerolog/log"
@@ -74,4 +75,34 @@ func Close(c io.Closer, name string) {
 	if err := c.Close(); err != nil {
 		log.Error().Err(err).Str("resource", name).Msg("Error while closing resource")
 	}
+}
+
+// PingWithRetry calls ping repeatedly until it succeeds or the time budget is
+// exhausted (budget/interval attempts, at least one). Every failed attempt is
+// logged so a delayed database is visible in the boot log; the caller decides
+// what a returned error means (the backend still refuses to start without a
+// database). ping and sleep are injected so the retry decision can be
+// unit-tested without a real database or real waiting.
+func PingWithRetry(ping func() error, budget, interval time.Duration, sleep func(time.Duration)) error {
+	attempts := int(budget / interval)
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if err = ping(); err == nil {
+			if attempt > 1 {
+				log.Info().Int("attempts", attempt).Msg("Connected to database after retry")
+			}
+			return nil
+		}
+
+		log.Warn().Err(err).Int("attempt", attempt).Int("maxAttempts", attempts).Msg("Waiting for database")
+		if attempt < attempts {
+			sleep(interval)
+		}
+	}
+
+	return err
 }

--- a/backend/db/db_test.go
+++ b/backend/db/db_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -30,4 +31,82 @@ func TestError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPingWithRetry(t *testing.T) {
+	t.Run("succeeds on the first attempt without sleeping", func(t *testing.T) {
+		pings, sleeps := 0, 0
+		err := PingWithRetry(func() error {
+			pings++
+			return nil
+		}, 30*time.Second, time.Second, func(time.Duration) { sleeps++ })
+
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if pings != 1 {
+			t.Errorf("expected 1 ping, got %d", pings)
+		}
+		if sleeps != 0 {
+			t.Errorf("expected no sleeps, got %d", sleeps)
+		}
+	})
+
+	t.Run("succeeds after transient failures", func(t *testing.T) {
+		pings, sleeps := 0, 0
+		err := PingWithRetry(func() error {
+			pings++
+			if pings < 3 {
+				return errors.New("connection refused")
+			}
+			return nil
+		}, 30*time.Second, time.Second, func(time.Duration) { sleeps++ })
+
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if pings != 3 {
+			t.Errorf("expected 3 pings, got %d", pings)
+		}
+		if sleeps != 2 {
+			t.Errorf("expected 2 sleeps between attempts, got %d", sleeps)
+		}
+	})
+
+	t.Run("gives up after the budget is exhausted", func(t *testing.T) {
+		down := errors.New("still down")
+		pings, sleeps := 0, 0
+		err := PingWithRetry(func() error {
+			pings++
+			return down
+		}, 5*time.Second, time.Second, func(time.Duration) { sleeps++ })
+
+		if !errors.Is(err, down) {
+			t.Fatalf("expected the last ping error, got %v", err)
+		}
+		if pings != 5 {
+			t.Errorf("expected 5 ping attempts (budget/interval), got %d", pings)
+		}
+		if sleeps != 4 {
+			t.Errorf("expected 4 sleeps (no sleep after the final attempt), got %d", sleeps)
+		}
+	})
+
+	t.Run("tries at least once when the interval exceeds the budget", func(t *testing.T) {
+		pings, sleeps := 0, 0
+		err := PingWithRetry(func() error {
+			pings++
+			return errors.New("down")
+		}, time.Second, 30*time.Second, func(time.Duration) { sleeps++ })
+
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if pings != 1 {
+			t.Errorf("expected exactly 1 ping, got %d", pings)
+		}
+		if sleeps != 0 {
+			t.Errorf("expected no sleeps, got %d", sleeps)
+		}
+	})
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -17,9 +17,14 @@ import (
 
 	"github.com/nicograef/jotti/backend/app"
 	"github.com/nicograef/jotti/backend/config"
+	dbpkg "github.com/nicograef/jotti/backend/db"
 	"github.com/nicograef/jotti/backend/repository/kassenjournal_repo"
 	"github.com/nicograef/jotti/backend/seed"
 )
+
+// version wird per ldflags einkompiliert (-X main.version=<tag>); der
+// Release-Workflow befuellt sie ueber das Docker-Build-Argument VERSION.
+var version = "dev"
 
 func main() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout})
@@ -37,8 +42,9 @@ func main() {
 	db.SetMaxOpenConns(50)
 	db.SetMaxIdleConns(10)
 
-	err = db.Ping()
-	if err != nil {
+	// Beim Start begrenzt auf die Datenbank warten (Boot-Reihenfolge nach
+	// Stromausfall), statt sofort zu sterben. Ohne Datenbank kein Start.
+	if err := dbpkg.PingWithRetry(db.Ping, 30*time.Second, time.Second, time.Sleep); err != nil {
 		log.Fatal().Err(err).Msg("Failed to ping Postgres")
 	}
 
@@ -70,7 +76,7 @@ func run(cfg config.Config, db *sql.DB) error {
 		}
 	}()
 
-	a, err := app.NewApp(cfg, db)
+	a, err := app.NewApp(cfg, db, version)
 	if err != nil {
 		return fmt.Errorf("failed to create app: %w", err)
 	}

--- a/database/migrate/Dockerfile
+++ b/database/migrate/Dockerfile
@@ -7,10 +7,16 @@ RUN apk add --no-cache curl \
     | tar -xz -C /usr/local/bin \
     && apk del curl
 
+# Unprivilegierter Benutzer: migrate liest nur /migrations und spricht die
+# Datenbank an, schreibt also nichts ins Dateisystem.
+RUN addgroup -S jotti && adduser -S -G jotti jotti
+
 # Migrationen ins Image backen, damit der Stack selbst-enthalten ist (kein
 # Bind-Mount vom Host noetig). Der Build-Context ist deshalb ./database statt
 # ./database/migrate — siehe die compose-Dateien und .github/workflows/release.yml.
 COPY migrations /migrations
+
+USER jotti
 
 CMD /usr/local/bin/migrate -path /migrations -database "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/jotti?sslmode=disable" up
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -17,11 +17,20 @@
 
 name: jotti-local
 
+# Log rotation for every long-running service: json-file capped at a small size
+# and a few files, so it takes effect on any host without daemon configuration.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "5m"
+    max-file: "3"
+
 services:
   postgres:
     image: postgres:17.8
     container_name: jotti-postgres-local
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -70,6 +79,7 @@ services:
       dockerfile: Dockerfile
     container_name: jotti-backend-local
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
@@ -104,11 +114,22 @@ services:
       dockerfile: Dockerfile
     container_name: jotti-frontend-local
     restart: unless-stopped
+    logging: *default-logging
     networks:
       - app-network
     depends_on:
       backend:
         condition: service_started
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://127.0.0.1:80/ >/dev/null 2>&1",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
     # No exposed ports; served via reverse proxy
 
   reverse-proxy:
@@ -117,6 +138,7 @@ services:
       dockerfile: Dockerfile
     container_name: jotti-reverse-proxy-local
     restart: unless-stopped
+    logging: *default-logging
     environment:
       # Host LAN IP, detected on the host and passed in by `make local-up`
       # (a bridged container can only see its docker-bridge IP, which phones
@@ -142,6 +164,16 @@ services:
         condition: service_started
       backend:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -S -O /dev/null http://127.0.0.1:80/ 2>&1 | grep -qE 'HTTP/1.[01] (2|3)[0-9][0-9]'",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
 
 networks:
   app-network:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -115,8 +115,8 @@ services:
     environment:
       # JOTTI_DOMAIN switches the image into public mode: one site for this
       # domain with an automatic Let's Encrypt certificate.
-      JOTTI_DOMAIN: ${JOTTI_DOMAIN}
-      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
+      JOTTI_DOMAIN: ${JOTTI_DOMAIN:-}
+      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL:-}
       # Optional: redirect www.<domain> to <domain> (needs www DNS to point here).
       JOTTI_WWW_REDIRECT: ${JOTTI_WWW_REDIRECT:-}
       # Set to 1 to issue via the Let's Encrypt staging CA while testing.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,11 +16,20 @@ name: jotti
 #
 # The jotti.rocks demo uses docker-compose.rocks.yml instead (nginx + certbot).
 
+# Log rotation for every long-running service: json-file capped at a small size
+# and a few files, so it takes effect on any host without daemon configuration.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "5m"
+    max-file: "3"
+
 services:
   postgres:
     image: postgres:17.8
     container_name: jotti-postgres
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -59,6 +68,7 @@ services:
     image: ghcr.io/nicograef/jotti-backend:${JOTTI_VERSION:-latest}
     container_name: jotti-backend
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
@@ -96,11 +106,22 @@ services:
     image: ghcr.io/nicograef/jotti-frontend:${JOTTI_VERSION:-latest}
     container_name: jotti-frontend
     restart: unless-stopped
+    logging: *default-logging
     networks:
       - app-network
     depends_on:
       backend:
         condition: service_started
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://127.0.0.1:80/ >/dev/null 2>&1",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
     deploy:
       resources:
         limits:
@@ -112,6 +133,7 @@ services:
     image: ghcr.io/nicograef/jotti-reverse-proxy:${JOTTI_VERSION:-latest}
     container_name: jotti-reverse-proxy
     restart: unless-stopped
+    logging: *default-logging
     environment:
       # JOTTI_DOMAIN switches the image into public mode: one site for this
       # domain with an automatic Let's Encrypt certificate.
@@ -134,6 +156,16 @@ services:
         condition: service_started
       backend:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -S -O /dev/null http://127.0.0.1:80/ 2>&1 | grep -qE 'HTTP/1.[01] (2|3)[0-9][0-9]'",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
     deploy:
       resources:
         limits:

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -20,11 +20,20 @@
 
 name: jotti-local
 
+# Log rotation for every long-running service: json-file capped at a small size
+# and a few files, so it takes effect on any host without daemon configuration.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "5m"
+    max-file: "3"
+
 services:
   postgres:
     image: postgres:17.8
     container_name: jotti-postgres-local
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -70,6 +79,7 @@ services:
     image: ghcr.io/nicograef/jotti-backend:RELEASE_VERSION
     container_name: jotti-backend-local
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
@@ -102,17 +112,29 @@ services:
     image: ghcr.io/nicograef/jotti-frontend:RELEASE_VERSION
     container_name: jotti-frontend-local
     restart: unless-stopped
+    logging: *default-logging
     networks:
       - app-network
     depends_on:
       backend:
         condition: service_started
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://127.0.0.1:80/ >/dev/null 2>&1",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
     # No exposed ports; served via reverse proxy
 
   reverse-proxy:
     image: ghcr.io/nicograef/jotti-reverse-proxy:RELEASE_VERSION
     container_name: jotti-reverse-proxy-local
     restart: unless-stopped
+    logging: *default-logging
     environment:
       # Host LAN IP, detected on the host and passed in by jotti-start.exe
       # (a bridged container can only see its docker-bridge IP, which phones
@@ -138,6 +160,16 @@ services:
         condition: service_started
       backend:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -S -O /dev/null http://127.0.0.1:80/ 2>&1 | grep -qE 'HTTP/1.[01] (2|3)[0-9][0-9]'",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
 
 networks:
   app-network:

--- a/docker-compose.rocks.yml
+++ b/docker-compose.rocks.yml
@@ -14,11 +14,20 @@ name: jotti
 # Requires VPS_PUBLIC_IP in .env (public IPv4 of this server) and
 # Docker Compose >= 2.23.1 (inline configs with interpolation).
 
+# Log rotation for every long-running service: json-file capped at a small size
+# and a few files, so it takes effect on any host without daemon configuration.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "5m"
+    max-file: "3"
+
 services:
   postgres:
     image: postgres:17.8
     container_name: jotti-postgres
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -61,6 +70,7 @@ services:
       dockerfile: Dockerfile
     container_name: jotti-backend
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
@@ -100,11 +110,22 @@ services:
       dockerfile: Dockerfile
     container_name: jotti-frontend
     restart: unless-stopped
+    logging: *default-logging
     networks:
       - app-network
     depends_on:
       backend:
         condition: service_started
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://127.0.0.1:80/ >/dev/null 2>&1",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
     deploy:
       resources:
         limits:
@@ -120,8 +141,19 @@ services:
       dockerfile: website/Dockerfile
     container_name: jotti-website
     restart: unless-stopped
+    logging: *default-logging
     networks:
       - app-network
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://127.0.0.1:80/ >/dev/null 2>&1",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
     deploy:
       resources:
         limits:
@@ -133,6 +165,14 @@ services:
     image: nginx:1.27-alpine
     container_name: jotti-reverse-proxy
     restart: unless-stopped
+    logging: *default-logging
+    # nginx runs in the foreground as PID 1 and receives stop signals directly;
+    # a background loop reloads every 12 hours so renewed certificates and
+    # re-resolved upstream addresses are picked up without a restart.
+    command:
+      - sh
+      - -c
+      - "while true; do sleep 12h; nginx -s reload; done & exec nginx -g 'daemon off;'"
     ports:
       - "80:80"
       - "443:443"
@@ -151,6 +191,16 @@ services:
         condition: service_healthy
       acme-dns:
         condition: service_started
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -S -O /dev/null http://127.0.0.1:80/ 2>&1 | grep -qE 'HTTP/1.[01] (2|3)[0-9][0-9]'",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
     deploy:
       resources:
         limits:
@@ -161,6 +211,7 @@ services:
     image: certbot/certbot:v2.11.0
     container_name: jotti-certbot
     restart: unless-stopped
+    logging: *default-logging
     volumes:
       - certbot-challenges:/var/www/certbot
       - letsencrypt:/etc/letsencrypt
@@ -186,6 +237,7 @@ services:
       dockerfile: Dockerfile
     container_name: jotti-resolver
     restart: unless-stopped
+    logging: *default-logging
     ports:
       - "53:53/udp"
       - "53:53/tcp"
@@ -211,6 +263,7 @@ services:
     image: joohoi/acme-dns:v2.0.2
     container_name: jotti-acme-dns
     restart: unless-stopped
+    logging: *default-logging
     configs:
       - source: acme-dns-config
         target: /etc/acme-dns/config.cfg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,19 @@
 name: jotti-dev
 
+# Log rotation for every long-running service: json-file capped at a small size
+# and a few files, so it takes effect on any host without daemon configuration.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "5m"
+    max-file: "3"
+
 services:
   postgres:
     image: postgres:17.8
     container_name: jotti-postgres-dev
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -42,6 +51,7 @@ services:
     image: golang:1.26.0-alpine
     container_name: jotti-backend-dev
     working_dir: /src
+    logging: *default-logging
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
@@ -65,6 +75,7 @@ services:
     image: node:24-alpine
     container_name: jotti-frontend-dev
     working_dir: /app
+    logging: *default-logging
     environment:
       NODE_ENV: development
       CI: "true"
@@ -81,6 +92,16 @@ services:
     depends_on:
       backend-dev:
         condition: service_started
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://127.0.0.1:5173/ >/dev/null 2>&1",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 40s
 
 networks:
   app-network:

--- a/docs/leitfaden/aktualisieren-backups.md
+++ b/docs/leitfaden/aktualisieren-backups.md
@@ -27,6 +27,11 @@ wegen der gesetzlichen 10-Jahre-Aufbewahrung.
   Datenbank. Die Bestätigung nennt Dump und Compose-Datei; standardmäßig
   `docker-compose.prod.yml`, über `COMPOSE_FILE` auf einen anderen Stack
   umstellbar (gilt ebenso für `make prod-backup`).
+- **Prüfen (gelegentlich):** `make prod-backup-verify` spielt das neueste Backup
+  in einen Wegwerf-Postgres ein und meldet die Tabellenzahl. So wisst ihr, dass
+  ein Backup wirklich wiederherstellbar ist, ohne den laufenden Betrieb
+  anzufassen. Einen bestimmten Dump prüft ihr per Argument:
+  `./scripts/prod-backup-verify.sh <datei>`.
 - **Täglich automatisch:** Für einen täglichen Dump liegen Vorlagen im Repository
   (systemd-Timer unter `packaging/systemd/` oder cron unter `packaging/cron/`); die
   Installationsschritte stehen als Kommentar in den Dateien.
@@ -36,6 +41,13 @@ wegen der gesetzlichen 10-Jahre-Aufbewahrung.
   (Dead-Man-Switch). So merkt ihr, wenn ein automatischer Lauf still ausfällt.
   Welchen Dienst ihr nutzt, ist frei wählbar; ein Fehlschlag des Aufrufs gefährdet
   das Backup nicht.
+- **Extern kopieren:** Holt die Dumps auf einen anderen Rechner, damit sie einen
+  Serverausfall überstehen. Ein Einzeiler dafür, vom Zielrechner aus (Pfad und
+  Zugang anpassen):
 
-> 💾 Kopiert die Backups regelmäßig vom Server weg. Ein Backup, das nur auf
-> demselben Server liegt, hilft bei dessen Ausfall nicht.
+  ```sh
+  rsync -avz admin@SERVER:/pfad/zu/jotti/backups/ ./jotti-backups/
+  ```
+
+> 💾 Ein Backup, das nur auf demselben Server liegt, hilft bei dessen Ausfall
+> nicht. Kopiert die Dumps regelmäßig weg.

--- a/docs/leitfaden/aktualisieren-backups.md
+++ b/docs/leitfaden/aktualisieren-backups.md
@@ -30,6 +30,12 @@ wegen der gesetzlichen 10-Jahre-Aufbewahrung.
 - **Täglich automatisch:** Für einen täglichen Dump liegen Vorlagen im Repository
   (systemd-Timer unter `packaging/systemd/` oder cron unter `packaging/cron/`); die
   Installationsschritte stehen als Kommentar in den Dateien.
+- **Überwachung (optional):** Tragt unter `BACKUP_PING_URL` die URL eines
+  Überwachungsdienstes ein (z. B. healthchecks.io). Nach jedem erfolgreichen Backup
+  ruft das Skript sie einmal auf. Bleibt der Aufruf aus, schlägt der Dienst Alarm
+  (Dead-Man-Switch). So merkt ihr, wenn ein automatischer Lauf still ausfällt.
+  Welchen Dienst ihr nutzt, ist frei wählbar; ein Fehlschlag des Aufrufs gefährdet
+  das Backup nicht.
 
 > 💾 Kopiert die Backups regelmäßig vom Server weg. Ein Backup, das nur auf
 > demselben Server liegt, hilft bei dessen Ausfall nicht.

--- a/docs/leitfaden/aktualisieren-backups.md
+++ b/docs/leitfaden/aktualisieren-backups.md
@@ -24,7 +24,9 @@ wegen der gesetzlichen 10-Jahre-Aufbewahrung.
   `BACKUP_DIR` (Standard `./backups`) und behält die neuesten `BACKUP_KEEP` Stück.
 - **Wiederherstellen:** `make prod-restore` listet die Backups, fragt eine
   Bestätigung ab und spielt das gewählte zurück. Das überschreibt die aktuelle
-  Datenbank.
+  Datenbank. Die Bestätigung nennt Dump und Compose-Datei; standardmäßig
+  `docker-compose.prod.yml`, über `COMPOSE_FILE` auf einen anderen Stack
+  umstellbar (gilt ebenso für `make prod-backup`).
 - **Täglich automatisch:** Für einen täglichen Dump liegen Vorlagen im Repository
   (systemd-Timer unter `packaging/systemd/` oder cron unter `packaging/cron/`); die
   Installationsschritte stehen als Kommentar in den Dateien.

--- a/packaging/cron/jotti-backup.cron
+++ b/packaging/cron/jotti-backup.cron
@@ -3,9 +3,11 @@
 # Install (idempotent — copies into the system cron.d drop-in directory):
 #   sudo cp packaging/cron/jotti-backup.cron /etc/cron.d/jotti-backup
 #
-# Adjust the path to your jotti checkout. The script reads .env there and writes
-# dumps to BACKUP_DIR (default ./backups). Set BACKUP_DIR/BACKUP_KEEP inline to
-# override. Keep the trailing newline — cron.d files require it.
+# Adjust the cd path in the cron line below to your jotti checkout. The script
+# reads .env there and writes dumps to BACKUP_DIR (default ./backups). With the
+# .env fix in place a missing key falls back to the built-in default, so setting
+# BACKUP_DIR/BACKUP_KEEP inline is optional. Keep the trailing newline — cron.d
+# files require it.
 #
 # Reminder: copy the dumps off this server regularly (10-year retention).
 

--- a/packaging/systemd/jotti-backup.service
+++ b/packaging/systemd/jotti-backup.service
@@ -6,9 +6,10 @@
 #   sudo systemctl daemon-reload
 #   sudo systemctl enable --now jotti-backup.timer
 #
-# Adjust WorkingDirectory to your jotti checkout. The script reads .env there and
-# writes dumps to BACKUP_DIR (default ./backups). Override the defaults below if
-# you keep backups elsewhere or want a different retention.
+# Adjust WorkingDirectory and the ExecStart path to your jotti checkout. The
+# script reads .env there and writes dumps to BACKUP_DIR (default ./backups).
+# The Environment= lines below are optional: with the .env fix in place a missing
+# key falls back to the built-in default, so set them only to override.
 
 [Unit]
 Description=jotti database backup (pg_dump, rotated)

--- a/packaging/windows/KURZANLEITUNG.md
+++ b/packaging/windows/KURZANLEITUNG.md
@@ -73,6 +73,20 @@ Wieder dieselben zwei Doppelklicks (`jotti-start.exe`, bei Bedarf
 Netzwerk-Adresse, **zeigt die Status-Seite sie erneut** — es gilt dasselbe
 Zertifikat, also **keine neue Warnung**.
 
+## Daten nach dem Fest sichern (optional)
+
+Wollt ihr die Kassendaten zusätzlich extern sichern (z. B. auf einen
+**USB-Stick**), erstellt mit einem Befehl eine Sicherungsdatei. Dazu die
+**Eingabeaufforderung** (cmd) öffnen und diese Zeile hineinkopieren:
+
+```
+docker exec jotti-postgres-local pg_dump --clean --if-exists -U admin -d jotti > "%PROGRAMDATA%\jotti\backups\manuell.sql"
+```
+
+Die Datei liegt danach im Ordner `%PROGRAMDATA%\jotti\backups`. In denselben
+Ordner spiegelt jotti auch die **automatischen Backups vor jedem Update**. Diesen
+Ordner könnt ihr komplett auf einen USB-Stick oder in eine Cloud kopieren.
+
 ## jotti aktualisieren
 
 > ⚠️ **Updates zuhause mit Internet machen, nicht auf dem Fest.** Wie beim

--- a/scripts/prod-backup-verify.sh
+++ b/scripts/prod-backup-verify.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# jotti — Backup Verify (self-hosted production, Weg B)
+#
+# Proves that a pg_dump created by prod-backup.sh is actually recoverable by
+# restoring it into a THROWAWAY postgres container and checking that the
+# restored database has tables. It never touches the running stack: the
+# container runs via `docker run --rm` on the default bridge (no stack network,
+# no stack volumes) and is discarded on exit. Steps:
+#   1. Validate prerequisites and pick the dump (argument or newest in BACKUP_DIR)
+#   2. Start a throwaway postgres (same pinned version as the stack) and wait
+#   3. Stream the dump into psql (ON_ERROR_STOP) and count the restored tables
+#   4. Print a short summary (dump, table count, result) and exit accordingly
+#
+# Configuration:
+#   BACKUP_DIR    directory to read dumps from (default: ./backups)
+#   COMPOSE_FILE  compose file the postgres version is read from
+#                 (default: docker-compose.prod.yml)
+#
+# Usage: ./scripts/prod-backup-verify.sh [DUMP_FILE]  (or `make prod-backup-verify`)
+#   DUMP_FILE  optional path or filename in BACKUP_DIR; defaults to the newest.
+# =============================================================================
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { printf "${GREEN}[INFO]${NC}  %s\n" "$1"; }
+warn()  { printf "${YELLOW}[WARN]${NC}  %s\n" "$1"; }
+error() { printf "${RED}[ERROR]${NC} %s\n" "$1" >&2; }
+fatal() { error "$1"; exit 1; }
+
+# read_env KEY — read a single value from .env without executing the file
+# (passwords may contain shell-special characters). Returns the last match,
+# trimmed of surrounding whitespace.
+read_env() {
+  local key="$1"
+  { grep -E "^${key}=" .env 2>/dev/null || true; } | tail -n1 | cut -d= -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
+# ---------------------------------------------------------------------------
+# Step 0 — Change to project root (script may be called from anywhere)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# ---------------------------------------------------------------------------
+# Step 1 — Validate prerequisites and select the dump
+# ---------------------------------------------------------------------------
+if ! command -v docker &>/dev/null; then
+  fatal "docker is not installed or not on PATH."
+fi
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  fatal "Missing compose file: $COMPOSE_FILE"
+fi
+if [[ ! -f .env ]]; then
+  fatal ".env file not found. Run 'make init' first."
+fi
+
+# The throwaway postgres uses the same role the dump was created with, so its
+# ownership statements (ALTER ... OWNER TO) resolve. Env wins, then .env, then
+# the shipped default.
+PG_USER="${POSTGRES_USER:-$(read_env POSTGRES_USER)}"
+[[ -n "$PG_USER" ]] || PG_USER="admin"
+
+# Pin the throwaway container to the exact postgres version of the stack so the
+# verify never drifts from what actually holds the data.
+PG_IMAGE="$(grep -oE 'postgres:[0-9][0-9.]*' "$COMPOSE_FILE" | head -n1)"
+[[ -n "$PG_IMAGE" ]] || fatal "Could not read the postgres version from $COMPOSE_FILE."
+
+BACKUP_DIR="${BACKUP_DIR:-$(read_env BACKUP_DIR)}"
+[[ -n "$BACKUP_DIR" ]] || BACKUP_DIR="./backups"
+
+mapfile -t dumps < <(find "$BACKUP_DIR" -maxdepth 1 -type f \
+  \( -name 'jotti-*.sql' -o -name 'jotti-*.sql.gz' \) -printf '%f\n' 2>/dev/null | sort)
+
+TARGET="${1:-}"
+if [[ -n "$TARGET" ]]; then
+  if [[ -f "$TARGET" ]]; then
+    SELECTED="$TARGET"
+  elif [[ -f "$BACKUP_DIR/$TARGET" ]]; then
+    SELECTED="$BACKUP_DIR/$TARGET"
+  else
+    fatal "Backup not found: $TARGET"
+  fi
+else
+  (( ${#dumps[@]} > 0 )) || fatal "No backups found in $BACKUP_DIR. Pass a dump file explicitly."
+  SELECTED="$BACKUP_DIR/${dumps[-1]}"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — Start a throwaway postgres (isolated from the running stack)
+# ---------------------------------------------------------------------------
+# --rm plus no --network and no -p: the container shares no network with the
+# stack and publishes no port. -fv on removal takes its anonymous data volume
+# (the image declares one) with it, so `docker volume ls` stays unchanged.
+# Nothing about the live stack is touched.
+CONTAINER="jotti-backup-verify-$$"
+cleanup() { docker rm -fv "$CONTAINER" &>/dev/null || true; }
+trap cleanup EXIT
+
+info "Starting throwaway $PG_IMAGE for the verify ..."
+docker run --rm -d --name "$CONTAINER" \
+  -e POSTGRES_USER="$PG_USER" \
+  -e POSTGRES_PASSWORD=verify \
+  -e POSTGRES_DB=jotti \
+  "$PG_IMAGE" >/dev/null
+
+# Probe over TCP, not the socket: the entrypoint's temporary init server listens
+# on the socket only, so a socket probe would report "ready" mid-initialisation
+# and the restore would race the real server's restart. TCP answers only once
+# the real server is up. Restore then uses the socket (trust-authenticated).
+ready=""
+for ((i = 0; i < 30; i++)); do
+  if docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -p 5432 -U "$PG_USER" &>/dev/null; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+[[ -n "$ready" ]] || fatal "Throwaway postgres did not become ready in time."
+
+# ---------------------------------------------------------------------------
+# Step 3 — Restore the dump and count the tables
+# ---------------------------------------------------------------------------
+decompress() {
+  if [[ "$SELECTED" == *.gz ]]; then
+    gzip -dc "$SELECTED"
+  else
+    cat "$SELECTED"
+  fi
+}
+
+info "Restoring $SELECTED into the throwaway database ..."
+if ! decompress | docker exec -i "$CONTAINER" \
+       psql -U "$PG_USER" -d jotti -q -v ON_ERROR_STOP=1 >/dev/null; then
+  fatal "Restore into the throwaway database failed (see psql errors above)."
+fi
+
+TABLE_COUNT="$(docker exec "$CONTAINER" \
+  psql -U "$PG_USER" -d jotti -tAc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'")"
+
+if ! [[ "$TABLE_COUNT" =~ ^[0-9]+$ ]] || (( TABLE_COUNT <= 0 )); then
+  fatal "Verify failed: the restored database has no tables (count: ${TABLE_COUNT:-unknown})."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4 — Summary
+# ---------------------------------------------------------------------------
+echo ""
+info "Verify OK — the dump is restorable."
+info "  Dump:   $SELECTED"
+info "  Tables: $TABLE_COUNT"

--- a/scripts/prod-backup.sh
+++ b/scripts/prod-backup.sh
@@ -41,7 +41,7 @@ fatal() { error "$1"; exit 1; }
 # trimmed of surrounding whitespace.
 read_env() {
   local key="$1"
-  grep -E "^${key}=" .env 2>/dev/null | tail -n1 | cut -d= -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+  { grep -E "^${key}=" .env 2>/dev/null || true; } | tail -n1 | cut -d= -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/prod-backup.sh
+++ b/scripts/prod-backup.sh
@@ -14,13 +14,14 @@ set -euo pipefail
 #   3. Rotate to the newest BACKUP_KEEP dumps
 #
 # Configuration (environment overrides .env, which overrides the defaults):
-#   BACKUP_DIR   target directory on the host (default: ./backups)
-#   BACKUP_KEEP  number of dumps to retain (default: 14; <=0 keeps all)
+#   BACKUP_DIR    target directory on the host (default: ./backups)
+#   BACKUP_KEEP   number of dumps to retain (default: 14; <=0 keeps all)
+#   COMPOSE_FILE  compose file to dump from (default: docker-compose.prod.yml)
 #
 # Usage: ./scripts/prod-backup.sh  (or `make prod-backup`)
 # =============================================================================
 
-COMPOSE_PROD="docker-compose.prod.yml"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
 PG_SERVICE="postgres"
 
 # ---------------------------------------------------------------------------
@@ -60,8 +61,8 @@ fi
 if ! docker compose version &>/dev/null; then
   fatal "docker compose (v2) is not available."
 fi
-if [[ ! -f "$COMPOSE_PROD" ]]; then
-  fatal "Missing compose file: $COMPOSE_PROD"
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  fatal "Missing compose file: $COMPOSE_FILE"
 fi
 if [[ ! -f .env ]]; then
   fatal ".env file not found. Run 'make init' first."
@@ -93,7 +94,7 @@ cleanup() { rm -f "$TMPFILE"; }
 trap cleanup EXIT
 
 info "Dumping database to $OUTFILE ..."
-if ! docker compose -f "$COMPOSE_PROD" exec -T "$PG_SERVICE" \
+if ! docker compose -f "$COMPOSE_FILE" exec -T "$PG_SERVICE" \
        sh -c 'pg_dump --clean --if-exists -U "$POSTGRES_USER" -d jotti' \
      | gzip -c > "$TMPFILE"; then
   fatal "pg_dump failed. Is the stack running? Start it with: make prod-up"

--- a/scripts/prod-backup.sh
+++ b/scripts/prod-backup.sh
@@ -14,9 +14,11 @@ set -euo pipefail
 #   3. Rotate to the newest BACKUP_KEEP dumps
 #
 # Configuration (environment overrides .env, which overrides the defaults):
-#   BACKUP_DIR    target directory on the host (default: ./backups)
-#   BACKUP_KEEP   number of dumps to retain (default: 14; <=0 keeps all)
-#   COMPOSE_FILE  compose file to dump from (default: docker-compose.prod.yml)
+#   BACKUP_DIR       target directory on the host (default: ./backups)
+#   BACKUP_KEEP      number of dumps to retain (default: 14; <=0 keeps all)
+#   COMPOSE_FILE     compose file to dump from (default: docker-compose.prod.yml)
+#   BACKUP_PING_URL  optional URL pinged after a successful backup (dead man's
+#                    switch); a failed ping is a warning, never an error
 #
 # Usage: ./scripts/prod-backup.sh  (or `make prod-backup`)
 # =============================================================================
@@ -78,6 +80,8 @@ if ! [[ "$BACKUP_KEEP" =~ ^-?[0-9]+$ ]]; then
   fatal "BACKUP_KEEP must be an integer (got: $BACKUP_KEEP)."
 fi
 
+BACKUP_PING_URL="${BACKUP_PING_URL:-$(read_env BACKUP_PING_URL)}"
+
 mkdir -p "$BACKUP_DIR"
 
 # ---------------------------------------------------------------------------
@@ -99,6 +103,13 @@ if ! docker compose -f "$COMPOSE_FILE" exec -T "$PG_SERVICE" \
      | gzip -c > "$TMPFILE"; then
   fatal "pg_dump failed. Is the stack running? Start it with: make prod-up"
 fi
+
+# A truncated pipe or a broken gzip stream must never masquerade as a backup.
+# Verify the compressed dump before promoting the .partial file; on failure the
+# EXIT trap discards it, so no .sql.gz is ever left behind.
+if ! gzip -t "$TMPFILE"; then
+  fatal "Integrity check failed (gzip -t): the dump is corrupt and was discarded."
+fi
 mv "$TMPFILE" "$OUTFILE"
 
 info "Backup created: $OUTFILE ($(du -h "$OUTFILE" | cut -f1))"
@@ -119,6 +130,20 @@ else
       info "Rotating old backup: ${dumps[i]}"
       rm -f "$BACKUP_DIR/${dumps[i]}"
     done
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4 — Success ping (dead man's switch)
+# ---------------------------------------------------------------------------
+# Only after a fully successful, integrity-checked dump: ping an optional
+# monitor so it can alarm when the ping ever stops arriving. A failed ping is a
+# warning, never a script error — the backup itself already succeeded.
+if [[ -n "$BACKUP_PING_URL" ]]; then
+  if curl -fsS --connect-timeout 5 --max-time 10 "$BACKUP_PING_URL" >/dev/null 2>&1; then
+    info "Success ping sent to BACKUP_PING_URL."
+  else
+    warn "Success ping to BACKUP_PING_URL failed (backup is fine)."
   fi
 fi
 

--- a/scripts/prod-harden.sh
+++ b/scripts/prod-harden.sh
@@ -150,7 +150,7 @@ echo "    sudo dpkg-reconfigure -plow unattended-upgrades"
 # ---------------------------------------------------------------------------
 echo ""
 echo "=========================================="
-printf "${GREEN} jotti — Server Hardening Complete${NC}\n"
+printf "${GREEN} %s${NC}\n" "jotti — Server Hardening Complete"
 echo "=========================================="
 echo ""
 echo "  Firewall (ufw): SSH ($SSH_PORT/tcp), 80/tcp, 443/tcp, 443/udp allowed;"

--- a/scripts/prod-init.sh
+++ b/scripts/prod-init.sh
@@ -35,7 +35,7 @@ fatal() { error "$1"; exit 1; }
 # trimmed of surrounding whitespace.
 read_env() {
   local key="$1"
-  grep -E "^${key}=" .env 2>/dev/null | tail -n1 | cut -d= -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+  { grep -E "^${key}=" .env 2>/dev/null || true; } | tail -n1 | cut -d= -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
 }
 
 # ---------------------------------------------------------------------------
@@ -159,7 +159,7 @@ HTTP_STATUS="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "http://$DOM
 # ---------------------------------------------------------------------------
 echo ""
 echo "=========================================="
-printf "${GREEN} jotti — Deployment Complete${NC}\n"
+printf "${GREEN} %s${NC}\n" "jotti — Deployment Complete"
 echo "=========================================="
 echo ""
 echo "  Domain:  https://$DOMAIN"

--- a/scripts/prod-init.sh
+++ b/scripts/prod-init.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Reads the domain and email from .env (no hardcoding), validates the host, then
 # starts the pinned production stack. Caddy obtains the Let's Encrypt certificate
 # automatically (HTTP-01/TLS-ALPN) — no certbot step. Steps:
-#   1. Validate prerequisites (Docker, Compose, .env, JOTTI_DOMAIN/LETSENCRYPT_EMAIL)
+#   1. Validate prerequisites (Docker, Compose, .env, JOTTI_DOMAIN/LETSENCRYPT_EMAIL/JOTTI_VERSION)
 #   2. Check that the domain resolves (and ideally points to this server)
 #   3. Pull the pinned images and start the stack
 #   4. Wait for the backend to be healthy and verify HTTPS
@@ -36,6 +36,17 @@ fatal() { error "$1"; exit 1; }
 read_env() {
   local key="$1"
   { grep -E "^${key}=" .env 2>/dev/null || true; } | tail -n1 | cut -d= -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
+# parse_semver "v1.2.3" — echoes "1 2 3" and returns 0, or returns 1 when the
+# value is not a plain vMAJOR.MINOR.PATCH (e.g. "latest", "dev"). A pre-release
+# or build suffix ("1.2.3-rc1", "1.2.3+meta") is trimmed before parsing. Mirrors
+# core.parseSemver (windows/starter/core/update.go); kept as a standalone copy.
+parse_semver() {
+  local s="${1#v}"
+  s="${s%%[-+]*}"
+  [[ "$s" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]] || return 1
+  printf '%s %s %s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
 }
 
 # ---------------------------------------------------------------------------
@@ -74,6 +85,7 @@ fi
 
 DOMAIN="$(read_env JOTTI_DOMAIN)"
 EMAIL="$(read_env LETSENCRYPT_EMAIL)"
+VERSION="$(read_env JOTTI_VERSION)"
 
 if [[ -z "$DOMAIN" ]]; then
   fatal "JOTTI_DOMAIN is not set in .env. Set it to your public domain (e.g. jotti.meinverein.de)."
@@ -81,8 +93,16 @@ fi
 if [[ -z "$EMAIL" ]]; then
   fatal "LETSENCRYPT_EMAIL is not set in .env. Set it to a contact email for the Let's Encrypt account."
 fi
+# Only a pinned release tag (vMAJOR.MINOR.PATCH) is accepted; "latest" or an
+# empty value would silently pull a moving image. The compose default
+# ${JOTTI_VERSION:-latest} stays as a fallback but is never reached here.
+if ! parse_semver "$VERSION" >/dev/null; then
+  error "JOTTI_VERSION in .env is not a pinned release tag (found: '${VERSION:-<empty>}')."
+  error "Set it to a release tag like v0.3.1 from https://github.com/nicograef/jotti/releases."
+  fatal "Refusing to deploy an unpinned version ('latest' and empty are not allowed)."
+fi
 
-info "Prerequisites OK (domain: $DOMAIN, email: $EMAIL)."
+info "Prerequisites OK (domain: $DOMAIN, email: $EMAIL, version: $VERSION)."
 
 # ---------------------------------------------------------------------------
 # Step 2 — Check DNS resolution and that it points to this server

--- a/scripts/prod-restore.sh
+++ b/scripts/prod-restore.sh
@@ -41,7 +41,7 @@ fatal() { error "$1"; exit 1; }
 # trimmed of surrounding whitespace.
 read_env() {
   local key="$1"
-  grep -E "^${key}=" .env 2>/dev/null | tail -n1 | cut -d= -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+  { grep -E "^${key}=" .env 2>/dev/null || true; } | tail -n1 | cut -d= -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/prod-restore.sh
+++ b/scripts/prod-restore.sh
@@ -14,13 +14,14 @@ set -euo pipefail
 #   3. Stop app services, restore via psql, restart the stack
 #
 # Configuration:
-#   BACKUP_DIR   directory to read dumps from (default: ./backups)
+#   BACKUP_DIR    directory to read dumps from (default: ./backups)
+#   COMPOSE_FILE  compose file to restore into (default: docker-compose.prod.yml)
 #
 # Usage: ./scripts/prod-restore.sh [DUMP_FILE]  (or `make prod-restore`)
 #   DUMP_FILE  optional path or filename in BACKUP_DIR; defaults to the newest.
 # =============================================================================
 
-COMPOSE_PROD="docker-compose.prod.yml"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
 PG_SERVICE="postgres"
 
 # ---------------------------------------------------------------------------
@@ -60,8 +61,8 @@ fi
 if ! docker compose version &>/dev/null; then
   fatal "docker compose (v2) is not available."
 fi
-if [[ ! -f "$COMPOSE_PROD" ]]; then
-  fatal "Missing compose file: $COMPOSE_PROD"
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  fatal "Missing compose file: $COMPOSE_FILE"
 fi
 if [[ ! -f .env ]]; then
   fatal ".env file not found. Run 'make init' first."
@@ -99,7 +100,8 @@ fi
 # ---------------------------------------------------------------------------
 echo ""
 warn "This will OVERWRITE the current jotti database with:"
-warn "  $SELECTED"
+warn "  Dump:    $SELECTED"
+warn "  Stack:   $COMPOSE_FILE"
 warn "All data created since that backup will be lost."
 read -r -p "Continue? Type 'yes' to proceed: " answer
 [[ "$answer" == "yes" ]] || fatal "Aborted by user. Nothing was changed."
@@ -108,10 +110,10 @@ read -r -p "Continue? Type 'yes' to proceed: " answer
 # Step 3 — Stop app services, restore, restart
 # ---------------------------------------------------------------------------
 info "Starting the database ..."
-docker compose -f "$COMPOSE_PROD" up -d --wait "$PG_SERVICE"
+docker compose -f "$COMPOSE_FILE" up -d --wait "$PG_SERVICE"
 
 info "Stopping application services during the restore ..."
-docker compose -f "$COMPOSE_PROD" stop backend frontend reverse-proxy
+docker compose -f "$COMPOSE_FILE" stop backend frontend reverse-proxy
 
 # Stream the dump (decompressing on the fly when gzip-compressed) into psql. The
 # postgres role comes from the container's own POSTGRES_USER env; ON_ERROR_STOP
@@ -125,7 +127,7 @@ decompress() {
 }
 
 info "Restoring $SELECTED ..."
-if ! decompress | docker compose -f "$COMPOSE_PROD" exec -T "$PG_SERVICE" \
+if ! decompress | docker compose -f "$COMPOSE_FILE" exec -T "$PG_SERVICE" \
        sh -c 'psql -U "$POSTGRES_USER" -d jotti -v ON_ERROR_STOP=1'; then
   error "Restore failed — the database may be in an inconsistent state."
   error "Application services are stopped. Inspect, fix, then restart: make prod-up"
@@ -133,7 +135,13 @@ if ! decompress | docker compose -f "$COMPOSE_PROD" exec -T "$PG_SERVICE" \
 fi
 
 info "Restarting the full stack ..."
-docker compose -f "$COMPOSE_PROD" up -d
+docker compose -f "$COMPOSE_FILE" up -d
+
+# Force-recreate the reverse-proxy so it re-resolves the freshly restarted
+# backend/frontend upstreams. On the rocks stack this clears nginx's cached
+# upstream IPs (the 502-after-restore trap); on Caddy stacks it is a no-op.
+info "Recreating the reverse-proxy ..."
+docker compose -f "$COMPOSE_FILE" up -d --no-deps --force-recreate reverse-proxy
 
 echo ""
 info "Restore complete. jotti is running again."

--- a/scripts/prod-update.sh
+++ b/scripts/prod-update.sh
@@ -42,7 +42,7 @@ fatal() { error "$1"; exit 1; }
 # trimmed of surrounding whitespace.
 read_env() {
   local key="$1"
-  grep -E "^${key}=" .env 2>/dev/null | tail -n1 | cut -d= -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+  { grep -E "^${key}=" .env 2>/dev/null || true; } | tail -n1 | cut -d= -f2- | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
 }
 
 # parse_semver "v1.2.3" — echoes "1 2 3" and returns 0, or returns 1 when the
@@ -210,7 +210,7 @@ fi
 # ---------------------------------------------------------------------------
 echo ""
 echo "=========================================="
-printf "${GREEN} jotti — Update Complete${NC}\n"
+printf "${GREEN} %s${NC}\n" "jotti — Update Complete"
 echo "=========================================="
 echo ""
 echo "  Version: $RUNNING_VERSION -> $TARGET_VERSION"

--- a/scripts/prod-update.sh
+++ b/scripts/prod-update.sh
@@ -98,10 +98,16 @@ fi
 # ---------------------------------------------------------------------------
 # Step 2 — Determine running vs. target version and guard against downgrades
 # ---------------------------------------------------------------------------
-# Target comes from .env (the version the operator bumped to); empty means
-# "latest", matching docker-compose.prod.yml's ${JOTTI_VERSION:-latest}.
+# Target comes from .env (the version the operator bumped to). Only a pinned
+# release tag (vMAJOR.MINOR.PATCH) is accepted; "latest" or an empty value would
+# silently track a moving image and defeat the downgrade guard. The compose
+# default ${JOTTI_VERSION:-latest} stays as a fallback but is never reached here.
 TARGET_VERSION="$(read_env JOTTI_VERSION)"
-[[ -n "$TARGET_VERSION" ]] || TARGET_VERSION="latest"
+if ! parse_semver "$TARGET_VERSION" >/dev/null; then
+  error "JOTTI_VERSION in .env is not a pinned release tag (found: '${TARGET_VERSION:-<empty>}')."
+  error "Set it to a release tag like v0.3.1 from https://github.com/nicograef/jotti/releases."
+  fatal "Refusing to update against an unpinned version ('latest' and empty are not allowed)."
+fi
 
 # Running version is the tag the backend container was created from. Absence of
 # the container means there is nothing to update yet.

--- a/scripts/rocks-init.sh
+++ b/scripts/rocks-init.sh
@@ -133,6 +133,8 @@ sleep 3
 
 info "Requesting certificate from Let's Encrypt..."
 
+# CERTBOT_DOMAINS is a list of -d flags and must be word-split.
+# shellcheck disable=SC2086
 if ! docker compose -f "$COMPOSE_CERT" run --rm --entrypoint certbot certbot certonly \
   --webroot -w /var/www/certbot \
   $CERTBOT_DOMAINS \
@@ -205,7 +207,7 @@ fi
 # ---------------------------------------------------------------------------
 echo ""
 echo "=========================================="
-printf "${GREEN} jotti.rocks — Deployment Complete${NC}\n"
+printf "${GREEN} %s${NC}\n" "jotti.rocks — Deployment Complete"
 echo "=========================================="
 echo ""
 echo "  Landing page:  https://$DOMAIN"

--- a/windows/starter/backup.go
+++ b/windows/starter/backup.go
@@ -29,6 +29,12 @@ const backupDir = "/jotti-backups"
 // nach jedem neuen Dump rotiert, damit das Volume nicht unbegrenzt waechst.
 const keptBackups = 5
 
+// hostBackupDirName ist der Unterordner im Zustandsverzeichnis, in den jeder
+// Pre-Update-Dump zusaetzlich gespiegelt wird (unter Windows
+// %PROGRAMDATA%\jotti\backups). Anders als das Docker-Volume ueberlebt dieser
+// Ordner ein `docker compose down -v` — er ist die zweite, unabhaengige Kopie.
+const hostBackupDirName = "backups"
+
 // dumpPrefix und dumpSuffix umrahmen die zeitgestempelten Backup-Dateinamen
 // (jotti-YYYYMMDD-HHMMSS.sql). Erzeugung und Rotations-Filter teilen sie sich,
 // damit der Filter nicht still aufhoert zu greifen, sollte sich das Namensschema
@@ -74,6 +80,17 @@ func maybeBackupBeforeUpdate(composePath, envPath, stateDir string) error {
 	if err := rotateBackups(keptBackups); err != nil {
 		// Rotation ist Hygiene, kein Grund den Start abzubrechen.
 		fmt.Printf("Hinweis: alte Backups konnten nicht rotiert werden (%v).\n", err)
+	}
+
+	// Den Dump zusaetzlich auf den Host spiegeln. Der Dump im Volume existiert
+	// bereits, daher ist ein Fehlschlag hier nur ein Hinweis, kein Startabbruch:
+	// so vernichtet ein spaeteres `docker compose down -v` nicht Daten und
+	// Backups zugleich.
+	hostDir := filepath.Join(stateDir, hostBackupDirName)
+	if err := mirrorBackupToHost(name, hostDir); err != nil {
+		fmt.Printf("Hinweis: Backup konnte nicht nach %s gespiegelt werden (%v).\n", hostDir, err)
+	} else {
+		fmt.Printf("Backup zusaetzlich gesichert in: %s\n", hostDir)
 	}
 	return nil
 }
@@ -140,4 +157,55 @@ func rotateBackups(keep int) error {
 		}
 	}
 	return nil
+}
+
+// mirrorBackupToHost kopiert den frisch erstellten Dump per `docker cp` aus dem
+// postgres-Container in hostDir und rotiert dort auf die neuesten keptBackups
+// Dateien. core.PlanBackupMirror entscheidet rein, was zu kopieren und zu
+// loeschen ist; diese Funktion fuehrt nur die Seiteneffekte aus. Der Aufrufer
+// behandelt einen Fehler hier als Hinweis, nicht als Startabbruch.
+func mirrorBackupToHost(name, hostDir string) error {
+	if err := os.MkdirAll(hostDir, 0o755); err != nil {
+		return fmt.Errorf("Backup-Ordner %s anlegen fehlgeschlagen: %w", hostDir, err)
+	}
+	existing, err := listHostBackups(hostDir)
+	if err != nil {
+		return err
+	}
+	plan := core.PlanBackupMirror(name, existing, keptBackups)
+
+	if plan.Copy != "" {
+		out, err := exec.Command("docker", "cp",
+			postgresContainer+":"+backupDir+"/"+plan.Copy, filepath.Join(hostDir, plan.Copy)).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("docker cp des Backups auf den Host fehlgeschlagen: %v: %s", err, strings.TrimSpace(string(out)))
+		}
+	}
+	for _, del := range plan.Delete {
+		if err := os.Remove(filepath.Join(hostDir, del)); err != nil {
+			return fmt.Errorf("altes Host-Backup %s loeschen fehlgeschlagen: %w", del, err)
+		}
+	}
+	return nil
+}
+
+// listHostBackups liefert die zeitgestempelten jotti-*.sql-Dumps in dir. Ein noch
+// fehlender Ordner gilt als leer (kein Fehler); alles ausserhalb des
+// Namensschemas bleibt unangetastet.
+func listHostBackups(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("Host-Backups auflisten fehlgeschlagen: %w", err)
+	}
+	var names []string
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, dumpPrefix) && strings.HasSuffix(name, dumpSuffix) {
+			names = append(names, name)
+		}
+	}
+	return names, nil
 }

--- a/windows/starter/core/backup.go
+++ b/windows/starter/core/backup.go
@@ -1,6 +1,9 @@
 package core
 
-import "sort"
+import (
+	"slices"
+	"sort"
+)
 
 // devVersion ist der Versionswert eines nicht-releasten Entwickler-Builds (der
 // Default von main.version). Ein Dev-Build loest nie ein Backup aus, damit der
@@ -35,4 +38,29 @@ func DumpsToDelete(names []string, keep int) []string {
 	sorted := append([]string(nil), names...)
 	sort.Strings(sorted)
 	return sorted[:len(sorted)-keep]
+}
+
+// MirrorPlan beschreibt, was der Host-Spiegel eines frisch erstellten Dumps tun
+// soll: Copy nennt die aus dem Volume auf den Host zu kopierende Datei (leer,
+// wenn sie dort bereits liegt), Delete die danach zu rotierenden Host-Dateien.
+type MirrorPlan struct {
+	Copy   string
+	Delete []string
+}
+
+// PlanBackupMirror entscheidet rein, wie ein soeben erzeugter Dump auf den Host
+// gespiegelt wird. Kopiert wird nur, wenn newDump dort noch fehlt (Namen sind
+// zeitgestempelt und eindeutig); geloescht werden — auf der Gesamtmenge nach dem
+// Kopieren — dieselben aeltesten ueber keep hinaus wie bei DumpsToDelete, sodass
+// Volume und Host-Spiegel dieselbe Aufbewahrung teilen. Bei keep <= 0 wird
+// defensiv nichts geloescht.
+func PlanBackupMirror(newDump string, hostNames []string, keep int) MirrorPlan {
+	plan := MirrorPlan{}
+	all := append([]string(nil), hostNames...)
+	if !slices.Contains(hostNames, newDump) {
+		plan.Copy = newDump
+		all = append(all, newDump)
+	}
+	plan.Delete = DumpsToDelete(all, keep)
+	return plan
 }

--- a/windows/starter/core/backup_test.go
+++ b/windows/starter/core/backup_test.go
@@ -63,3 +63,53 @@ func TestDumpsToDeleteGuardsAgainstZeroKeep(t *testing.T) {
 		t.Fatalf("keep <= 0 darf nie alle Backups loeschen: got %v", got)
 	}
 }
+
+func TestPlanBackupMirrorCopiesAndRotates(t *testing.T) {
+	// Host hat schon zwei aeltere Dumps; der neue kommt hinzu. Bei keep 2
+	// bleiben die neuesten zwei erhalten, der aelteste faellt weg.
+	host := []string{"jotti-20260610-080000.sql", "jotti-20260611-060000.sql"}
+	got := PlanBackupMirror("jotti-20260612-070000.sql", host, 2)
+	want := MirrorPlan{
+		Copy:   "jotti-20260612-070000.sql",
+		Delete: []string{"jotti-20260610-080000.sql"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PlanBackupMirror: got %+v, want %+v", got, want)
+	}
+}
+
+func TestPlanBackupMirrorSkipsCopyWhenAlreadyOnHost(t *testing.T) {
+	// Liegt der Dump schon auf dem Host (Wiederholung im selben Sekundentakt),
+	// wird nicht erneut kopiert; die Gesamtmenge aendert sich nicht.
+	host := []string{"jotti-20260611-060000.sql", "jotti-20260612-070000.sql"}
+	got := PlanBackupMirror("jotti-20260612-070000.sql", host, 5)
+	if got.Copy != "" {
+		t.Fatalf("bereits gespiegelter Dump darf nicht erneut kopiert werden: got Copy %q", got.Copy)
+	}
+	if got.Delete != nil {
+		t.Fatalf("unter dem Limit darf nichts geloescht werden: got %v", got.Delete)
+	}
+}
+
+func TestPlanBackupMirrorKeepsWhenWithinLimit(t *testing.T) {
+	// Leerer Host, erster Spiegel: kopieren, nichts loeschen.
+	got := PlanBackupMirror("jotti-20260612-070000.sql", nil, 5)
+	if got.Copy != "jotti-20260612-070000.sql" {
+		t.Fatalf("erster Spiegel muss kopieren: got Copy %q", got.Copy)
+	}
+	if got.Delete != nil {
+		t.Fatalf("unter dem Limit darf nichts geloescht werden: got %v", got.Delete)
+	}
+}
+
+func TestPlanBackupMirrorGuardsAgainstZeroKeep(t *testing.T) {
+	// keep <= 0 ist eine Fehlkonfiguration: kopieren ja, aber nie alles loeschen.
+	host := []string{"jotti-20260610-080000.sql", "jotti-20260611-060000.sql"}
+	got := PlanBackupMirror("jotti-20260612-070000.sql", host, 0)
+	if got.Copy != "jotti-20260612-070000.sql" {
+		t.Fatalf("Kopie muss auch bei keep <= 0 erfolgen: got Copy %q", got.Copy)
+	}
+	if got.Delete != nil {
+		t.Fatalf("keep <= 0 darf nie Host-Backups loeschen: got %v", got.Delete)
+	}
+}


### PR DESCRIPTION
Round 1 of operations hardening: the F1-F4 fixes, closing CI gaps, and broad production hardening.

## Phases
1. Harden `read_env` and silence the F1/F3 backup traps so failures surface instead of being swallowed.
2. Parametrize backup and restore through `COMPOSE_FILE` so both work against any environment.
3. Add dump integrity checking plus a success ping to the production backup.
4. Add `prod-backup-verify` to prove backups via a throwaway restore test.
5. Extend the release smoke test to run a backup and its verify roundtrip.
6. Fail-fast version pinning for init and update (hard error on unpinned versions).
7. Fix the Windows and website CI jobs, add a shellcheck job and Dependabot.
8. Add log rotation, healthchecks and nginx reload to the compose stack.
9. Run the backend and migrate images as non-root.
10. Add DB start retry and expose version info in the health endpoint.
11. Windows host mirror for the pre-update dump and manual backup.

## Verification
Release dry-runs are green for the affected phases (P5 smoke backup+verify roundtrip and P9 non-root image build), in addition to a green local `make verify`.