### PR TITLE
fix(frontend): rebuild drawer on Radix Dialog to fix iOS PWA bugs

### DIFF
--- a/docs/plans/plan-pwa-ios-drawer-fixes.md
+++ b/docs/plans/plan-pwa-ios-drawer-fixes.md
@@ -136,12 +136,12 @@ in iOS-Standalone korrekt arbeitet.
 
 ### Acceptance criteria
 
-- [ ] `grep -r "vaul" frontend/src frontend/package.json` liefert keine Treffer mehr.
-- [ ] Alle sechs Drawer öffnen und schließen in den bestehenden Unit-Tests über die
+- [x] `grep -r "vaul" frontend/src frontend/package.json` liefert keine Treffer mehr.
+- [x] Alle sechs Drawer öffnen und schließen in den bestehenden Unit-Tests über die
       unveränderte `Drawer*`-API (Dialog-Rolle sichtbar, Overlay vorhanden).
-- [ ] `StickyActionBar` als `DrawerTrigger asChild` öffnet den Drawer; bei leerer Auswahl
+- [x] `StickyActionBar` als `DrawerTrigger asChild` öffnet den Drawer; bei leerer Auswahl
       verhindert der bestehende `onOpenChange`-Guard das Öffnen (bestehende Tests grün).
-- [ ] `make check` grün; komplette E2E-Suite (`desktop-admin` + `mobile-service`) grün —
+- [x] `make check` grün; komplette E2E-Suite (`desktop-admin` + `mobile-service`) grün —
       insbesondere `bestellen-kassieren.spec.ts`, `stornierung-serviceleitung.mobile.spec.ts`,
       `umbuchung.mobile.spec.ts`, `direktverkauf-storno.mobile.spec.ts`.
 
@@ -178,15 +178,15 @@ erfolgreich abschließen.
 
 ### Acceptance criteria
 
-- [ ] Im mobilen E2E-Viewport ist der Kassieren-Button bei ≥ 9 Positionen **und** gefüllten
+- [x] Im mobilen E2E-Viewport ist der Kassieren-Button bei ≥ 9 Positionen **und** gefüllten
       Trinkgeld-/Erhalten-Feldern sichtbar (`toBeInViewport`) und die Zahlung wird
       erfolgreich verbucht (neue Spec grün).
-- [ ] Gleiches Kriterium für „Bestellung aufnehmen" bei einer Bestellung mit ≥ 9 Positionen.
-- [ ] Rückgeld-/Trinkgeld-Zeilen und Hinweistext erscheinen weiterhin korrekt (bestehende
+- [x] Gleiches Kriterium für „Bestellung aufnehmen" bei einer Bestellung mit ≥ 9 Positionen.
+- [x] Rückgeld-/Trinkgeld-Zeilen und Hinweistext erscheinen weiterhin korrekt (bestehende
       Unit-Tests `Zahlung.test.tsx` grün, ggf. angepasst an neue Struktur).
-- [ ] Kein Element im Drawer außer `DrawerBody` ist vertikal scrollbar (kein verschachteltes
+- [x] Kein Element im Drawer außer `DrawerBody` ist vertikal scrollbar (kein verschachteltes
       Scrollen; `Receipt` ohne eigenen `max-h`-Cap).
-- [ ] `make check` und E2E-Suite grün.
+- [x] `make check` und E2E-Suite grün.
 
 ---
 
@@ -213,16 +213,16 @@ Umbuchen-Button und „Abbrechen" bei beliebig vielen Positionen sichtbar.
 
 ### Acceptance criteria
 
-- [ ] Alle vier Drawer folgen der Struktur Header → `DrawerBody` → Footer; keine eigenen
+- [x] Alle vier Drawer folgen der Struktur Header → `DrawerBody` → Footer; keine eigenen
       `max-h`-Caps in Listen mehr (`grep -rn "max-h-\[" frontend/src/service` zeigt keine
       Treffer in Drawer-Inhalten).
-- [ ] Storno- und Umbuchungs-Footer sind im mobilen E2E-Viewport bei vielen Positionen
+- [x] Storno- und Umbuchungs-Footer sind im mobilen E2E-Viewport bei vielen Positionen
       sichtbar und funktionsfähig (bestehende Specs `stornierung-serviceleitung.mobile`,
       `umbuchung.mobile`, `direktverkauf-storno.mobile` grün; wo keine lange Liste
       abgedeckt ist, Unit-Test auf Strukturebene ergänzen).
-- [ ] Tischsuche im `TischAuswahlDrawer` funktioniert unverändert (bestehender Unit-Test
+- [x] Tischsuche im `TischAuswahlDrawer` funktioniert unverändert (bestehender Unit-Test
       grün); das Suchfeld scrollt nicht mit der Liste.
-- [ ] `make check` und E2E-Suite grün.
+- [x] `make check` und E2E-Suite grün.
 
 ---
 
@@ -248,10 +248,10 @@ jedem Drawer. Kein neues Overlay-Framework, kein globaler State.
 
 ### Acceptance criteria
 
-- [ ] Während eines laufenden Submits schließt weder Escape noch Backdrop-Tap den Drawer;
+- [x] Während eines laufenden Submits schließt weder Escape noch Backdrop-Tap den Drawer;
       nach Erfolg schließt er wie bisher automatisch (Unit-Test je Verhalten).
-- [ ] Der Pending-Zustand ist visuell erkennbar (gedimmter Body + Spinner im Button) —
+- [x] Der Pending-Zustand ist visuell erkennbar (gedimmter Body + Spinner im Button) —
       Unit-Test auf Strukturebene.
-- [ ] Fehlerfall unverändert: Toast erscheint, Drawer bleibt offen und wieder bedienbar
+- [x] Fehlerfall unverändert: Toast erscheint, Drawer bleibt offen und wieder bedienbar
       (bestehende Tests grün).
-- [ ] `make check` und E2E-Suite grün.
+- [x] `make check` und E2E-Suite grün.

--- a/e2e/support/servicekraft.ts
+++ b/e2e/support/servicekraft.ts
@@ -39,17 +39,15 @@ export async function oeffneTisch(page: Page, tisch: string): Promise<void> {
   await expect(page.getByRole('tab', { name: 'Bestellen' })).toBeVisible()
 }
 
-// bestellePosition nimmt auf dem aktuell offenen Tisch eine Bestellung über
-// den Bestellen-Tab auf: Produkt aufklappen, Variante zur gewünschten Menge
-// hinzufügen, Bestellung im Drawer bestätigen.
-export async function bestellePosition(
+// waehleVariante fügt auf dem Bestellen-Tab eine Variante zur gewünschten
+// Menge der aktuellen Auswahl hinzu, ohne die Bestellung abzuschicken —
+// Baustein für Bestellungen mit mehreren Positionen.
+export async function waehleVariante(
   page: Page,
   produkt: string,
   variante: string,
   menge = 1,
 ): Promise<void> {
-  await page.getByRole('tab', { name: 'Bestellen' }).click()
-
   const variantenZeile = zeileMit(page, variante, 'Variante hinzufügen')
   // Produkt nur aufklappen, wenn die Variante noch nicht sichtbar ist — beim
   // zweiten Aufruf für dasselbe Produkt bliebe es sonst geöffnet und der
@@ -62,6 +60,20 @@ export async function bestellePosition(
   for (let i = 0; i < menge; i++) {
     await variantenZeile.getByRole('button', { name: 'Variante hinzufügen' }).click()
   }
+}
+
+// bestellePosition nimmt auf dem aktuell offenen Tisch eine Bestellung über
+// den Bestellen-Tab auf: Produkt aufklappen, Variante zur gewünschten Menge
+// hinzufügen, Bestellung im Drawer bestätigen.
+export async function bestellePosition(
+  page: Page,
+  produkt: string,
+  variante: string,
+  menge = 1,
+): Promise<void> {
+  await page.getByRole('tab', { name: 'Bestellen' }).click()
+
+  await waehleVariante(page, produkt, variante, menge)
 
   await page.getByRole('button', { name: /Bestellung überprüfen/ }).click()
   const drawer = page.getByRole('dialog')
@@ -148,7 +160,7 @@ function vollePositionsZeilen(page: Page): Locator {
 // „noch 0" im Zeilentext steht. Eine Obergrenze pro Zeile
 // verhindert eine Endlosschleife, falls der Text unerwartet nie „noch 0"
 // erreicht.
-async function waehleAlleVollAus(page: Page): Promise<void> {
+export async function waehleAlleVollAus(page: Page): Promise<void> {
   const zeilen = vollePositionsZeilen(page)
   const anzahlZeilen = await zeilen.count()
   for (let i = 0; i < anzahlZeilen; i++) {

--- a/e2e/tests/tischservice-lange-bestellung.mobile.spec.ts
+++ b/e2e/tests/tischservice-lange-bestellung.mobile.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from '@playwright/test'
+
+import { anmelden } from '../support/anmelden'
+import { resetAndSeed } from '../support/seed'
+import {
+  oeffneTisch,
+  waehleAlleVollAus,
+  waehleVariante,
+} from '../support/servicekraft'
+
+// Viewport-Regression für das Drawer-Scroll-Layout (Bug 2 aus dem Praxistest
+// 2026-07-09): Bei einer Bestellung mit vielen Positionen und ausgefüllten
+// Trinkgeld-/Erhalten-Feldern müssen die Primär-Buttons („Bestellung
+// aufnehmen", „Kassieren") im mobilen Viewport sichtbar und bedienbar bleiben
+// — der Mittelteil des Drawers (DrawerBody) scrollt, Header und Footer stehen
+// fest.
+
+// „Tisch 1" startet im Demo-Drehbuch ausgeglichen (Saldo 0,00 €) und ohne
+// unbezahlte Positionen — die Auswahl auf dem Kassieren-Tab enthält damit
+// genau die hier bestellten Positionen.
+const TISCH = 'Tisch 1'
+
+// 9 unterschiedliche Varianten → 9 Positionen im Beleg (Summe 52,00 €). Die
+// Variantennamen sind über alle gewählten Produkte hinweg eindeutig, damit
+// waehleVariante jede Zeile ohne Mehrdeutigkeit trifft.
+const POSITIONEN: [produkt: string, variante: string][] = [
+  ['Bratwurst', 'Normal'],
+  ['Bratwurst', 'XXL'],
+  ['Bratwurst', 'Currywurst'],
+  ['Pommes', 'Klein'],
+  ['Pommes', 'Groß'],
+  ['Flammkuchen', 'Classic'],
+  ['Flammkuchen', 'Speck & Zwiebel'],
+  ['Flammkuchen', 'Mediterran'],
+  ['Tagesgericht', 'Fr: Schnitzel mit Pommes'],
+]
+
+test.describe('Drawer-Scroll-Layout bei langer Positionsliste', () => {
+  test('Bestellung mit 9 Positionen aufnehmen und mit Trinkgeld kassieren', async ({
+    page,
+    request,
+  }) => {
+    const zugangsdaten = await resetAndSeed(request)
+    await anmelden(page, zugangsdaten.service)
+    await oeffneTisch(page, TISCH)
+
+    // Alle 9 Positionen in einer Bestellung sammeln.
+    await page.getByRole('tab', { name: 'Bestellen' }).click()
+    for (const [produkt, variante] of POSITIONEN) {
+      await waehleVariante(page, produkt, variante)
+    }
+
+    // Bestell-Drawer: Beleg zeigt alle Positionen, die Buttons bleiben trotz
+    // langer Liste im Viewport.
+    await page.getByRole('button', { name: /Bestellung überprüfen/ }).click()
+    const bestellDrawer = page.getByRole('dialog')
+    await expect(bestellDrawer.getByText('Flammkuchen Mediterran')).toBeVisible()
+    const aufnehmen = bestellDrawer.getByRole('button', {
+      name: 'Bestellung aufnehmen',
+    })
+    await expect(aufnehmen).toBeInViewport()
+    await expect(
+      bestellDrawer.getByRole('button', { name: 'Abbrechen' }),
+    ).toBeInViewport()
+    await aufnehmen.click()
+    await expect(
+      page.getByText('Bestellung wurde aufgenommen.').first(),
+    ).toBeVisible()
+
+    // Alle Positionen zum Kassieren auswählen und den Zahlungs-Drawer öffnen.
+    await page.getByRole('tab', { name: 'Kassieren' }).click()
+    await waehleAlleVollAus(page)
+    await page.getByRole('button', { name: /Kassieren/ }).click()
+
+    // Trinkgeld und Erhalten eintragen: Die zusätzlichen Rückgeld-/
+    // Trinkgeld-Zeilen samt Hinweistext verlängern den Drawer-Inhalt weiter.
+    const zahlungsDrawer = page.getByRole('dialog')
+    await zahlungsDrawer.getByLabel('inklusive Trinkgeld').fill('55,00')
+    await zahlungsDrawer.getByLabel('Erhalten').fill('60,00')
+    await expect(
+      zahlungsDrawer.getByText('Trinkgeld', { exact: true }),
+    ).toBeVisible()
+    await expect(zahlungsDrawer.getByText('Rückgeld')).toBeVisible()
+
+    // Der Kassieren-Button bleibt im Viewport und die Zahlung gelingt.
+    const kassieren = zahlungsDrawer.getByRole('button', { name: 'Kassieren' })
+    await expect(kassieren).toBeInViewport()
+    await kassieren.click()
+    await expect(page.getByText('Zahlung erfolgreich.').first()).toBeVisible()
+
+    // Tisch ist danach wieder ausgeglichen (Saldo-Element im Tisch-Header).
+    const tischSaldo = page.locator('[data-slot="item-description"].text-2xl')
+    await expect(tischSaldo).toHaveText('0,00 €')
+  })
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,6 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.2",
-    "vaul": "^1.1.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
-      vaul:
-        specifier: ^1.1.2
-        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3844,12 +3841,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  vaul@1.1.2:
-    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
-    peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
@@ -7784,15 +7775,6 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
-
-  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
 
   victory-vendor@37.3.6:
     dependencies:

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -55,9 +55,11 @@ function DrawerContent({
   // DrawerBody wird gedimmt und nimmt keine Eingaben an.
   pending?: boolean
 }) {
-  // Radix ruft die Dismiss-Handler aus dem Closure ihrer Registrierung auf;
-  // ein dort eingefrorenes `pending` wäre veraltet. Die Ref liefert dem
-  // Handler immer den aktuellen Wert.
+  // Radix ruft die Dismiss-Handler mit der Closure ihrer Registrierung auf:
+  // Ein direkt gelesenes `pending` bleibt im Escape-Handler nach dem Wechsel
+  // auf true noch false (radix-ui 1.6.1; durch den Pending-Unit-Test in
+  // ZahlungDrawer.test.tsx abgesichert). Die Ref liefert dem Handler deshalb
+  // immer den aktuellen Wert.
   const pendingRef = React.useRef(pending)
   React.useEffect(() => {
     pendingRef.current = pending

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Drawer as DrawerPrimitive } from "vaul"
+import { Dialog as DrawerPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
@@ -35,7 +35,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}
@@ -46,30 +46,44 @@ function DrawerOverlay({
 function DrawerContent({
   className,
   children,
+  pending = false,
+  onEscapeKeyDown,
+  onInteractOutside,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+}: React.ComponentProps<typeof DrawerPrimitive.Content> & {
+  // Laufender Submit: Escape und Backdrop-Tap schließen den Drawer nicht,
+  // DrawerBody wird gedimmt und nimmt keine Eingaben an.
+  pending?: boolean
+}) {
+  // Radix ruft die Dismiss-Handler aus dem Closure ihrer Registrierung auf;
+  // ein dort eingefrorenes `pending` wäre veraltet. Die Ref liefert dem
+  // Handler immer den aktuellen Wert.
+  const pendingRef = React.useRef(pending)
+  React.useEffect(() => {
+    pendingRef.current = pending
+  }, [pending])
+
   return (
     <DrawerPortal data-slot="drawer-portal">
       <DrawerOverlay />
       <DrawerPrimitive.Content
         data-slot="drawer-content"
+        data-pending={pending || undefined}
+        onEscapeKeyDown={(event) => {
+          if (pendingRef.current) event.preventDefault()
+          onEscapeKeyDown?.(event)
+        }}
+        onInteractOutside={(event) => {
+          if (pendingRef.current) event.preventDefault()
+          onInteractOutside?.(event)
+        }}
         className={cn(
-          "group/drawer-content fixed z-50 flex h-auto flex-col bg-popover text-sm text-popover-foreground data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "group/drawer-content fixed inset-x-0 bottom-0 z-50 flex max-h-[85dvh] flex-col rounded-t-xl border-t bg-popover pb-[env(safe-area-inset-bottom,0px)] text-sm text-popover-foreground duration-200 data-open:animate-in data-open:fade-in-0 data-open:slide-in-from-bottom-10 data-closed:animate-out data-closed:fade-out-0 data-closed:slide-out-to-bottom-10",
           className
         )}
         {...props}
       >
-        <div className="mx-auto mt-4 hidden h-1.5 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
-        {/*
-          iOS Safari reads the tiny finger jitter of a tap as a vaul drag
-          gesture, which moves the sheet and swallows the tap (buttons fail to
-          fire, the panel flickers). Marking the whole panel no-drag makes taps
-          land reliably; the handle above stays a sibling, so swipe-to-dismiss
-          from the handle still works. `contents` keeps the wrapper layout-free.
-        */}
-        <div data-vaul-no-drag className="contents">
-          {children}
-        </div>
+        {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>
   )
@@ -80,7 +94,23 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="drawer-header"
       className={cn(
-        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        "flex flex-col gap-0.5 p-4 text-center md:gap-1.5 md:text-left",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+// DrawerBody ist der einzige Scrollbereich des Drawers. Header und Footer
+// sind direkte Flex-Kinder von DrawerContent und bleiben dadurch immer
+// sichtbar — auch bei beliebig langem Inhalt.
+function DrawerBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-body"
+      className={cn(
+        "min-h-0 overflow-y-auto group-data-[pending]/drawer-content:pointer-events-none group-data-[pending]/drawer-content:opacity-50",
         className
       )}
       {...props}
@@ -132,6 +162,7 @@ export {
   DrawerClose,
   DrawerContent,
   DrawerHeader,
+  DrawerBody,
   DrawerFooter,
   DrawerTitle,
   DrawerDescription,

--- a/frontend/src/service/TablePage.test.tsx
+++ b/frontend/src/service/TablePage.test.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Position } from './table/Bestellung'
@@ -42,22 +41,6 @@ vi.mock('@/hooks/use-mobile', () => ({
 vi.mock('./product/hooks', () => ({
   useAktiveProdukte: () => ({ produkte: [], isPending: false }),
 }))
-
-// vaul's Drawer braucht Browser-APIs, die jsdom nicht bereitstellt — der
-// Drawer-Inhalt ist für diese Tests irrelevant.
-vi.mock('@/components/ui/drawer', () => {
-  const Passthrough = ({ children }: { children?: ReactNode }) => children
-  return {
-    Drawer: Passthrough,
-    DrawerTrigger: Passthrough,
-    DrawerContent: () => null,
-    DrawerHeader: Passthrough,
-    DrawerTitle: Passthrough,
-    DrawerDescription: Passthrough,
-    DrawerFooter: Passthrough,
-    DrawerClose: Passthrough,
-  }
-})
 
 const { getTischState, getTischHistorie } = vi.hoisted(() => ({
   getTischState: vi.fn<() => Promise<TischSession>>(),

--- a/frontend/src/service/components/PositionAuswahlListe.tsx
+++ b/frontend/src/service/components/PositionAuswahlListe.tsx
@@ -20,14 +20,12 @@ interface PositionAuswahlListeProps {
   onRemove: (id: string) => void
 }
 
-// PositionAuswahlListe rendert eine scrollbare Positionsliste mit Mengen-Steppern
+// PositionAuswahlListe rendert eine Positionsliste mit Mengen-Steppern
 // (Minus/Anzahl/Plus). Sie ist controlled: die Mengenlogik (Grenzen,
-// Voll-Vorauswahl) bleibt im jeweiligen Drawer, hier liegen nur Darstellung und
-// der native Scrollbereich. Nur diese Liste scrollt (natives overflow-y-auto,
-// dvh-basierte Maximalhöhe, damit Kommentarfeld und Buttons auch mit geöffneter
-// Bildschirmtastatur erreichbar bleiben); Header, Summe, Kommentarfeld und Footer
-// liegen im Drawer außerhalb dieser Komponente. Lange Namen werden per truncate
-// abgeschnitten, sodass die Stepper-Buttons an ihrem Platz bleiben.
+// Voll-Vorauswahl) bleibt im jeweiligen Drawer, hier liegt nur die Darstellung.
+// Die Liste scrollt nicht selbst — sie liegt im DrawerBody, dem einzigen
+// Scrollbereich des Drawers. Lange Namen werden per truncate abgeschnitten,
+// sodass die Stepper-Buttons an ihrem Platz bleiben.
 export function PositionAuswahlListe({
   positionen,
   mengen,
@@ -35,7 +33,7 @@ export function PositionAuswahlListe({
   onRemove,
 }: PositionAuswahlListeProps) {
   return (
-    <div className="px-4 space-y-2 overflow-y-auto max-h-[45dvh]">
+    <div className="px-4 space-y-2">
       {positionen.map((position) => {
         const selected = mengen[position.id] || 0
         return (

--- a/frontend/src/service/components/TischAuswahlDrawer.test.tsx
+++ b/frontend/src/service/components/TischAuswahlDrawer.test.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -17,17 +16,6 @@ vi.mock('react-router', () => ({
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
-
-// vaul's Drawer depends on browser APIs unavailable in jsdom — render children inline.
-vi.mock('@/components/ui/drawer', () => {
-  const Passthrough = ({ children }: { children?: ReactNode }) => children
-  return {
-    Drawer: Passthrough,
-    DrawerContent: Passthrough,
-    DrawerHeader: Passthrough,
-    DrawerTitle: Passthrough,
-  }
-})
 
 vi.mock('@/lib/Backend', () => ({
   BackendSingleton: {},
@@ -70,6 +58,18 @@ function renderDrawer() {
 }
 
 describe('TischAuswahlDrawer', () => {
+  it('zeigt die Tisch-Liste im DrawerBody, das Suchfeld scrollt nicht mit', () => {
+    renderDrawer()
+
+    const dialog = screen.getByRole('dialog')
+    const body = dialog.querySelector('[data-slot="drawer-body"]')
+    expect(body).not.toBeNull()
+    expect(body).toContainElement(screen.getByText('Stammtisch'))
+    expect(body).not.toContainElement(
+      screen.getByPlaceholderText('Tisch suchen...'),
+    )
+  })
+
   it('invalidiert nach Favoriten-Toggle beide Query-Caches', async () => {
     const user = userEvent.setup()
     const { invalidate } = renderDrawer()

--- a/frontend/src/service/components/TischAuswahlDrawer.tsx
+++ b/frontend/src/service/components/TischAuswahlDrawer.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router'
 
 import {
   Drawer,
+  DrawerBody,
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
@@ -64,12 +65,13 @@ export function TischAuswahlDrawer({
   }
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange} direction="bottom">
-      <DrawerContent className="px-4 pb-6">
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent aria-describedby={undefined}>
         <DrawerHeader>
           <DrawerTitle>Alle Tische</DrawerTitle>
         </DrawerHeader>
-        <div className="mb-3">
+        {/* Suchfeld außerhalb von DrawerBody, damit es beim Scrollen der Liste sichtbar bleibt. */}
+        <div className="px-4 pb-3">
           <Input
             placeholder="Tisch suchen..."
             value={suche}
@@ -78,7 +80,7 @@ export function TischAuswahlDrawer({
             }}
           />
         </div>
-        <div className="flex flex-col gap-0 overflow-y-auto max-h-[60vh]">
+        <DrawerBody className="flex flex-col gap-0 px-4 pb-6">
           {gefilterteTische.map((tisch) => (
             <div
               key={tisch.id}
@@ -121,7 +123,7 @@ export function TischAuswahlDrawer({
               </button>
             </div>
           ))}
-        </div>
+        </DrawerBody>
       </DrawerContent>
     </Drawer>
   )

--- a/frontend/src/service/components/direktverkauf/DirektverkaufHistorie.test.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufHistorie.test.tsx
@@ -1,6 +1,5 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { DirektverkaufHistorieEintrag } from '../../direktverkauf/Direktverkauf'
@@ -13,21 +12,6 @@ vi.mock('sonner', () => ({
 vi.mock('@/lib/Auth', () => ({
   AuthSingleton: { canCancel: true },
 }))
-
-// vaul's Drawer depends on browser APIs unavailable in jsdom.
-// Render its children inline so the storno form logic stays testable.
-vi.mock('@/components/ui/drawer', () => {
-  const Passthrough = ({ children }: { children?: ReactNode }) => children
-  return {
-    Drawer: Passthrough,
-    DrawerContent: Passthrough,
-    DrawerHeader: Passthrough,
-    DrawerTitle: Passthrough,
-    DrawerDescription: Passthrough,
-    DrawerFooter: Passthrough,
-    DrawerClose: Passthrough,
-  }
-})
 
 afterEach(() => {
   cleanup()

--- a/frontend/src/service/components/direktverkauf/DirektverkaufStornoDrawer.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufStornoDrawer.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Drawer,
+  DrawerBody,
   DrawerClose,
   DrawerContent,
   DrawerDescription,
@@ -85,14 +86,14 @@ export function DirektverkaufStornoDrawer({
         if (!isOpen) onClose()
       }}
     >
-      <DrawerContent>
-        <div className="mx-auto w-full max-w-sm">
-          <DrawerHeader>
-            <DrawerTitle>Verkauf stornieren</DrawerTitle>
-            <DrawerDescription>
-              Positionen aus diesem Verkauf zum Stornieren auswählen.
-            </DrawerDescription>
-          </DrawerHeader>
+      <DrawerContent pending={loading}>
+        <DrawerHeader className="mx-auto w-full max-w-sm">
+          <DrawerTitle>Verkauf stornieren</DrawerTitle>
+          <DrawerDescription>
+            Positionen aus diesem Verkauf zum Stornieren auswählen.
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerBody className="mx-auto w-full max-w-sm">
           <PositionAuswahlListe
             positionen={toAuswahlPositionen(verkauf.offenePositionen)}
             mengen={mengen}
@@ -118,23 +119,23 @@ export function DirektverkaufStornoDrawer({
               }}
             />
           </div>
-          <DrawerFooter>
-            <Button
-              variant="destructive"
-              disabled={loading || noPositionenSelected || kommentarInvalid}
-              onClick={() => {
-                void onSubmit()
-              }}
-            >
-              {loading ? <Spinner /> : null} Stornierung erteilen
+        </DrawerBody>
+        <DrawerFooter className="mx-auto w-full max-w-sm">
+          <Button
+            variant="destructive"
+            disabled={loading || noPositionenSelected || kommentarInvalid}
+            onClick={() => {
+              void onSubmit()
+            }}
+          >
+            {loading ? <Spinner /> : null} Stornierung erteilen
+          </Button>
+          <DrawerClose asChild>
+            <Button variant="outline" disabled={loading}>
+              Abbrechen
             </Button>
-            <DrawerClose asChild>
-              <Button variant="outline" disabled={loading}>
-                Abbrechen
-              </Button>
-            </DrawerClose>
-          </DrawerFooter>
-        </div>
+          </DrawerClose>
+        </DrawerFooter>
       </DrawerContent>
     </Drawer>
   )

--- a/frontend/src/service/components/table/Bestellung.test.tsx
+++ b/frontend/src/service/components/table/Bestellung.test.tsx
@@ -1,6 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Produkt } from '../../product/Produkt'
@@ -10,23 +9,6 @@ import { Bestellung } from './Bestellung'
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
-
-// vaul's Drawer braucht Browser-APIs, die jsdom nicht bereitstellt. Der Trigger
-// (Sticky-Leiste) wird inline gerendert, der Drawer-Inhalt ausgeblendet — so
-// bleibt nur die Aktionsleiste übrig, die hier geprüft wird.
-vi.mock('@/components/ui/drawer', () => {
-  const Passthrough = ({ children }: { children?: ReactNode }) => children
-  return {
-    Drawer: Passthrough,
-    DrawerTrigger: Passthrough,
-    DrawerContent: () => null,
-    DrawerHeader: Passthrough,
-    DrawerTitle: Passthrough,
-    DrawerDescription: Passthrough,
-    DrawerFooter: Passthrough,
-    DrawerClose: Passthrough,
-  }
-})
 
 afterEach(() => {
   cleanup()

--- a/frontend/src/service/components/table/BestellungDrawer.test.tsx
+++ b/frontend/src/service/components/table/BestellungDrawer.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Produkt } from '../../product/Produkt'
+import type { Tisch } from '../../table/Tisch'
+import { BestellungDrawer } from './BestellungDrawer'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+const tisch: Tisch = { id: 1, name: 'Stammtisch', saldoCents: 0 }
+
+const testProdukt: Produkt = {
+  id: 1,
+  name: 'Bratwurst',
+  kategorie: 'essen',
+  status: 'active',
+  varianten: [
+    {
+      id: 1,
+      name: 'Normal',
+      preisCents: 350,
+      status: 'active',
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    },
+  ],
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+}
+
+function renderDrawer(mengen: Record<number, number>) {
+  render(
+    <BestellungDrawer
+      backend={{ bestellungAufnehmen: vi.fn().mockResolvedValue(undefined) }}
+      tisch={tisch}
+      products={[testProdukt]}
+      mengen={mengen}
+      bestellungAufgenommen={vi.fn()}
+    />,
+  )
+}
+
+describe('BestellungDrawer', () => {
+  it('öffnet bei leerer Auswahl nicht (onOpenChange-Guard)', async () => {
+    const user = userEvent.setup()
+    renderDrawer({})
+
+    // Klick auf die Trigger-Fläche (das Wurzel-Div der Aktionsleiste), nicht
+    // auf den deaktivierten Button — der Guard muss das Öffnen verhindern.
+    const bar = screen
+      .getByRole('button', { name: /Bestellung überprüfen/ })
+      .closest('div[aria-haspopup="dialog"]')
+    if (bar === null) throw new Error('Trigger-Fläche nicht gefunden')
+    await user.click(bar)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('öffnet mit Auswahl über den Trigger; Footer-Buttons liegen außerhalb des Scrollbereichs', async () => {
+    const user = userEvent.setup()
+    renderDrawer({ 1: 2 })
+
+    await user.click(
+      screen.getByRole('button', { name: /Bestellung überprüfen/ }),
+    )
+
+    const dialog = await screen.findByRole('dialog')
+    const body = dialog.querySelector('[data-slot="drawer-body"]')
+    expect(body).not.toBeNull()
+    expect(body).toContainElement(screen.getByText(/Bratwurst/))
+    expect(body).not.toContainElement(
+      screen.getByRole('button', { name: 'Bestellung aufnehmen' }),
+    )
+    expect(body).not.toContainElement(
+      screen.getByRole('button', { name: 'Abbrechen' }),
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Abbrechen' }))
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/service/components/table/BestellungDrawer.tsx
+++ b/frontend/src/service/components/table/BestellungDrawer.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Drawer,
+  DrawerBody,
   DrawerClose,
   DrawerContent,
   DrawerDescription,
@@ -87,14 +88,14 @@ export function BestellungDrawer(props: BestellungDrawerProps) {
           disabled={noPositionenSelected}
         />
       </DrawerTrigger>
-      <DrawerContent>
-        <div className="mx-auto w-full max-w-sm">
-          <DrawerHeader>
-            <DrawerTitle>Bestellung für {props.tisch.name}</DrawerTitle>
-            <DrawerDescription>
-              Überprüfe deine Bestellung vor dem Absenden.
-            </DrawerDescription>
-          </DrawerHeader>
+      <DrawerContent pending={loading}>
+        <DrawerHeader className="mx-auto w-full max-w-sm">
+          <DrawerTitle>Bestellung für {props.tisch.name}</DrawerTitle>
+          <DrawerDescription>
+            Überprüfe deine Bestellung vor dem Absenden.
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerBody className="mx-auto w-full max-w-sm">
           <Receipt positionen={receiptItems} totalPrice={totalPrice} />
           <div className="px-4">
             <KommentarField
@@ -103,22 +104,22 @@ export function BestellungDrawer(props: BestellungDrawerProps) {
               }}
             />
           </div>
-          <DrawerFooter>
-            <Button
-              disabled={loading}
-              onClick={() => {
-                void onSubmit()
-              }}
-            >
-              {loading ? <Spinner /> : null} Bestellung aufnehmen
+        </DrawerBody>
+        <DrawerFooter className="mx-auto w-full max-w-sm">
+          <Button
+            disabled={loading}
+            onClick={() => {
+              void onSubmit()
+            }}
+          >
+            {loading ? <Spinner /> : null} Bestellung aufnehmen
+          </Button>
+          <DrawerClose asChild>
+            <Button variant="outline" disabled={loading}>
+              Abbrechen
             </Button>
-            <DrawerClose asChild>
-              <Button variant="outline" disabled={loading}>
-                Abbrechen
-              </Button>
-            </DrawerClose>
-          </DrawerFooter>
-        </div>
+          </DrawerClose>
+        </DrawerFooter>
       </DrawerContent>
     </Drawer>
   )

--- a/frontend/src/service/components/table/HistorieStornierungDrawer.test.tsx
+++ b/frontend/src/service/components/table/HistorieStornierungDrawer.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Position } from '../../table/Bestellung'
+import type { Tisch } from '../../table/Tisch'
+import { HistorieStornierungDrawer } from './HistorieStornierungDrawer'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+const tisch: Tisch = { id: 1, name: 'Stammtisch', saldoCents: 0 }
+
+const position: Position = {
+  positionId: '00000000-0000-0000-0000-000000000001',
+  varianteId: 1,
+  produktName: 'Bratwurst',
+  varianteName: 'Normal',
+  kategorie: 'essen',
+  steuersatz: 'regel',
+  einzelpreisCents: 350,
+  menge: 2,
+  bestellerUserId: 1,
+  bestellerName: 'Tester',
+}
+
+describe('HistorieStornierungDrawer', () => {
+  it('rendert Positionsliste und Kommentar im DrawerBody, Buttons im Footer außerhalb', () => {
+    render(
+      <HistorieStornierungDrawer
+        backend={{ stornierungErteilen: vi.fn().mockResolvedValue(undefined) }}
+        tisch={tisch}
+        vorgangId="00000000-0000-0000-0000-000000000042"
+        positionen={[position]}
+        onClose={vi.fn()}
+        onStornierungErteilt={vi.fn()}
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    const body = dialog.querySelector('[data-slot="drawer-body"]')
+    expect(body).not.toBeNull()
+    expect(body).toContainElement(screen.getByText(/Bratwurst/))
+    expect(body).toContainElement(
+      screen.getByPlaceholderText('Kommentar (erforderlich)'),
+    )
+    expect(body).not.toContainElement(
+      screen.getByRole('button', { name: 'Stornierung erteilen' }),
+    )
+    expect(body).not.toContainElement(
+      screen.getByRole('button', { name: 'Abbrechen' }),
+    )
+  })
+})

--- a/frontend/src/service/components/table/HistorieStornierungDrawer.tsx
+++ b/frontend/src/service/components/table/HistorieStornierungDrawer.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Drawer,
+  DrawerBody,
   DrawerClose,
   DrawerContent,
   DrawerDescription,
@@ -85,16 +86,16 @@ export function HistorieStornierungDrawer({
         if (!isOpen) onClose()
       }}
     >
-      <DrawerContent>
-        <div className="mx-auto w-full max-w-sm">
-          <DrawerHeader>
-            <DrawerTitle>
-              Stornierung aus Vorgang {vorgangId.slice(0, 8)}
-            </DrawerTitle>
-            <DrawerDescription>
-              Positionen aus diesem Vorgang zum Stornieren auswählen.
-            </DrawerDescription>
-          </DrawerHeader>
+      <DrawerContent pending={loading}>
+        <DrawerHeader className="mx-auto w-full max-w-sm">
+          <DrawerTitle>
+            Stornierung aus Vorgang {vorgangId.slice(0, 8)}
+          </DrawerTitle>
+          <DrawerDescription>
+            Positionen aus diesem Vorgang zum Stornieren auswählen.
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerBody className="mx-auto w-full max-w-sm">
           <PositionAuswahlListe
             positionen={toAuswahlPositionen(positionen)}
             mengen={mengen}
@@ -120,23 +121,23 @@ export function HistorieStornierungDrawer({
               }}
             />
           </div>
-          <DrawerFooter>
-            <Button
-              variant="destructive"
-              disabled={loading || noPositionenSelected || kommentarInvalid}
-              onClick={() => {
-                void onSubmit()
-              }}
-            >
-              {loading ? <Spinner /> : null} Stornierung erteilen
+        </DrawerBody>
+        <DrawerFooter className="mx-auto w-full max-w-sm">
+          <Button
+            variant="destructive"
+            disabled={loading || noPositionenSelected || kommentarInvalid}
+            onClick={() => {
+              void onSubmit()
+            }}
+          >
+            {loading ? <Spinner /> : null} Stornierung erteilen
+          </Button>
+          <DrawerClose asChild>
+            <Button variant="outline" disabled={loading}>
+              Abbrechen
             </Button>
-            <DrawerClose asChild>
-              <Button variant="outline" disabled={loading}>
-                Abbrechen
-              </Button>
-            </DrawerClose>
-          </DrawerFooter>
-        </div>
+          </DrawerClose>
+        </DrawerFooter>
       </DrawerContent>
     </Drawer>
   )

--- a/frontend/src/service/components/table/HistorieUmbuchungDrawer.test.tsx
+++ b/frontend/src/service/components/table/HistorieUmbuchungDrawer.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Position } from '../../table/Bestellung'
+import type { Tisch } from '../../table/Tisch'
+import { HistorieUmbuchungDrawer } from './HistorieUmbuchungDrawer'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../../table/hooks', () => ({
+  useAktiveTische: () => ({
+    tische: [
+      { id: 1, name: 'Stammtisch', saldoCents: 0 },
+      { id: 2, name: 'Nebentisch', saldoCents: 0 },
+    ],
+    isPending: false,
+  }),
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+const tisch: Tisch = { id: 1, name: 'Stammtisch', saldoCents: 0 }
+
+const position: Position = {
+  positionId: '00000000-0000-0000-0000-000000000001',
+  varianteId: 1,
+  produktName: 'Bratwurst',
+  varianteName: 'Normal',
+  kategorie: 'essen',
+  steuersatz: 'regel',
+  einzelpreisCents: 350,
+  menge: 2,
+  bestellerUserId: 1,
+  bestellerName: 'Tester',
+}
+
+describe('HistorieUmbuchungDrawer', () => {
+  it('rendert Positionsliste und Ziel-Tisch-Auswahl im DrawerBody, Buttons im Footer außerhalb', () => {
+    render(
+      <HistorieUmbuchungDrawer
+        backend={{ bestellungUmbuchen: vi.fn().mockResolvedValue(undefined) }}
+        tisch={tisch}
+        vorgangId="00000000-0000-0000-0000-000000000042"
+        positionen={[position]}
+        onClose={vi.fn()}
+        onBestellungUmgebucht={vi.fn()}
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    const body = dialog.querySelector('[data-slot="drawer-body"]')
+    expect(body).not.toBeNull()
+    expect(body).toContainElement(screen.getByText(/Bratwurst/))
+    expect(body).toContainElement(screen.getByRole('combobox'))
+    expect(body).not.toContainElement(
+      screen.getByRole('button', { name: 'Umbuchung ausführen' }),
+    )
+    expect(body).not.toContainElement(
+      screen.getByRole('button', { name: 'Abbrechen' }),
+    )
+  })
+})

--- a/frontend/src/service/components/table/HistorieUmbuchungDrawer.tsx
+++ b/frontend/src/service/components/table/HistorieUmbuchungDrawer.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
   Drawer,
+  DrawerBody,
   DrawerClose,
   DrawerContent,
   DrawerDescription,
@@ -132,16 +133,16 @@ export function HistorieUmbuchungDrawer({
         if (!isOpen) onClose()
       }}
     >
-      <DrawerContent>
-        <div className="mx-auto w-full max-w-sm">
-          <DrawerHeader>
-            <DrawerTitle>
-              Umbuchung aus Vorgang {vorgangId.slice(0, 8)}
-            </DrawerTitle>
-            <DrawerDescription>
-              Positionen auswählen und auf einen Ziel-Tisch umbuchen.
-            </DrawerDescription>
-          </DrawerHeader>
+      <DrawerContent pending={loading}>
+        <DrawerHeader className="mx-auto w-full max-w-sm">
+          <DrawerTitle>
+            Umbuchung aus Vorgang {vorgangId.slice(0, 8)}
+          </DrawerTitle>
+          <DrawerDescription>
+            Positionen auswählen und auf einen Ziel-Tisch umbuchen.
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerBody className="mx-auto w-full max-w-sm">
           <PositionAuswahlListe
             positionen={toAuswahlPositionen(positionen)}
             mengen={mengen}
@@ -180,28 +181,28 @@ export function HistorieUmbuchungDrawer({
               )}
             </NativeSelect>
           </div>
-          <DrawerFooter>
-            <Button
-              variant="secondary"
-              disabled={
-                loading ||
-                noPositionenSelected ||
-                zielTischId === null ||
-                zielTische.length === 0
-              }
-              onClick={() => {
-                void onSubmit()
-              }}
-            >
-              {loading ? <Spinner /> : null} Umbuchung ausführen
+        </DrawerBody>
+        <DrawerFooter className="mx-auto w-full max-w-sm">
+          <Button
+            variant="secondary"
+            disabled={
+              loading ||
+              noPositionenSelected ||
+              zielTischId === null ||
+              zielTische.length === 0
+            }
+            onClick={() => {
+              void onSubmit()
+            }}
+          >
+            {loading ? <Spinner /> : null} Umbuchung ausführen
+          </Button>
+          <DrawerClose asChild>
+            <Button variant="outline" disabled={loading}>
+              Abbrechen
             </Button>
-            <DrawerClose asChild>
-              <Button variant="outline" disabled={loading}>
-                Abbrechen
-              </Button>
-            </DrawerClose>
-          </DrawerFooter>
-        </div>
+          </DrawerClose>
+        </DrawerFooter>
       </DrawerContent>
     </Drawer>
   )

--- a/frontend/src/service/components/table/Receipt.tsx
+++ b/frontend/src/service/components/table/Receipt.tsx
@@ -15,7 +15,7 @@ export function Receipt({
 }) {
   return (
     <>
-      <div className="inset-shadow-sm overflow-y-auto max-h-[40dvh] px-4 pt-2 pb-0 space-y-2">
+      <div className="px-4 pt-2 pb-0 space-y-2">
         {positionen.map((position) => {
           return (
             <div

--- a/frontend/src/service/components/table/TischHistorie.test.tsx
+++ b/frontend/src/service/components/table/TischHistorie.test.tsx
@@ -5,7 +5,6 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
-import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Bestellung } from '../../table/Bestellung'
@@ -23,23 +22,6 @@ vi.mock('sonner', () => ({
 vi.mock('@/lib/Auth', () => ({
   AuthSingleton: { canCancel: true },
 }))
-
-// vaul's Drawer braucht Browser-APIs, die jsdom nicht bereitstellt.
-// DrawerContent wird als Passthrough gemockt, damit Drawer-Inhalte
-// (inkl. Beleg-Buttons) im Test sichtbar sind.
-vi.mock('@/components/ui/drawer', () => {
-  const Passthrough = ({ children }: { children?: ReactNode }) => children
-  return {
-    Drawer: Passthrough,
-    DrawerTrigger: Passthrough,
-    DrawerContent: Passthrough,
-    DrawerHeader: Passthrough,
-    DrawerTitle: Passthrough,
-    DrawerDescription: Passthrough,
-    DrawerFooter: Passthrough,
-    DrawerClose: Passthrough,
-  }
-})
 
 afterEach(() => {
   cleanup()

--- a/frontend/src/service/components/table/TischHistorie.tsx
+++ b/frontend/src/service/components/table/TischHistorie.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Drawer,
+  DrawerBody,
   DrawerClose,
   DrawerContent,
   DrawerDescription,
@@ -424,16 +425,16 @@ function Details({
       }}
     >
       <DrawerContent>
-        <div className="mx-auto w-full max-w-sm">
-          <DrawerHeader>
-            <DrawerTitle>
-              {title} {id.slice(0, 8)}
-            </DrawerTitle>
-            <DrawerDescription>
-              von {userName} am {new Date(date).toLocaleDateString('de-DE')} um{' '}
-              {new Date(date).toLocaleTimeString('de-DE')} Uhr
-            </DrawerDescription>
-          </DrawerHeader>
+        <DrawerHeader className="mx-auto w-full max-w-sm">
+          <DrawerTitle>
+            {title} {id.slice(0, 8)}
+          </DrawerTitle>
+          <DrawerDescription>
+            von {userName} am {new Date(date).toLocaleDateString('de-DE')} um{' '}
+            {new Date(date).toLocaleTimeString('de-DE')} Uhr
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerBody className="mx-auto w-full max-w-sm">
           {positionen ? (
             <Receipt positionen={positionen} totalPrice={totalPrice} />
           ) : (
@@ -448,22 +449,22 @@ function Details({
               <Kommentar value={kommentar} />
             </div>
           )}
-          <DrawerFooter>
-            {primaryAction && (
-              <Button
-                onClick={primaryAction.onAction}
-                disabled={primaryAction.loading}
-              >
-                {primaryAction.loading ? 'Drucke…' : primaryAction.label}
-              </Button>
-            )}
-            <DrawerClose asChild>
-              <Button variant="outline" disabled={primaryAction?.loading}>
-                Schließen
-              </Button>
-            </DrawerClose>
-          </DrawerFooter>
-        </div>
+        </DrawerBody>
+        <DrawerFooter className="mx-auto w-full max-w-sm">
+          {primaryAction && (
+            <Button
+              onClick={primaryAction.onAction}
+              disabled={primaryAction.loading}
+            >
+              {primaryAction.loading ? 'Drucke…' : primaryAction.label}
+            </Button>
+          )}
+          <DrawerClose asChild>
+            <Button variant="outline" disabled={primaryAction?.loading}>
+              Schließen
+            </Button>
+          </DrawerClose>
+        </DrawerFooter>
       </DrawerContent>
     </Drawer>
   )

--- a/frontend/src/service/components/table/Zahlung.test.tsx
+++ b/frontend/src/service/components/table/Zahlung.test.tsx
@@ -1,6 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Position } from '../../table/Bestellung'
@@ -14,23 +13,6 @@ vi.mock('sonner', () => ({
 vi.mock('@/lib/Auth', () => ({
   AuthSingleton: { userId: 1 },
 }))
-
-// vaul's Drawer braucht Browser-APIs, die jsdom nicht bereitstellt. Trigger
-// inline rendern, Drawer-Inhalt ausblenden — so bleibt nur die Aktionsleiste
-// (der Kassieren-Trigger) übrig.
-vi.mock('@/components/ui/drawer', () => {
-  const Passthrough = ({ children }: { children?: ReactNode }) => children
-  return {
-    Drawer: Passthrough,
-    DrawerTrigger: Passthrough,
-    DrawerContent: () => null,
-    DrawerHeader: Passthrough,
-    DrawerTitle: Passthrough,
-    DrawerDescription: Passthrough,
-    DrawerFooter: Passthrough,
-    DrawerClose: Passthrough,
-  }
-})
 
 afterEach(() => {
   cleanup()

--- a/frontend/src/service/components/table/ZahlungDrawer.test.tsx
+++ b/frontend/src/service/components/table/ZahlungDrawer.test.tsx
@@ -1,0 +1,157 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Position } from '../../table/Bestellung'
+import type { Tisch } from '../../table/Tisch'
+import { ZahlungDrawer } from './ZahlungDrawer'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+const tisch: Tisch = { id: 1, name: 'Stammtisch', saldoCents: 0 }
+
+const position: Position = {
+  positionId: '00000000-0000-0000-0000-000000000001',
+  varianteId: 1,
+  produktName: 'Bratwurst',
+  varianteName: 'Normal',
+  kategorie: 'essen',
+  steuersatz: 'regel',
+  einzelpreisCents: 350,
+  menge: 2,
+  bestellerUserId: 1,
+  bestellerName: 'Tester',
+}
+
+function renderDrawer(
+  zahlungKassieren: () => Promise<void> = vi.fn().mockResolvedValue(undefined),
+) {
+  const zahlungKassiert = vi.fn()
+  render(
+    <ZahlungDrawer
+      backend={{ zahlungKassieren }}
+      tisch={tisch}
+      unbezahltePositionen={[position]}
+      mengen={{ [position.positionId]: 1 }}
+      zahlungKassiert={zahlungKassiert}
+    />,
+  )
+  return { zahlungKassiert }
+}
+
+async function openDrawer(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /Kassieren/ }))
+  return await screen.findByRole('dialog')
+}
+
+describe('ZahlungDrawer', () => {
+  it('öffnet über den Trigger und schließt über Abbrechen', async () => {
+    const user = userEvent.setup()
+    renderDrawer()
+
+    const dialog = await openDrawer(user)
+    expect(dialog).toBeVisible()
+    expect(
+      document.querySelector('[data-slot="drawer-overlay"]'),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Abbrechen' }))
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  it('schließt ohne laufenden Submit über Escape', async () => {
+    const user = userEvent.setup()
+    renderDrawer()
+
+    await openDrawer(user)
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  it('scrollt nur im DrawerBody; der Kassieren-Button liegt im Footer außerhalb', async () => {
+    const user = userEvent.setup()
+    renderDrawer()
+
+    const dialog = await openDrawer(user)
+    const body = dialog.querySelector('[data-slot="drawer-body"]')
+    expect(body).not.toBeNull()
+
+    // Einziger Scrollbereich: kein weiteres overflow-y-auto im Drawer.
+    const scrollContainers = dialog.querySelectorAll(
+      '[class*="overflow-y-auto"]',
+    )
+    expect(scrollContainers).toHaveLength(1)
+    expect(scrollContainers[0]).toBe(body)
+
+    // Beleg scrollt im Body, Submit und Abbrechen bleiben außerhalb sichtbar.
+    expect(body).toContainElement(screen.getByText(/Bratwurst/))
+    const submit = screen.getByRole('button', { name: 'Kassieren' })
+    const abbrechen = screen.getByRole('button', { name: 'Abbrechen' })
+    expect(body).not.toContainElement(submit)
+    expect(body).not.toContainElement(abbrechen)
+  })
+
+  it('ignoriert Escape und Backdrop-Tap während des Submits und schließt nach Erfolg', async () => {
+    const user = userEvent.setup()
+    let resolveSubmit: () => void = () => undefined
+    const { zahlungKassiert } = renderDrawer(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve
+        }),
+    )
+
+    const dialog = await openDrawer(user)
+    await user.click(screen.getByRole('button', { name: 'Kassieren' }))
+
+    // Pending-Zustand: Drawer markiert, Spinner sichtbar, Buttons deaktiviert.
+    expect(dialog).toHaveAttribute('data-pending')
+    expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Abbrechen' })).toBeDisabled()
+
+    await user.keyboard('{Escape}')
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    const overlay = document.querySelector('[data-slot="drawer-overlay"]')
+    if (overlay === null) throw new Error('Overlay nicht gefunden')
+    await user.pointer({
+      keys: '[MouseLeft]',
+      target: overlay,
+    })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    resolveSubmit()
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+    expect(zahlungKassiert).toHaveBeenCalled()
+  })
+
+  it('bleibt im Fehlerfall offen und wieder bedienbar', async () => {
+    const { toast } = await import('sonner')
+    const user = userEvent.setup()
+    renderDrawer(vi.fn().mockRejectedValue(new Error('kaputt')))
+
+    const dialog = await openDrawer(user)
+    await user.click(screen.getByRole('button', { name: 'Kassieren' }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled()
+    })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(dialog).not.toHaveAttribute('data-pending')
+    expect(screen.getByRole('button', { name: 'Kassieren' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Abbrechen' })).toBeEnabled()
+  })
+})

--- a/frontend/src/service/components/table/ZahlungDrawer.tsx
+++ b/frontend/src/service/components/table/ZahlungDrawer.tsx
@@ -4,6 +4,7 @@ import { EuroInput } from '@/components/common/EuroInput'
 import { Button } from '@/components/ui/button'
 import {
   Drawer,
+  DrawerBody,
   DrawerClose,
   DrawerContent,
   DrawerDescription,
@@ -100,14 +101,14 @@ export function ZahlungDrawer(props: ZahlungDrawerProps) {
           disabled={noPositionenSelected}
         />
       </DrawerTrigger>
-      <DrawerContent>
-        <div className="mx-auto w-full max-w-sm">
-          <DrawerHeader>
-            <DrawerTitle>Zahlung für {props.tisch.name}</DrawerTitle>
-            <DrawerDescription>
-              Überprüfe deine Zahlung vor dem Absenden.
-            </DrawerDescription>
-          </DrawerHeader>
+      <DrawerContent pending={loading}>
+        <DrawerHeader className="mx-auto w-full max-w-sm">
+          <DrawerTitle>Zahlung für {props.tisch.name}</DrawerTitle>
+          <DrawerDescription>
+            Überprüfe deine Zahlung vor dem Absenden.
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerBody className="mx-auto w-full max-w-sm">
           <Receipt
             positionen={toReceiptItems(positionenToPay)}
             totalPrice={totalPrice}
@@ -157,22 +158,22 @@ export function ZahlungDrawer(props: ZahlungDrawerProps) {
               }}
             />
           </div>
-          <DrawerFooter>
-            <Button
-              disabled={loading}
-              onClick={() => {
-                void onSubmit()
-              }}
-            >
-              {loading ? <Spinner /> : null} Kassieren
+        </DrawerBody>
+        <DrawerFooter className="mx-auto w-full max-w-sm">
+          <Button
+            disabled={loading}
+            onClick={() => {
+              void onSubmit()
+            }}
+          >
+            {loading ? <Spinner /> : null} Kassieren
+          </Button>
+          <DrawerClose asChild>
+            <Button variant="outline" disabled={loading}>
+              Abbrechen
             </Button>
-            <DrawerClose asChild>
-              <Button variant="outline" disabled={loading}>
-                Abbrechen
-              </Button>
-            </DrawerClose>
-          </DrawerFooter>
-        </div>
+          </DrawerClose>
+        </DrawerFooter>
       </DrawerContent>
     </Drawer>
   )


### PR DESCRIPTION
Implements `docs/plans/plan-pwa-ios-drawer-fixes.md` — fixes the three drawer bugs from the 2026-07-09 field test (`praxistest-2026-07-09-bugreport.md`).

## Bug 1 — vaul breaks in the iOS standalone PWA
`frontend/src/components/ui/drawer.tsx` is rewritten in place on the Radix `Dialog` primitives (same pattern as `sheet.tsx`), styled as a bottom sheet. The exported `Drawer*` API is unchanged, so all consumers keep their imports. vaul (and its `scrollTo(0,0)` scroll lock, the drag handle, and the `data-vaul-no-drag` workaround) is removed entirely; background scroll locking is now Radix's `react-remove-scroll`. Dismissal is via Abbrechen button, backdrop tap, and Escape — no swipe-to-dismiss (Radix Dialog cannot drag; a functionless handle would mislead).

## Bug 2 — drawer content not scrollable, primary buttons pushed off-screen
New layout contract: `DrawerContent` is `fixed inset-x-0 bottom-0 flex flex-col max-h-[85dvh]` with safe-area padding; a new **`DrawerBody`** (`min-h-0 overflow-y-auto`) is the drawer's *single* scroll area. All seven drawer usages are restructured to `DrawerHeader → DrawerBody → DrawerFooter` — the six from the plan plus the `Details` drawer inside `TischHistorie.tsx`, which renders a `Receipt` and needed the same treatment once Receipt lost its cap. All nested scroll caps are gone (`Receipt` `max-h-[40dvh]`, `PositionAuswahlListe` `max-h-[45dvh]`, TischAuswahl list `max-h-[60vh]`); the search field in `TischAuswahlDrawer` stays above the scroll area.

## Bug 3 — no pending feedback, drawer closable during submit
`DrawerContent` gains a `pending` prop (wired to `loading` in all five submit drawers): while pending, Escape and backdrop tap are ignored and `DrawerBody` is dimmed and inert (`data-pending` + group variant); the button spinner stays the primary indicator. Note: the dismiss handlers must read `pending` through a ref — Radix observably calls them with the closure captured at registration (verified empirically against radix-ui 1.6.1; a mutation test confirms the unit test catches a regression here).

## Tests
- Unit tests now render the real drawer (the jsdom mocks existed only for vaul); queries adapted to Radix semantics (`role="dialog"`, portal). 240/240 pass.
- New tests: drawer opens via trigger / empty-selection guard (`BestellungDrawer.test.tsx`), Escape/backdrop close when idle + blocked while pending + auto-close on success + error keeps drawer usable (`ZahlungDrawer.test.tsx`), structure-level Header→Body→Footer assertions for the Storno/Umbuchung/TischAuswahl drawers.
- New E2E viewport regression (`tischservice-lange-bestellung.mobile.spec.ts`, mobile-service project): order with 9 positions, fill Trinkgeld + Erhalten, assert `toBeInViewport()` for the primary buttons, complete the payment. Full suite green: 24/24 (desktop-admin + mobile-service), `make check` green.

## Remaining risk (documented in the plan)
`display-mode: standalone` + WebKit cannot be reproduced in Playwright. The automation proves functional equivalence; that the flicker is actually gone in the installed PWA needs the next field test on a real iPhone (shadcn-ui#8507 reports the Radix path as working).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoKPpEtZ4AmQWWyE11zthm)_