### PR TITLE
refactor(admin): apply cleanup review to the admin redesign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.6.0
           run_install: false
 
       - uses: actions/setup-node@v6
@@ -316,7 +316,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.6.0
           run_install: false
 
       - uses: actions/setup-node@v6
@@ -538,7 +538,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.6.0
           run_install: false
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -100,7 +100,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: 11.6.0
           run_install: false
 
       - uses: actions/setup-node@v6

--- a/e2e/tests/admin-benutzer-verwalten.spec.ts
+++ b/e2e/tests/admin-benutzer-verwalten.spec.ts
@@ -4,7 +4,8 @@ import { anmelden } from '../support/anmelden'
 import { resetAndSeed } from '../support/seed'
 
 // Deckt den Verwaltungspfad für Benutzer ab: Anlegen (inkl. Anzeige des
-// Einmalpasswort-Codes) und Deaktivieren.
+// Einmalpasswort-Codes) und Deaktivieren. Die Seite „Helfer & Zugänge" zeigt
+// die Benutzer als Tabelle mit Status-Switch je Zeile.
 
 test.describe('Admin verwaltet Benutzer', () => {
   test('Benutzer anlegen zeigt das Einmalpasswort und der Benutzer lässt sich deaktivieren', async ({
@@ -15,10 +16,12 @@ test.describe('Admin verwaltet Benutzer', () => {
     await anmelden(page, zugangsdaten.admin)
 
     await page.goto('/admin/benutzer')
-    await expect(page.getByRole('heading', { name: 'Benutzer verwalten' })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'Helfer & Zugänge' }),
+    ).toBeVisible()
 
     // Neuen Benutzer anlegen.
-    await page.getByRole('button', { name: 'Neuer Benutzer' }).click()
+    await page.getByRole('button', { name: 'Neuer Helfer' }).click()
     const newDialog = page.getByRole('dialog')
     await newDialog.getByLabel('Name', { exact: true }).fill('Petra Neumann')
     await newDialog.getByLabel('Benutzername').fill('petra')
@@ -44,12 +47,15 @@ test.describe('Admin verwaltet Benutzer', () => {
     await createdDialog.getByRole('button', { name: 'Okay' }).click()
 
     // Neue Benutzer starten inaktiv (Passwort noch nicht gesetzt): erst
-    // aktivieren, dann den Deaktivieren-Pfad prüfen.
-    const userItem = page
-      .locator('[data-slot="item"]')
+    // aktivieren, dann den Deaktivieren-Pfad prüfen. Die Tabellenzeile wird
+    // über den Namen und ihren Status-Switch aufgelöst.
+    const userRow = page
+      .locator('div')
+      .filter({ has: page.getByRole('switch') })
       .filter({ hasText: 'Petra Neumann' })
-    await expect(userItem).toBeVisible()
-    const userSwitch = userItem.getByRole('switch')
+      .last()
+    await expect(userRow).toBeVisible()
+    const userSwitch = userRow.getByRole('switch')
     await expect(userSwitch).not.toBeChecked()
 
     await userSwitch.click()

--- a/e2e/tests/admin-druckstationen-verwalten.spec.ts
+++ b/e2e/tests/admin-druckstationen-verwalten.spec.ts
@@ -3,8 +3,8 @@ import { expect, test } from '@playwright/test'
 import { anmelden } from '../support/anmelden'
 import { resetAndSeed } from '../support/seed'
 
-// Deckt den Verwaltungspfad für Druckstationen ab: die Drucker-IP einer
-// Station ändern und speichern.
+// Deckt den Verwaltungspfad für die Bondrucker-Stationen ab: die Drucker-IP
+// einer Station ändern. Die IP wird on-blur gespeichert (kein Speichern-Button).
 
 test.describe('Admin verwaltet Druckstationen', () => {
   test('Drucker-IP einer Station ändern', async ({ page, request }) => {
@@ -12,23 +12,24 @@ test.describe('Admin verwaltet Druckstationen', () => {
     await anmelden(page, zugangsdaten.admin)
 
     await page.goto('/admin/druckstationen')
-    await expect(
-      page.getByRole('heading', { name: 'Druckstationen' }),
-    ).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Bondrucker' })).toBeVisible()
 
     // Die Essen-Station ist per Seed-Drehbuch mit 192.168.8.51 konfiguriert.
-    const essenRow = page
+    const essenCard = page
       .locator('div')
-      .filter({ hasText: 'Arbeitsbons für bestellte Essens-Positionen.' })
+      .filter({ hasText: 'Bons für die Essensausgabe' })
       .filter({ has: page.getByLabel('Drucker-IP') })
       .last()
-    const ipInput = essenRow.getByLabel('Drucker-IP')
+    const ipInput = essenCard.getByLabel('Drucker-IP')
     await expect(ipInput).toHaveValue('192.168.8.51')
 
+    // Neue IP eintragen und das Feld verlassen — das speichert on-blur.
     await ipInput.fill('192.168.8.99')
-    await essenRow.getByRole('button', { name: 'Speichern' }).click()
+    await ipInput.blur()
 
-    await expect(page.getByText('Druckstation „Essen“ gespeichert.')).toBeVisible()
+    await expect(
+      page.getByText(/Drucker-IP für .Essen. gespeichert\./),
+    ).toBeVisible()
     await expect(ipInput).toHaveValue('192.168.8.99')
   })
 })

--- a/e2e/tests/admin-dsfinvk-export.spec.ts
+++ b/e2e/tests/admin-dsfinvk-export.spec.ts
@@ -18,17 +18,21 @@ test.describe('Admin lädt den DSFinV-K-Export herunter', () => {
     await anmelden(page, zugangsdaten.admin)
 
     await page.goto('/admin/kassenberichte')
-    await expect(page.getByRole('heading', { name: 'Kassenberichte' })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'Berichte & Export' }),
+    ).toBeVisible()
 
     // Eine abgeschlossene Kassensitzung wählen (Seed: Freitag/Samstag sind
-    // abgeschlossen, Sonntag ist die laufende Sitzung).
-    const kassensitzungFilter = page.getByRole('combobox').first()
-    await kassensitzungFilter.click()
-    await page.getByRole('option', { name: /Sommerfest 26 Samstag/ }).click()
-    await expect(kassensitzungFilter).toContainText('Sommerfest 26 Samstag')
+    // abgeschlossen, Sonntag ist die laufende Sitzung). Die Sitzungsliste ist
+    // eine Spalte wählbarer Karten.
+    await page
+      .getByRole('button', { name: /Sommerfest 26 Samstag/ })
+      .click()
 
     const downloadPromise = page.waitForEvent('download')
-    await page.getByRole('button', { name: 'DSFinV-K-Export' }).click()
+    await page
+      .getByRole('button', { name: 'Archiv herunterladen (ZIP)' })
+      .click()
     const download = await downloadPromise
 
     await expect(page.getByText('DSFinV-K-Archiv heruntergeladen.')).toBeVisible()

--- a/e2e/tests/admin-kassenfuehrung.spec.ts
+++ b/e2e/tests/admin-kassenfuehrung.spec.ts
@@ -17,22 +17,27 @@ test.describe('Admin führt die Kasse', () => {
     await anmelden(page, zugangsdaten.admin)
 
     await page.goto('/admin/kasse')
-    await expect(page.getByRole('heading', { name: 'Kassensitzung' })).toBeVisible()
+    // Die offene Sonntags-Sitzung (ZNr 3) ist als Kassentag-Stepper sichtbar.
+    await expect(
+      page.getByRole('heading', { name: /Kassentag Nr\. 3/ }),
+    ).toBeVisible()
+    await expect(page.getByText('Laufender Betrieb')).toBeVisible()
 
-    // Die offene Sonntags-Sitzung (ZNr 3) ist sichtbar.
-    await expect(page.getByText(/Kassensitzung #3/)).toBeVisible()
-    await expect(page.getByText(/offen/)).toBeVisible()
-
-    // Geldtransit-Einlage buchen.
-    await page.getByRole('radio', { name: /Einlage/ }).check()
-    await page.getByLabel('Betrag').fill('25,00')
-    await page.getByLabel('Kommentar').fill('Zusätzliches Wechselgeld')
-    await page.getByRole('button', { name: 'Geldtransit buchen' }).click()
+    // Geldtransit-Einlage buchen: „Geld einlegen" öffnet den Buchungsdialog.
+    await page.getByRole('button', { name: 'Geld einlegen' }).click()
+    const geldtransitDialog = page.getByRole('dialog')
+    await geldtransitDialog.getByLabel('Betrag').fill('25,00')
+    await geldtransitDialog.getByLabel('Kommentar').fill('Zusätzliches Wechselgeld')
+    await geldtransitDialog
+      .getByRole('button', { name: 'Geld einlegen' })
+      .click()
     await expect(page.getByText('Kassenbewegung gebucht.')).toBeVisible()
 
     // Kasse abschließen anstoßen: Soll-Bestand zählen und Dialog öffnen.
     await page.getByLabel('Gezählter Ist-Bestand').fill('500,00')
-    await page.getByRole('button', { name: 'Kasse abschließen' }).first().click()
+    await page
+      .getByRole('button', { name: /Kasse endgültig abschließen/ })
+      .click()
 
     const confirmDialog = page.getByRole('alertdialog')
     await expect(confirmDialog.getByText('Soll-Bestand')).toBeVisible()

--- a/e2e/tests/admin-live-reporting.spec.ts
+++ b/e2e/tests/admin-live-reporting.spec.ts
@@ -3,9 +3,9 @@ import { expect, test } from '@playwright/test'
 import { anmelden } from '../support/anmelden'
 import { resetAndSeed } from '../support/seed'
 
-// Deckt das Live-Dashboard ab: die Umsätze der laufenden (Sonntags-)Sitzung
-// aus den Seed-Daten sind sichtbar. Das Dashboard ist eine einzelne scrollbare
-// Seite ohne Tabs — alle Blöcke sind direkt erreichbar.
+// Deckt die Übersicht (Live-Dashboard) ab: die Umsätze der laufenden
+// (Sonntags-)Sitzung aus den Seed-Daten sind sichtbar. Die Übersicht ist eine
+// einzelne scrollbare Seite ohne Tabs — alle Blöcke sind direkt erreichbar.
 
 test.describe('Admin sieht das Live-Dashboard', () => {
   test('Live-Dashboard zeigt Umsätze der Seed-Daten', async ({
@@ -18,22 +18,22 @@ test.describe('Admin sieht das Live-Dashboard', () => {
     await page.goto('/admin/auswertung')
     const liveSection = page.getByTestId('live-reporting-section')
     await expect(
-      liveSection.getByRole('heading', { name: 'Live-Dashboard' }),
+      liveSection.getByRole('heading', { name: 'Übersicht' }),
     ).toBeVisible()
 
     // Single-Scroll: keine Tabs mehr.
     await expect(liveSection.getByRole('tab')).toHaveCount(0)
 
     // Kennzahlen der laufenden Sitzung sind sichtbar (Seed hat Bestellungen,
-    // Direktverkäufe und Stornierungen am Sonntag).
-    await expect(liveSection.getByText('Gesamtumsatz')).toBeVisible()
-    await expect(liveSection.getByText('Offene Saldi')).toBeVisible()
-    await expect(liveSection.getByText('Bestellungen')).toBeVisible()
+    // Direktverkäufe und Stornierungen am Sonntag): Hero-Kennzahl plus Nebenkarten.
+    await expect(liveSection.getByText('Kassierter Umsatz')).toBeVisible()
+    await expect(liveSection.getByText('Noch offen')).toBeVisible()
+    await expect(liveSection.getByText('Bestellt gesamt')).toBeVisible()
 
     // Aktualitäts-Anzeige und manueller Refresh sind vorhanden.
-    await expect(liveSection.getByText(/^Stand \d{2}:\d{2}$/)).toBeVisible()
+    await expect(liveSection.getByText(/aktualisiert \d{2}:\d{2}/)).toBeVisible()
     await expect(
-      liveSection.getByRole('button', { name: 'Aktualisieren' }),
+      liveSection.getByRole('button', { name: 'Jetzt' }),
     ).toBeVisible()
 
     // Offene Tische aus dem Seed-Drehbuch sind gelistet.
@@ -41,22 +41,21 @@ test.describe('Admin sieht das Live-Dashboard', () => {
       liveSection.getByRole('heading', { name: 'Offene Tische' }),
     ).toBeVisible()
 
-    // Servicekräfte-Block zeigt die aktiven Bediener des Sonntags.
+    // Team-Block zeigt die aktiven Bediener des Sonntags.
     await expect(
-      liveSection.getByRole('heading', { name: 'Servicekräfte' }),
+      liveSection.getByRole('heading', { name: 'Team' }),
     ).toBeVisible()
     await expect(liveSection.getByText('maria (Maria Schmidt)')).toBeVisible()
 
-    // Stornierungen-Block zeigt die dokumentierten Stornos des Sonntags.
-    await expect(
-      liveSection.getByRole('heading', { name: 'Stornierungen' }),
-    ).toBeVisible()
+    // Stornierungen pro Servicekraft: felix hat kassiert und storniert, seine
+    // Team-Zeile trägt den roten Storno-Marker.
+    await expect(liveSection.getByText('1 Storno')).toBeVisible()
+
+    // Der Stornierungen-Block ist eingeklappt; „Details" zeigt die
+    // dokumentierten Stornos des Sonntags.
+    await liveSection.getByRole('button', { name: 'Details' }).click()
     await expect(
       liveSection.getByText('Reklamation Tagesgericht, Kulanz'),
     ).toBeVisible()
-
-    // Stornierungen pro Servicekraft: felix hat kassiert und storniert, seine
-    // Servicekraft-Zeile trägt den roten Storno-Marker.
-    await expect(liveSection.getByText('1 Storno')).toBeVisible()
   })
 })

--- a/e2e/tests/admin-live-reporting.spec.ts
+++ b/e2e/tests/admin-live-reporting.spec.ts
@@ -47,12 +47,12 @@ test.describe('Admin sieht das Live-Dashboard', () => {
     ).toBeVisible()
     await expect(liveSection.getByText('maria (Maria Schmidt)')).toBeVisible()
 
-    // Stornierungen pro Servicekraft: felix hat kassiert und storniert, seine
-    // Team-Zeile trägt den roten Storno-Marker.
-    await expect(liveSection.getByText('1 Storno')).toBeVisible()
-
-    // Der Stornierungen-Block ist eingeklappt; „Details" zeigt die
-    // dokumentierten Stornos des Sonntags.
+    // Der Stornierungen-Block ist eingeklappt: die Zusammenfassung schlüsselt die
+    // Stornos pro Servicekraft auf (felix hat kassiert und storniert), „Details"
+    // zeigt die dokumentierten Stornos des Sonntags.
+    await expect(
+      liveSection.getByText(/felix \(Felix Weber\) 1/),
+    ).toBeVisible()
     await liveSection.getByRole('button', { name: 'Details' }).click()
     await expect(
       liveSection.getByText('Reklamation Tagesgericht, Kulanz'),

--- a/e2e/tests/admin-produkte-verwalten.spec.ts
+++ b/e2e/tests/admin-produkte-verwalten.spec.ts
@@ -4,7 +4,9 @@ import { anmelden } from '../support/anmelden'
 import { resetAndSeed } from '../support/seed'
 
 // Deckt den Verwaltungspfad für Produkte samt Varianten ab: Anlegen,
-// Bearbeiten, eine Variante aktivieren und wieder deaktivieren.
+// Bearbeiten, eine Variante aktivieren und wieder deaktivieren. Die Seite
+// „Produkte & Preise" listet Produkte je Kategorie mit Varianten als Chips
+// (Name, Preis, Mini-Switch); eine inaktive Variante trägt die „aus"-Markierung.
 
 test.describe('Admin verwaltet Produkte und Varianten', () => {
   test('Produkt samt Variante anlegen, ändern und Variante deaktivieren', async ({
@@ -15,7 +17,9 @@ test.describe('Admin verwaltet Produkte und Varianten', () => {
     await anmelden(page, zugangsdaten.admin)
 
     await page.goto('/admin/produkte')
-    await expect(page.getByRole('heading', { name: 'Produkte verwalten' })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'Produkte & Preise' }),
+    ).toBeVisible()
 
     // Neues Produkt anlegen.
     await page.getByRole('button', { name: 'Neues Produkt' }).click()
@@ -24,12 +28,14 @@ test.describe('Admin verwaltet Produkte und Varianten', () => {
     await newProductDialog.getByRole('button', { name: 'Produkt anlegen' }).click()
     await expect(page.getByText('Produkt "Eistee" wurde angelegt.')).toBeVisible()
 
-    // Das neue Produkt in der Liste öffnen und eine Variante anlegen.
+    // Die Produktzeile über den Namen und ihren Bearbeiten-Button auflösen und
+    // eine Variante anlegen (der gestrichelte „Variante"-Button je Zeile).
     const produktItem = page
-      .locator('[data-slot="item"]')
+      .locator('div')
+      .filter({ has: page.getByRole('button', { name: 'Produkt bearbeiten' }) })
       .filter({ hasText: 'Eistee' })
-    await produktItem.getByRole('button', { name: 'Varianten' }).click()
-    await produktItem.getByRole('button', { name: 'Variante' }).click()
+      .last()
+    await produktItem.getByRole('button', { name: 'Variante', exact: true }).click()
 
     const newVariantDialog = page.getByRole('dialog')
     await newVariantDialog.getByLabel('Name').fill('0,5l')
@@ -37,20 +43,23 @@ test.describe('Admin verwaltet Produkte und Varianten', () => {
     await newVariantDialog.getByRole('button', { name: 'Variante anlegen' }).click()
     await expect(page.getByText('Variante "0,5l" wurde angelegt.')).toBeVisible()
 
-    // Die neue Variante ist zunächst deaktiviert; die Zeile mit Preis prüfen.
+    // Die neue Variante ist zunächst deaktiviert: Preis-Chip sichtbar, Switch
+    // aus und die „aus"-Markierung gesetzt.
     await expect(produktItem.getByText('2,80')).toBeVisible()
+    const ausMarker = produktItem.getByText('aus', { exact: true })
+    await expect(ausMarker).toBeVisible()
     const variantSwitch = produktItem.getByRole('switch').last()
     await expect(variantSwitch).not.toBeChecked()
 
-    // Variante aktivieren.
+    // Variante aktivieren: Switch an, „aus"-Markierung verschwindet.
     await variantSwitch.click()
     await expect(variantSwitch).toBeChecked()
-    await expect(produktItem.getByText('1 aktiv')).toBeVisible()
+    await expect(ausMarker).toBeHidden()
 
     // Variante wieder deaktivieren.
     await variantSwitch.click()
     await expect(variantSwitch).not.toBeChecked()
-    await expect(produktItem.getByText('0 aktiv')).toBeVisible()
+    await expect(ausMarker).toBeVisible()
 
     // Produkt bearbeiten: Namen ändern.
     await produktItem
@@ -60,8 +69,6 @@ test.describe('Admin verwaltet Produkte und Varianten', () => {
     await editDialog.getByLabel('Name').fill('Eistee Pfirsich')
     await editDialog.getByRole('button', { name: 'Speichern' }).click()
 
-    await expect(
-      page.locator('[data-slot="item"]').filter({ hasText: 'Eistee Pfirsich' }),
-    ).toBeVisible()
+    await expect(page.getByText('Eistee Pfirsich')).toBeVisible()
   })
 })

--- a/e2e/tests/admin-tische-verwalten.spec.ts
+++ b/e2e/tests/admin-tische-verwalten.spec.ts
@@ -3,7 +3,9 @@ import { expect, test } from '@playwright/test'
 import { anmelden } from '../support/anmelden'
 import { resetAndSeed } from '../support/seed'
 
-// Deckt den Verwaltungspfad für Tische ab: Anlegen und den Namen ändern.
+// Deckt den Verwaltungspfad für Tische ab: Anlegen und den Namen ändern. Die
+// Tische erscheinen als präfixgruppierte Kacheln; ein Klick auf die Kachel
+// öffnet den Bearbeiten-Dialog (Umbenennen, Löschen).
 
 test.describe('Admin verwaltet Tische', () => {
   test('Tisch anlegen und Namen ändern', async ({ page, request }) => {
@@ -11,7 +13,7 @@ test.describe('Admin verwaltet Tische', () => {
     await anmelden(page, zugangsdaten.admin)
 
     await page.goto('/admin/tische')
-    await expect(page.getByRole('heading', { name: 'Tische verwalten' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Tische' })).toBeVisible()
 
     // Neuen Tisch anlegen.
     await page.getByRole('button', { name: 'Neuer Tisch' }).click()
@@ -20,19 +22,16 @@ test.describe('Admin verwaltet Tische', () => {
     await newDialog.getByRole('button', { name: 'Tisch anlegen' }).click()
     await expect(page.getByText('Tisch "Tisch 99" wurde angelegt.')).toBeVisible()
 
-    const tischItem = page
-      .locator('[data-slot="item"]')
-      .filter({ hasText: 'Tisch 99' })
-    await expect(tischItem).toBeVisible()
+    // Die Kachel öffnet per Klick den Bearbeiten-Dialog.
+    const tischKachel = page.getByRole('button', { name: /Tisch 99/ })
+    await expect(tischKachel).toBeVisible()
+    await tischKachel.getByText('Tisch 99').click()
 
     // Namen ändern.
-    await tischItem.getByRole('button', { name: 'Tisch bearbeiten' }).click()
     const editDialog = page.getByRole('dialog')
     await editDialog.getByLabel('Name').fill('Zelt B3')
     await editDialog.getByRole('button', { name: 'Speichern' }).click()
 
-    await expect(
-      page.locator('[data-slot="item"]').filter({ hasText: 'Zelt B3' }),
-    ).toBeVisible()
+    await expect(page.getByRole('button', { name: /Zelt B3/ })).toBeVisible()
   })
 })

--- a/e2e/tests/kassenabschluss.mobile.spec.ts
+++ b/e2e/tests/kassenabschluss.mobile.spec.ts
@@ -57,11 +57,15 @@ test.describe('Kassenabschluss beendet die laufende Kassensitzung', () => {
     // Als Admin die Kasse abschließen.
     await anmelden(page, zugangsdaten.admin)
     await page.goto('/admin/kasse')
-    await expect(page.getByRole('heading', { name: 'Kassensitzung' })).toBeVisible()
-    await expect(page.getByText('offen')).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: /Kassentag Nr\. 3/ }),
+    ).toBeVisible()
+    await expect(page.getByText('Laufender Betrieb')).toBeVisible()
 
     await page.getByLabel('Gezählter Ist-Bestand').fill('342,00')
-    await page.getByRole('button', { name: 'Kasse abschließen' }).click()
+    await page
+      .getByRole('button', { name: /Kasse endgültig abschließen/ })
+      .click()
 
     await expect(
       page.getByRole('alertdialog', { name: 'Kasse abschließen?' }),

--- a/frontend/src/admin/AdminSidebar.tsx
+++ b/frontend/src/admin/AdminSidebar.tsx
@@ -15,11 +15,8 @@ import {
 import { NavLink, useLocation, useNavigate } from 'react-router'
 
 import { useFehlgeschlageneDruckauftraege } from '@/admin/settings/hooks'
-import {
-  RUECKSTAND_WARN_SEKUNDEN,
-  useTSESignaturQueue,
-  useTSEStatus,
-} from '@/admin/tse/hooks'
+import { useTSESignaturQueue, useTSEStatus } from '@/admin/tse/hooks'
+import { tseAmpel } from '@/admin/tse/tseAmpel'
 import { useTheme } from '@/components/theme-provider'
 import {
   Sidebar,
@@ -91,17 +88,9 @@ export function AdminSidebar() {
 
   const kasseOffen = kassensitzung !== null
   const bondruckerFehler = druckauftraege.length > 0
-  // Finanzamt & TSE ist kritisch, wenn die TSE nicht konfiguriert ist oder —
-  // bei konfigurierter TSE — der Signatur-Rückstand die Schwelle reißt bzw.
-  // Signaturaufträge endgültig fehlgeschlagen sind. Deckt sich mit der
-  // showTSEBanner-Logik im Dashboard: ein fehlerhafter Status (nicht ladend)
-  // zählt als „nicht konfiguriert".
-  const tseNichtKonfiguriert = !tseLoading && !tseStatus?.istKonfiguriert
-  const signaturRueckstand =
-    !tseNichtKonfiguriert &&
-    ((queue?.rueckstandSekunden ?? 0) >= RUECKSTAND_WARN_SEKUNDEN ||
-      (queue?.fehlgeschlageneAuftraege ?? 0) > 0)
-  const finanzamtFehler = tseNichtKonfiguriert || signaturRueckstand
+  // Finanzamt & TSE ist kritisch nach derselben Regel wie die „Läuft alles?"-
+  // Karte: tseAmpel ist die Single Source of Truth für den TSE-Fehlerzustand.
+  const finanzamtFehler = tseAmpel(tseStatus, tseLoading, queue).fehler
 
   const heuteItems: NavItem[] = [
     {
@@ -167,7 +156,6 @@ export function AdminSidebar() {
     },
   ]
 
-  // "Kasse offen · seit HH:MM" bei offener Kasse, sonst "Kasse geschlossen".
   const kasseStatusText = kasseOffen
     ? `Kasse offen · seit ${new Date(
         kassensitzung.eroeffnetAm,

--- a/frontend/src/admin/kasse/GeldtransitDialog.tsx
+++ b/frontend/src/admin/kasse/GeldtransitDialog.tsx
@@ -24,7 +24,11 @@ import { Input } from '@/components/ui/input'
 import { useFormActionSubmit } from '@/hooks/use-form-action-submit'
 
 import { kasseBackend } from './hooks'
-import { BetragCentsSchema, type GeldtransitRichtung } from './Kassensitzung'
+import {
+  BetragCentsSchema,
+  type GeldtransitRichtung,
+  KommentarSchema,
+} from './Kassensitzung'
 
 // GeldtransitDialog bucht eine einzelne Bargeldbewegung mit fest vorgegebener
 // Richtung (die Buttons „+ Geld einlegen" / „− Geld entnehmen" wählen sie). Die
@@ -48,10 +52,7 @@ export function GeldtransitDialog({
     betragCents: BetragCentsSchema.gte(1, {
       message: 'Bitte einen Betrag größer als 0 eingeben.',
     }),
-    kommentar: z
-      .string()
-      .min(3, { message: 'Kommentar muss mindestens 3 Zeichen lang sein.' })
-      .max(200, { message: 'Kommentar darf maximal 200 Zeichen lang sein.' }),
+    kommentar: KommentarSchema,
   })
   type FormData = z.infer<typeof FormDataSchema>
 

--- a/frontend/src/admin/kasse/KasseBackend.ts
+++ b/frontend/src/admin/kasse/KasseBackend.ts
@@ -12,6 +12,7 @@ import {
   type Kassenbestand,
   KassenbestandSchema,
   KassensitzungSchema,
+  KommentarSchema,
 } from './Kassensitzung'
 
 export const KassensitzungEroeffnenSchema = z.object({
@@ -34,10 +35,7 @@ export const GeldtransitBuchenSchema = z.object({
     .number()
     .int()
     .min(1, { message: 'Betrag muss mindestens 1 Cent sein.' }),
-  kommentar: z
-    .string()
-    .min(3, { message: 'Kommentar muss mindestens 3 Zeichen lang sein.' })
-    .max(200, { message: 'Kommentar darf maximal 200 Zeichen lang sein.' }),
+  kommentar: KommentarSchema,
 })
 
 export const KasseAbschliessenSchema = z.object({

--- a/frontend/src/admin/kasse/Kassensitzung.ts
+++ b/frontend/src/admin/kasse/Kassensitzung.ts
@@ -15,7 +15,8 @@ export const GeldtransitRichtungSchema = z.enum([
 export const KassensitzungStatus = {
   OFFEN: 'offen',
   // Transienter Barrierestatus, den KasseAbschliessen hält (Saldo-Prüfung,
-  // Reporting, TSE-Signierung). Erstwertig, nicht dasselbe wie abgeschlossen.
+  // Reporting, TSE-Signierung). Ein eigenständiger Wert, nicht dasselbe wie
+  // abgeschlossen.
   WIRD_ABGESCHLOSSEN: 'wird_abgeschlossen',
   ABGESCHLOSSEN: 'abgeschlossen',
 } as const
@@ -47,6 +48,11 @@ export const BetragCentsSchema = z
   .number()
   .int()
   .gte(0, { message: 'Betrag muss mindestens 0 Cent sein.' })
+
+export const KommentarSchema = z
+  .string()
+  .min(3, { message: 'Kommentar muss mindestens 3 Zeichen lang sein.' })
+  .max(200, { message: 'Kommentar darf maximal 200 Zeichen lang sein.' })
 
 // Canonical Kassensitzung record (zNr, datum, bezeichnung, status). Reporting
 // re-exports this so both areas share one definition.

--- a/frontend/src/admin/kasse/ZaehlhilfeDialog.tsx
+++ b/frontend/src/admin/kasse/ZaehlhilfeDialog.tsx
@@ -28,8 +28,9 @@ function nennwertLabel(nennwert: Nennwert): string {
     : `${String(nennwert / 100)} €`
 }
 
-// ZaehlhilfeInhalt hält die Zählung. Er wird beim Öffnen frisch gemountet (key
-// am Aufrufer), damit jede Zählung leer startet — ohne setState im Effekt.
+// ZaehlhilfeInhalt hält die Zählung. Er wird beim Öffnen frisch gemountet
+// (bedingt gerendert am Aufrufer), damit jede Zählung leer startet — ohne
+// setState im Effekt.
 function ZaehlhilfeInhalt({
   onOpenChange,
   onUebernehmen,

--- a/frontend/src/admin/reporting/AdminDashboardPage.tsx
+++ b/frontend/src/admin/reporting/AdminDashboardPage.tsx
@@ -60,7 +60,7 @@ export function AdminDashboardPage() {
       `seit ${formatStand(new Date(kassensitzung.eroeffnetAm).getTime())}`,
     kassenbestand !== null &&
       `Soll-Bestand ${formatCents(kassenbestand.sollBestandCents)} €`,
-  ].filter((teil): teil is string => teil !== false && teil !== '')
+  ].filter((teil): teil is string => typeof teil === 'string')
   const kasseText = kasseTeile.length > 0 ? kasseTeile.join(' · ') : 'geöffnet'
 
   return (

--- a/frontend/src/admin/reporting/types.ts
+++ b/frontend/src/admin/reporting/types.ts
@@ -62,12 +62,6 @@ export const UmsatzSteuersatzSchema = z.object({
 })
 export type UmsatzSteuersatz = z.infer<typeof UmsatzSteuersatzSchema>
 
-export {
-  type Kassensitzung,
-  KassensitzungSchema,
-  kassensitzungStatusLabel,
-} from '@/admin/kasse/Kassensitzung'
-
 // AbgeschlosseneSitzung ist ein Eintrag der Kassenberichte-Sitzungsliste: die
 // abgeschlossene Kassensitzung mit Gesamtumsatz und Abschlusszeitpunkt aus dem
 // Tagesabschluss-Event. Status entfällt (alle Einträge sind abgeschlossen).

--- a/frontend/src/admin/reporting/utils.ts
+++ b/frontend/src/admin/reporting/utils.ts
@@ -1,5 +1,5 @@
-// Admin-Auswertungen zeigen den eingefrorenen Username, ergaenzt um den live
-// aufgeloesten Klarnamen: "username (Klarname)". Fehlt der Klarname, nur Username.
+// Admin-Auswertungen zeigen den eingefrorenen Username, ergänzt um den live
+// aufgelösten Klarnamen: "username (Klarname)". Fehlt der Klarname, nur Username.
 export function formatBediener(userName: string, name: string): string {
   return name ? `${userName} (${name})` : userName
 }

--- a/frontend/src/admin/settings/DruckstationBackend.ts
+++ b/frontend/src/admin/settings/DruckstationBackend.ts
@@ -73,9 +73,10 @@ const REFERENZ_PRAEFIX_LABEL: Record<string, string> = {
   'stornierung-erteilt': 'Stornierung',
 }
 
-// Testbons tragen als Referenz "testdruck:<kategorie>" (keine Event-ID). Sie
-// werden fachlich als „Testbon <Station>" angezeigt.
-const KATEGORIE_LABEL: Record<string, string> = {
+// Fachlicher Anzeigename je Kategorie, geteilt von der Referenz-Anzeige
+// fehlgeschlagener Druckaufträge (unten) und den Stationsköpfen der
+// Bondrucker-Seite. Testbons tragen als Referenz "testdruck:<kategorie>".
+export const KATEGORIE_LABEL: Record<string, string> = {
   essen: 'Essen',
   getraenk: 'Getränk',
   sonstiges: 'Sonstiges',

--- a/frontend/src/admin/settings/DruckstationConfigPage.tsx
+++ b/frontend/src/admin/settings/DruckstationConfigPage.tsx
@@ -28,24 +28,35 @@ import {
   formatDruckauftragReferenz,
   hatBonmodus,
   type Kategorie,
+  KATEGORIE_LABEL,
   validateDruckerIp,
 } from './DruckstationBackend'
 import { useDruckstationen, useFehlgeschlageneDruckauftraege } from './hooks'
 
-// Kurzbeschreibung und ein einprägsames Label je Station (Handoff 1g).
+// Kurzbeschreibung und Label je Station (Handoff 1g); das Label kommt aus dem
+// geteilten KATEGORIE_LABEL des Backends (Single Source of Truth).
 const KATEGORIE_INFO: Record<
   Kategorie,
   { label: string; beschreibung: string }
 > = {
-  essen: { label: 'Essen', beschreibung: 'Bons für die Essensausgabe' },
-  getraenk: { label: 'Getränk', beschreibung: 'Bons für den Ausschank' },
+  essen: {
+    label: KATEGORIE_LABEL.essen,
+    beschreibung: 'Bons für die Essensausgabe',
+  },
+  getraenk: {
+    label: KATEGORIE_LABEL.getraenk,
+    beschreibung: 'Bons für den Ausschank',
+  },
   sonstiges: {
-    label: 'Sonstiges',
+    label: KATEGORIE_LABEL.sonstiges,
     beschreibung: 'Bons für sonstige Positionen',
   },
-  kassenbeleg: { label: 'Kassenbeleg', beschreibung: 'Beleg für Gäste' },
+  kassenbeleg: {
+    label: KATEGORIE_LABEL.kassenbeleg,
+    beschreibung: 'Beleg für Gäste',
+  },
   abholbon: {
-    label: 'Abholbon',
+    label: KATEGORIE_LABEL.abholbon,
     beschreibung: 'Abholnummern beim Direktverkauf',
   },
 }

--- a/frontend/src/admin/tables/Tische.tsx
+++ b/frontend/src/admin/tables/Tische.tsx
@@ -4,7 +4,7 @@ import { EmptyState } from '@/components/common/EmptyState'
 import { useActionSubmit } from '@/hooks/use-action-submit'
 
 import { HinweisKarte } from '../components/HinweisKarte'
-import { type Tisch, TischStatus } from './Tisch'
+import { type Tisch } from './Tisch'
 import type { TischBackend } from './TischBackend'
 import { gruppiereTische } from './tischGrouping'
 import { TischItem } from './TischItem'
@@ -14,7 +14,7 @@ interface TischeProps {
   backend: Pick<TischBackend, 'activateTisch' | 'deactivateTisch'>
   tische: Tisch[]
   onEdit: (tischId: number) => void
-  onStatusChange: (tischId: number, status: TischStatus) => void
+  onStatusChange: () => void
 }
 
 export function Tische(props: TischeProps) {
@@ -30,14 +30,14 @@ export function Tische(props: TischeProps) {
   const activateTisch = async (tischId: number) => {
     await runActivate(async () => {
       await props.backend.activateTisch(tischId)
-      props.onStatusChange(tischId, TischStatus.ACTIVE)
+      props.onStatusChange()
     })
   }
 
   const deactivateTisch = async (tischId: number) => {
     await runDeactivate(async () => {
       await props.backend.deactivateTisch(tischId)
-      props.onStatusChange(tischId, TischStatus.INACTIVE)
+      props.onStatusChange()
     })
   }
 

--- a/frontend/src/admin/users/PasswordResetDialog.tsx
+++ b/frontend/src/admin/users/PasswordResetDialog.tsx
@@ -34,11 +34,11 @@ export function PasswordResetDialog(props: PasswordResetDialogProps) {
           </DialogDescription>
         </DialogHeader>
         <Field className="gap-1">
-          <FieldLabel htmlFor="username">Benutzername</FieldLabel>
+          <FieldLabel>Benutzername</FieldLabel>
           <p className="text-3xl">{props.username}</p>
         </Field>
         <Field className="gap-1">
-          <FieldLabel htmlFor="onetimePassword">Code</FieldLabel>
+          <FieldLabel>Code</FieldLabel>
           <p
             data-testid="onetime-password"
             className="text-3xl tracking-widest"

--- a/frontend/src/admin/users/UserCreatedDialog.tsx
+++ b/frontend/src/admin/users/UserCreatedDialog.tsx
@@ -36,11 +36,11 @@ export function UserCreatedDialog(props: UserCreatedDialogProps) {
           </DialogDescription>
         </DialogHeader>
         <Field className="gap-1">
-          <FieldLabel htmlFor="username">Benutzername</FieldLabel>
+          <FieldLabel>Benutzername</FieldLabel>
           <p className="text-3xl">{props.user?.username}</p>
         </Field>
         <Field className="gap-1">
-          <FieldLabel htmlFor="onetimePassword">Code</FieldLabel>
+          <FieldLabel>Code</FieldLabel>
           <p
             data-testid="onetime-password"
             className="text-3xl tracking-widest"

--- a/frontend/src/admin/users/Users.tsx
+++ b/frontend/src/admin/users/Users.tsx
@@ -4,7 +4,7 @@ import { EmptyState } from '@/components/common/EmptyState'
 import { useActionSubmit } from '@/hooks/use-action-submit'
 import { AuthSingleton } from '@/lib/Auth'
 
-import { type User, UserStatus } from './User'
+import { type User } from './User'
 import type { UserBackend } from './UserBackend'
 import { UserRow } from './UserRow'
 import { BENUTZER_SPALTEN } from './UsersSpalten'
@@ -14,7 +14,7 @@ interface UsersProps {
   backend: Pick<UserBackend, 'activateUser' | 'deactivateUser' | 'deleteUser'>
   users: User[]
   onEdit: (userId: number) => void
-  onStatusChange: (userId: number, status: UserStatus) => void
+  onStatusChange: () => void
   onResetPassword: (userId: number) => Promise<void>
   onDeleted: (userId: number) => void
 }
@@ -37,14 +37,14 @@ export function Users(props: UsersProps) {
   const activateUser = async (userId: number) => {
     await runActivate(async () => {
       await props.backend.activateUser(userId)
-      props.onStatusChange(userId, UserStatus.ACTIVE)
+      props.onStatusChange()
     })
   }
 
   const deactivateUser = async (userId: number) => {
     await runDeactivate(async () => {
       await props.backend.deactivateUser(userId)
-      props.onStatusChange(userId, UserStatus.INACTIVE)
+      props.onStatusChange()
     })
   }
 


### PR DESCRIPTION

Quality pass over the redesigned admin area; no behavior change intended.

- reporting/AdminDashboardPage: tighten the kasseTeile filter predicate to
  `typeof teil === 'string'` so a not-yet-loaded session cannot slip a null
  through the `teil is string` guard.
- reporting/types: remove the unused Kassensitzung re-export (dead code).
- users: drop dead `htmlFor` attributes in the one-time-credential dialogs
  (they pointed at ids that never render).
- AdminSidebar: reuse `tseAmpel(...).fehler` instead of reimplementing the
  TSE-error rule inline; drop the now-unused RUECKSTAND_WARN_SEKUNDEN import.
- kasse: extract a shared `KommentarSchema` and reuse it in GeldtransitDialog
  and KasseBackend (previously duplicated byte-for-byte).
- settings: export `KATEGORIE_LABEL` and source the Bondrucker station labels
  from it (single source of truth).
- users/tables: drop the unused args of `onStatusChange` (every caller ignores
  them).
- comments: fix the ZaehlhilfeDialog mount note (conditional render, not a
  React key), reporting/utils umlauts, the Kassensitzung status wording, and a
  redundant sidebar comment.