### PR TITLE
feat(frontend): apply spektral brand accents and motion inventory to the app

### DIFF
--- a/docs/adrs/05_spektral-branding-website.md
+++ b/docs/adrs/05_spektral-branding-website.md
@@ -4,6 +4,12 @@
 - **Kontext-Dokumente:**
   PRD `docs/prds/prd-website-redesign.md` (fasst den Design-Handoff
   zusammen), Plan `docs/plans/plan-website-redesign.md`
+- **Ablöse-Vermerk (2026-07-14):** Die Frontend-Ausnahme dieses ADR (unten
+  unter „Entscheidung": „Das Produkt-Frontend (`frontend/`) behält sein
+  bestehendes, zurückhaltendes Design") ist durch
+  [ADR 06](06_spektral-branding-app.md) abgelöst — die App erhält nun eine
+  dezente Spektral-Übertragung nach der Vier-Stellen-Regel. Der übrige Inhalt
+  dieses ADR (Website) bleibt akzeptiert und unverändert gültig.
 
 ## Kontext
 

--- a/docs/adrs/06_spektral-branding-app.md
+++ b/docs/adrs/06_spektral-branding-app.md
@@ -1,0 +1,87 @@
+# ADR 06: Spektral-Branding im App-Frontend (Ablösung der Frontend-Ausnahme aus ADR 05)
+
+- **Status:** akzeptiert (2026-07-14)
+- **Kontext-Dokumente:**
+  PRD `docs/prds/prd-spektral-redesign-frontend.md` (mit dem verbindlichen
+  Motion-Inventar), Plan `docs/plans/plan-spektral-redesign-frontend.md`,
+  Design-Handoff `docs/prds/design_handoff_spektral_redesign/`
+- **Löst ab:** die Frontend-Ausnahme aus
+  [ADR 05](05_spektral-branding-website.md) (siehe dort den Ablöse-Vermerk)
+
+## Kontext
+
+[ADR 05](05_spektral-branding-website.md) hat den vollen Spektral-Einsatz für
+die Marketing-Website abgenommen, das Produkt-Frontend aber ausdrücklich
+ausgenommen: „Das Produkt-Frontend (`frontend/`) behält sein bestehendes,
+zurückhaltendes Design; die Spektral-Erweiterung ist keine Aussage über die
+App." Damit blieben Website und App visuell entkoppelt.
+
+Der Design-Handoff und die PRD `docs/prds/prd-spektral-redesign-frontend.md`
+für das App-Redesign kehren diese Ausnahme um — allerdings nicht als Kopie des
+Website-Auftritts, sondern als bewusst dezente Übertragung der Markensprache
+auf ein Bedien-Werkzeug, das ehrenamtliche Helfer unter Zeitdruck bedienen.
+Die PRD hat diesen Umfang mit dem Betreiber als verbindlich abgenommen
+(inklusive des tabellierten Motion-Inventars).
+
+Das ist eine Entscheidung mit langfristiger Tragweite (sie prägt das gesamte
+App-Design und bindet alle Redesign-Phasen) und zugleich eine bewusste Abkehr
+von einer zuvor dokumentierten Festlegung — genau der Fall, für den
+`docs/adrs/` gedacht ist.
+
+Erwogene Alternativen:
+
+1. **Frontend-Ausnahme aus ADR 05 beibehalten** — die App bliebe optisch
+   markenlos und zur neu gestalteten Website inkonsistent; die bereits
+   abgenommene PRD wäre nicht umsetzbar.
+2. **Den vollen Website-Spektral-Einsatz 1:1 in die App übernehmen** —
+   animierte Verläufe, Spektral-Flächen und -Streifen als tragende UI-Elemente
+   wären für ein Kassen-Bedienwerkzeug zu laut, lenkten von Beträgen und
+   Status ab und widersprächen dem Produkt-Konservatismus (AGENTS.md).
+3. **Dezente Übertragung mit einer harten Leitplanke** (gewählt): das Spektrum
+   erscheint an genau vier klar umrissenen Stellen, alles Übrige (Layout,
+   Bedienablauf, Status-Semantik, Barrierefreiheit) bleibt unangetastet.
+
+## Entscheidung
+
+Die Spektral-Markensprache wird dezent in das App-Frontend (`frontend/`)
+übertragen (Alternative 3); die Frontend-Ausnahme aus ADR 05 ist damit
+abgelöst. Das Redesign ist ein reiner Restyling-Layer.
+
+**Vier-Stellen-Regel (neue Leitplanke).** Der Spektral-Verlauf (`--spectral`)
+und die `--sp-*`-Töne erscheinen in der App ausschließlich an vier Stellen:
+
+1. **Wortmarke** — „jotti" als Spektral-Text-Füllung (Space Grotesk 700),
+2. **Hintergrund-Glows** — weiche, geblurte Farbflächen am Login und hinter den
+   Admin-Seitenköpfen,
+3. **Ladezustände** — der Spektral-getönte Skeleton-Shimmer,
+4. **Hairline-Akzente** — die 2-px-Kante der Hero-Kennzahlkarte und der 3-px-
+   Marker am aktiven Sidebar-Eintrag.
+
+Alles darüber hinaus ist ausgeschlossen. Insbesondere bleiben unangetastet:
+
+- die **Status-Semantik** (Grün `--primary` / Rot `--destructive` / Amber): die
+  Ampelfarben sind reserviert und werden nie durch Spektral-Töne ersetzt oder
+  eingefärbt,
+- **Layouts, Bedienabläufe und Barrierefreiheit** (ARIA-Rollen, `aria-label`,
+  Fokusreihenfolge): das Redesign ändert nur die Optik, nie das Verhalten.
+
+**Bewegung** folgt durchgehend dem verbindlichen Motion-Inventar der PRD
+(Dauern und Easings dort tabelliert). Eine zentrale
+`@media (prefers-reduced-motion: reduce)`-Regel neutralisiert alle Animationen
+und Transitions global — inklusive der Loop-Animationen (Shimmer, Live-Puls,
+Glow-Drift). Kein Zustand darf sich allein aus Bewegung erschließen.
+
+## Konsequenzen
+
+- Die **Vier-Stellen-Regel** bindet alle künftigen Design-Änderungen am
+  Frontend: eine neue Spektral-Fläche außerhalb dieser vier Stellen — oder eine
+  Einfärbung der Status-Ampel — braucht ein neues ADR.
+- **ADR 05 bleibt akzeptiert** und für die Website vollständig gültig; nur seine
+  Frontend-Ausnahme ist abgelöst. Der dortige Ablöse-Vermerk verweist hierher.
+- Kontrast- und Barrierefreiheits-Prüfungen berücksichtigen die Glows und
+  Hairlines als Hintergrund für Text; Korrekturen erfolgen token-/deckkraft-
+  seitig innerhalb der Handoff-Bandbreite, nicht als Einzelfall-Hacks.
+- Die verbindliche Motion-Tabelle der PRD ist die einzige Quelle für Dauern und
+  Kurven; Einsatzstellen konsumieren nur die zentral definierten Utilities und
+  legen keine Ad-hoc-Animationen an.
+- Eine Rückkehr zum markenlosen Frontend bräuchte ein neues ADR.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -19,3 +19,4 @@ Entscheidung, Konsequenzen).
 | 03  | [Drawer auf Radix Dialog statt vaul](03_drawer-radix-statt-vaul.md) | akzeptiert |
 | 04  | [Warn-Bestätigung für irreversible Routine-Aktionen](04_warn-bestaetigung.md) | akzeptiert |
 | 05  | [Spektral-Branding auf der Website](05_spektral-branding-website.md) | akzeptiert |
+| 06  | [Spektral-Branding im App-Frontend](06_spektral-branding-app.md) | akzeptiert |

--- a/docs/plans/plan-spektral-redesign-frontend.md
+++ b/docs/plans/plan-spektral-redesign-frontend.md
@@ -236,19 +236,19 @@ Sichtbarer Effekt dieser Phase ist ausschließlich der Schriftwechsel der
 
 ### Acceptance criteria
 
-- [ ] `--sp-*` und `--spectral` stehen in `:root` und `.dark` wertidentisch
+- [x] `--sp-*` und `--spectral` stehen in `:root` und `.dark` wertidentisch
       zur Website (Dark-Verlauf rekomponiert), mit Quellkommentar auf
       `website/src/styles/brand.css`.
-- [ ] Keyframes `shimmer`/`fadeUp`/`pop`/`pulsedot`/`drift` und die benannten
+- [x] Keyframes `shimmer`/`fadeUp`/`pop`/`pulsedot`/`drift` und die benannten
       Utilities sind zentral in `index.css` definiert und in Komponenten
       verwendbar.
-- [ ] Die zentrale `prefers-reduced-motion`-Regel nullt Animationen und
+- [x] Die zentrale `prefers-reduced-motion`-Regel nullt Animationen und
       Transitions global (DevTools-Emulation: auch bestehende Drawer-/
       Spinner-Animationen stehen).
-- [ ] `CardTitle`, Dialog-/Drawer-Titel, `AdminPageHeader`-h1 und
+- [x] `CardTitle`, Dialog-/Drawer-Titel, `AdminPageHeader`-h1 und
       Tischtitel rendern Space Grotesk; Fließtext, Buttons, Beträge und die
       Doku bleiben Inter.
-- [ ] Kein weiterer visueller Diff; `make check` grün.
+- [x] Kein weiterer visueller Diff; `make check` grün.
 
 ---
 
@@ -277,14 +277,14 @@ mobiler Admin-Kopf (bestehende Größe).
 
 ### Acceptance criteria
 
-- [ ] „jotti“ erscheint an allen sechs Stellen mit Spektralverlauf in Space
+- [x] „jotti“ erscheint an allen sechs Stellen mit Spektralverlauf in Space
       Grotesk und bleibt als Text im DOM auffindbar (kein Bild).
-- [ ] Login-, Passwort-, Fehler- und Hydrate-Seite sind optisch identisch
+- [x] Login-, Passwort-, Fehler- und Hydrate-Seite sind optisch identisch
       behandelt.
-- [ ] Dark Mode nutzt den Dark-Verlauf (automatisch über das Token).
-- [ ] Bestehende Tests, die auf den Text „jotti“ matchen, laufen unverändert;
+- [x] Dark Mode nutzt den Dark-Verlauf (automatisch über das Token).
+- [x] Bestehende Tests, die auf den Text „jotti“ matchen, laufen unverändert;
       die Footer-Versionszeile der Sidebar ist unverändert schlichter Text.
-- [ ] `make check` grün.
+- [x] `make check` grün.
 
 ---
 
@@ -314,19 +314,19 @@ teal+violett; Farbpaare nach Mapping. Alle Glows sind `aria-hidden`,
 
 ### Acceptance criteria
 
-- [ ] Login (und über das `AuthLayout` auch Passwort- und Fehlerseite) zeigt
+- [x] Login (und über das `AuthLayout` auch Passwort- und Fehlerseite) zeigt
       die drei driftenden Glows hinter der Karte; unter reduzierter Bewegung
       steht die Drift.
-- [ ] Alle acht Admin-Seiten zeigen den Seitenkopf-Glow mit dem Farbpaar aus
+- [x] Alle acht Admin-Seiten zeigen den Seitenkopf-Glow mit dem Farbpaar aus
       dem Mapping.
-- [ ] Glows sind für Screenreader und Accessibility-Queries unsichtbar und
+- [x] Glows sind für Screenreader und Accessibility-Queries unsichtbar und
       klickdurchlässig; bestehende Tests grün.
-- [ ] Kontrast-Stichprobe: Text über Glows erfüllt AA in Hell und Dunkel
+- [x] Kontrast-Stichprobe: Text über Glows erfüllt AA in Hell und Dunkel
       (Deckkraft ggf. innerhalb der Handoff-Bandbreite justiert).
-- [ ] Druckvorschau der Kassenberichte ist frei von Glows.
-- [ ] Kein Layout-Shift und keine horizontalen Scrollbalken durch
+- [x] Druckvorschau der Kassenberichte ist frei von Glows.
+- [x] Kein Layout-Shift und keine horizontalen Scrollbalken durch
       Glow-Überhang.
-- [ ] `make check` grün.
+- [x] `make check` grün.
 
 ---
 
@@ -350,15 +350,15 @@ einheitlich spektral — keine Änderungen an den Verwendungsstellen nötig.
 
 ### Acceptance criteria
 
-- [ ] Die Skeleton-Komponente shimmert spektral getönt in Hell und Dunkel;
+- [x] Die Skeleton-Komponente shimmert spektral getönt in Hell und Dunkel;
       `grep animate-pulse frontend/src` liefert keine Treffer mehr.
-- [ ] Alle Verwendungsstellen gesichtet: `TischListSkeleton`,
+- [x] Alle Verwendungsstellen gesichtet: `TischListSkeleton`,
       `ProductListSkeleton` (Bestellen + Direktverkauf),
       `HistorieRowSkeleton` (beide Historien), `EigeneUebersicht`,
       `SidebarMenuSkeleton`.
-- [ ] Unter reduzierter Bewegung steht der Shimmer (statischer Platzhalter
+- [x] Unter reduzierter Bewegung steht der Shimmer (statischer Platzhalter
       bleibt sichtbar).
-- [ ] `make check` grün.
+- [x] `make check` grün.
 
 ---
 
@@ -382,13 +382,13 @@ Opacity .6), ausgelöst über den bestehenden `data-active`-Zustand.
 
 ### Acceptance criteria
 
-- [ ] Die Hero-Karte trägt die Spektral-Kante; die vier Nebenkarten und alle
+- [x] Die Hero-Karte trägt die Spektral-Kante; die vier Nebenkarten und alle
       übrigen Karten nicht.
-- [ ] Der aktive Sidebar-Eintrag zeigt den Marker zusätzlich zum bestehenden
+- [x] Der aktive Sidebar-Eintrag zeigt den Marker zusätzlich zum bestehenden
       Hintergrund; alle Nav-Einträge geprüft, Icons und Text unverschoben.
-- [ ] Beide Akzente sind dekorativ (`aria-hidden`), Hell und Dunkel geprüft;
+- [x] Beide Akzente sind dekorativ (`aria-hidden`), Hell und Dunkel geprüft;
       im Druckpfad der Kassenberichte tauchen sie nicht auf.
-- [ ] `make check` grün.
+- [x] `make check` grün.
 
 ---
 
@@ -416,11 +416,11 @@ Handoff-Delta C).
 
 ### Acceptance criteria
 
-- [ ] Buttons geben beim Drücken spürbares Press-Feedback, Stepper stärker;
+- [x] Buttons geben beim Drücken spürbares Press-Feedback, Stepper stärker;
       Disabled-Verhalten unverändert (keine `pointer-events`-Regression).
-- [ ] Die Mengen-Pill im Dock-Button poppt bei Änderung.
-- [ ] Unter reduzierter Bewegung wechseln Zustände sofort, ohne Übergänge.
-- [ ] Bestehende Button-/Stepper-/Drawer-Tests grün; `make check` grün.
+- [x] Die Mengen-Pill im Dock-Button poppt bei Änderung.
+- [x] Unter reduzierter Bewegung wechseln Zustände sofort, ohne Übergänge.
+- [x] Bestehende Button-/Stepper-/Drawer-Tests grün; `make check` grün.
 
 ---
 
@@ -449,15 +449,15 @@ Pop.
 
 ### Acceptance criteria
 
-- [ ] Tab-Wechsel in Tischansicht und Direktverkauf blenden sanft ein;
+- [x] Tab-Wechsel in Tischansicht und Direktverkauf blenden sanft ein;
       `tabsLocked`-Verhalten unverändert.
-- [ ] Tischkarten und Zahlungs-Positionen staggern nur beim ersten Aufbau;
+- [x] Tischkarten und Zahlungs-Positionen staggern nur beim ersten Aufbau;
       ein Refetch (z. B. nach einer Buchung) animiert nicht erneut.
-- [ ] Badge-Wechsel poppt; Texte und Semantik unverändert (Tests grün).
-- [ ] Nach dem Eröffnen der Kasse erscheint die erledigt-Karte mit fadeUp,
+- [x] Badge-Wechsel poppt; Texte und Semantik unverändert (Tests grün).
+- [x] Nach dem Eröffnen der Kasse erscheint die erledigt-Karte mit fadeUp,
       das Häkchen poppt.
-- [ ] Unter reduzierter Bewegung erscheint alles sofort, ohne Flackern.
-- [ ] `make check` grün.
+- [x] Unter reduzierter Bewegung erscheint alles sofort, ohne Flackern.
+- [x] `make check` grün.
 
 ---
 
@@ -490,17 +490,17 @@ die bisherigen Toast-Texte.
 
 ### Acceptance criteria
 
-- [ ] Pop erscheint nach erfolgreichem Bestellen, Kassieren und
+- [x] Pop erscheint nach erfolgreichem Bestellen, Kassieren und
       Direktverkauf; in diesen drei Flows feuert kein Erfolgs-Toast mehr.
-- [ ] Auto-Dismiss nach Ablauf der Anzeigedauer, Tap schließt sofort; der
+- [x] Auto-Dismiss nach Ablauf der Anzeigedauer, Tap schließt sofort; der
       nachgelagerte Statuswechsel/Refetch wird erst nach dem Schließen
       ausgelöst — getestet mit `vi.useFakeTimers`.
-- [ ] Fehlerpfad unverändert (`toast.error`, Drawer bleibt offen; bestehende
+- [x] Fehlerpfad unverändert (`toast.error`, Drawer bleibt offen; bestehende
       `ZahlungDrawer`-Tests grün).
-- [ ] Umbuchungs-, Storno-, Belegdruck- und Verwaltungs-Toasts unverändert.
-- [ ] Unter reduzierter Bewegung erscheint der Pop ohne Animation und
+- [x] Umbuchungs-, Storno-, Belegdruck- und Verwaltungs-Toasts unverändert.
+- [x] Unter reduzierter Bewegung erscheint der Pop ohne Animation und
       verschwindet nach Ablauf bzw. Tap.
-- [ ] `make check` grün.
+- [x] `make check` grün.
 
 ---
 
@@ -528,14 +528,14 @@ Layout-Shift).
 
 ### Acceptance criteria
 
-- [ ] Der Tisch-Saldo zählt bei Änderung animiert und endet exakt am
+- [x] Der Tisch-Saldo zählt bei Änderung animiert und endet exakt am
       Zielwert (Hook-Test).
-- [ ] Die Übersicht-Kennzahlen zählen beim 30-s-Refetch bzw.
+- [x] Die Übersicht-Kennzahlen zählen beim 30-s-Refetch bzw.
       „Jetzt“-Refresh nur bei tatsächlicher Wertänderung; kein Layout-Shift.
-- [ ] Ohne Animationsumgebung liefert der Hook sofort den Endwert (Test).
-- [ ] Bestehende `TablePage`-/`LiveReportingSection`-Tests bleiben grün
+- [x] Ohne Animationsumgebung liefert der Hook sofort den Endwert (Test).
+- [x] Bestehende `TablePage`-/`LiveReportingSection`-Tests bleiben grün
       (Endzustände unverändert).
-- [ ] `make check` grün.
+- [x] `make check` grün.
 
 ---
 
@@ -567,15 +567,15 @@ Druck-Stichprobe der Kassenberichte, volle Prüfung.
 
 ### Acceptance criteria
 
-- [ ] Der Kassentag-Chip pulsiert nur bei offener Kasse, der Live-Punkt der
+- [x] Der Kassentag-Chip pulsiert nur bei offener Kasse, der Live-Punkt der
       Übersicht pulsiert; alle übrigen StatusDots statisch; `aria-label` und
       Rolle unverändert (`AdminSidebar`-Tests grün).
-- [ ] Unter reduzierter Bewegung steht der Puls.
-- [ ] `docs/adrs/06_spektral-branding-app.md` geschrieben, ADR 05 mit
+- [x] Unter reduzierter Bewegung steht der Puls.
+- [x] `docs/adrs/06_spektral-branding-app.md` geschrieben, ADR 05 mit
       Ablöse-Vermerk, README-Tabelle aktualisiert.
-- [ ] Screenshot-Satz aller Screens in Hell und Dunkel für die Sichtabnahme
+- [x] Screenshot-Satz aller Screens in Hell und Dunkel für die Sichtabnahme
       erstellt; Reduced-Motion- und Druck-Gegenprobe durchgeführt und im
       Chat dokumentiert.
-- [ ] `make verify` grün.
+- [x] `make verify` grün.
 - [ ] Nach bestandener Sichtabnahme durch den Betreiber (Human-Gate):
       Handoff-Bundle `docs/prds/design_handoff_spektral_redesign/` löschen.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@base-ui/react": "^1.6.0",
     "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/space-grotesk": "^5.2.10",
     "@hookform/resolvers": "^5.4.0",
     "@tailwindcss/vite": "^4.3.2",
     "@tanstack/react-query": "^5.101.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
+      '@fontsource-variable/space-grotesk':
+        specifier: ^5.2.10
+        version: 5.2.10
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.81.0(react@19.2.7))
@@ -512,6 +515,9 @@ packages:
 
   '@fontsource-variable/inter@5.2.8':
     resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
+
+  '@fontsource-variable/space-grotesk@5.2.10':
+    resolution: {integrity: sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -4456,6 +4462,8 @@ snapshots:
   '@floating-ui/utils@0.2.11': {}
 
   '@fontsource-variable/inter@5.2.8': {}
+
+  '@fontsource-variable/space-grotesk@5.2.10': {}
 
   '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:

--- a/frontend/src/admin/AdminLayout.tsx
+++ b/frontend/src/admin/AdminLayout.tsx
@@ -2,6 +2,7 @@ import { Menu } from 'lucide-react'
 import { Outlet } from 'react-router'
 
 import { UserDropdown } from '@/components/common/UserDropdown'
+import { Wortmarke } from '@/components/common/Wortmarke'
 import { Button } from '@/components/ui/button'
 import { SidebarProvider, useSidebar } from '@/components/ui/sidebar'
 
@@ -22,7 +23,7 @@ function AdminMobileHeader() {
         >
           <Menu className="h-5 w-5" />
         </Button>
-        <span className="text-sm font-bold">jotti</span>
+        <Wortmarke className="text-sm" />
       </div>
       <UserDropdown />
     </header>

--- a/frontend/src/admin/AdminSidebar.tsx
+++ b/frontend/src/admin/AdminSidebar.tsx
@@ -202,6 +202,7 @@ export function AdminSidebar() {
             <StatusDot
               zustand={kasseOffen ? 'ok' : 'neutral'}
               label={kasseOffen ? 'Kasse offen' : 'Kasse geschlossen'}
+              puls={kasseOffen}
             />
             {kasseStatusText}
           </span>

--- a/frontend/src/admin/AdminSidebar.tsx
+++ b/frontend/src/admin/AdminSidebar.tsx
@@ -18,6 +18,7 @@ import { NavLink, useLocation, useNavigate } from 'react-router'
 import { useFehlgeschlageneDruckauftraege } from '@/admin/settings/hooks'
 import { useTSESignaturQueue, useTSEStatus } from '@/admin/tse/hooks'
 import { tseAmpel } from '@/admin/tse/tseAmpel'
+import { Wortmarke } from '@/components/common/Wortmarke'
 import { useTheme } from '@/components/theme-provider'
 import {
   Sidebar,
@@ -181,7 +182,7 @@ export function AdminSidebar() {
   return (
     <Sidebar collapsible="offcanvas" className="print:hidden">
       <SidebarHeader className="gap-3">
-        <h1 className="px-1 text-3xl font-extrabold">jotti</h1>
+        <Wortmarke as="h1" className="w-fit px-1 text-[26px]" />
         <NavLink
           to="/admin/kasse"
           className="flex flex-col gap-1 rounded-lg border bg-background px-3 py-2.5 shadow-sm"

--- a/frontend/src/admin/AdminSidebar.tsx
+++ b/frontend/src/admin/AdminSidebar.tsx
@@ -53,25 +53,33 @@ function NavGroup({ label, items }: { label: string; items: NavItem[] }) {
       <SidebarGroupLabel>{label}</SidebarGroupLabel>
       <SidebarGroupContent>
         <SidebarMenu>
-          {items.map((item) => (
-            <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton
-                asChild
-                isActive={location.pathname === item.url}
-              >
-                <NavLink to={item.url}>
-                  <item.icon />
-                  <span className="flex-1">{item.title}</span>
-                  {item.status && (
-                    <StatusDot
-                      zustand={item.status.zustand}
-                      label={item.status.label}
-                    />
-                  )}
-                </NavLink>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
+          {items.map((item) => {
+            const istAktiv = location.pathname === item.url
+            return (
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton asChild isActive={istAktiv}>
+                  <NavLink to={item.url} className="relative">
+                    {/* Dekorativer Spektral-Marker am linken Rand des aktiven
+                        Eintrags, zusätzlich zum bestehenden bg-sidebar-accent. */}
+                    {istAktiv && (
+                      <span
+                        aria-hidden
+                        className="absolute inset-y-2 left-0 w-[3px] rounded-[2px] bg-[image:var(--spectral)] opacity-60"
+                      />
+                    )}
+                    <item.icon />
+                    <span className="flex-1">{item.title}</span>
+                    {item.status && (
+                      <StatusDot
+                        zustand={item.status.zustand}
+                        label={item.status.label}
+                      />
+                    )}
+                  </NavLink>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )
+          })}
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>

--- a/frontend/src/admin/components/AdminPageHeader.tsx
+++ b/frontend/src/admin/components/AdminPageHeader.tsx
@@ -1,20 +1,27 @@
 import type { ReactNode } from 'react'
 
+import { HeaderGlow, type SpektralFarbe } from './HeaderGlow'
+
 // Einheitlicher Seitenkopf aller acht Admin-Seiten (Design-Handoff, Abschnitte
 // 1a–1h): H1 24 px/700, darunter eine erklärende Unterzeile 14 px in
 // muted-foreground und rechts ein Aktions-Slot (etwa der Anlegen-Button).
 // Ersetzt die früheren losen H1 der einzelnen Seiten und den fixierten FAB.
+// Dahinter ein dekorativer Spektral-Glow (HeaderGlow); das optionale Farbpaar
+// variiert ihn je Seite, Default teal+violett.
 export function AdminPageHeader({
   titel,
   unterzeile,
   aktionen,
+  glowFarben,
 }: {
   titel: string
   unterzeile?: ReactNode
   aktionen?: ReactNode
+  glowFarben?: readonly [SpektralFarbe, SpektralFarbe]
 }) {
   return (
-    <div className="flex items-start justify-between gap-4">
+    <div className="relative isolate flex items-start justify-between gap-4">
+      <HeaderGlow farben={glowFarben} />
       <div>
         <h1 className="font-heading text-2xl font-bold leading-8">{titel}</h1>
         {unterzeile !== undefined && (

--- a/frontend/src/admin/components/AdminPageHeader.tsx
+++ b/frontend/src/admin/components/AdminPageHeader.tsx
@@ -16,7 +16,7 @@ export function AdminPageHeader({
   return (
     <div className="flex items-start justify-between gap-4">
       <div>
-        <h1 className="text-2xl font-bold leading-8">{titel}</h1>
+        <h1 className="font-heading text-2xl font-bold leading-8">{titel}</h1>
         {unterzeile !== undefined && (
           <p className="mt-1 text-sm text-muted-foreground">{unterzeile}</p>
         )}

--- a/frontend/src/admin/components/HeaderGlow.tsx
+++ b/frontend/src/admin/components/HeaderGlow.tsx
@@ -1,0 +1,30 @@
+// Dekorativer Seitenkopf-Glow (Handoff „Glow-Rezept"): zwei überlagerte,
+// stark geblurte Ellipsen-Gradients aus einem Spektral-Farbpaar hinter dem
+// AdminPageHeader. Rein dekorativ — für Screenreader unsichtbar (aria-hidden),
+// klickdurchlässig (pointer-events-none) und im Druck ausgeblendet
+// (print:hidden). Der äußere Container clippt den Überhang (overflow-hidden),
+// damit kein horizontaler Scrollbalken entsteht; das Farbpaar ist die einzige
+// Stellschraube, Default teal+violett.
+export type SpektralFarbe =
+  'red' | 'orange' | 'green' | 'teal' | 'blue' | 'violet'
+
+export function HeaderGlow({
+  farben = ['teal', 'violet'],
+}: {
+  farben?: readonly [SpektralFarbe, SpektralFarbe]
+}) {
+  const [erste, zweite] = farben
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 -z-10 overflow-hidden print:hidden"
+    >
+      <div
+        className="absolute -top-[70px] -left-10 h-[200px] w-[460px] opacity-[0.18] blur-[52px]"
+        style={{
+          background: `radial-gradient(ellipse at 20% 40%, color-mix(in oklab, var(--sp-${erste}) 40%, transparent), transparent 60%), radial-gradient(ellipse at 70% 60%, color-mix(in oklab, var(--sp-${zweite}) 28%, transparent), transparent 60%)`,
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/admin/components/StatusDot.tsx
+++ b/frontend/src/admin/components/StatusDot.tsx
@@ -15,13 +15,19 @@ const zustandKlasse: Record<StatusDotZustand, string> = {
 // gesetzt, damit der Zustand auch ohne Sichtkontakt lesbar ist. role="img"
 // statt role="status": Der Punkt trägt Bedeutung (roter Punkt = Problem), soll
 // aber nicht als Live-Region bei jedem Refetch neu vorgelesen werden.
+//
+// puls: weicher Ring-Puls (Keyframe pulsedot, 2,4 s), signalisiert einen
+// „lebenden" Zustand. Bewusst nur an zwei Stellen gesetzt (Kassentag-Chip bei
+// offener Kasse, Live-Punkt der Übersicht); alle übrigen Punkte bleiben statisch.
 export function StatusDot({
   zustand,
   label,
+  puls = false,
   className,
 }: {
   zustand: StatusDotZustand
   label: string
+  puls?: boolean
   className?: string
 }) {
   return (
@@ -31,6 +37,7 @@ export function StatusDot({
       className={cn(
         'inline-block size-[7px] shrink-0 rounded-full',
         zustandKlasse[zustand],
+        puls && 'animate-pulsedot',
         className,
       )}
     />

--- a/frontend/src/admin/kasse/KassensitzungPage.tsx
+++ b/frontend/src/admin/kasse/KassensitzungPage.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { Check } from 'lucide-react'
-import type { ReactNode } from 'react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 
 import { AdminPageHeader } from '@/admin/components/AdminPageHeader'
 import { formatDatumLang } from '@/admin/reporting/utils'
@@ -24,6 +24,16 @@ export { KasseAbschliessenSection } from './KasseAbschliessenSection'
 
 type StepState = 'done' | 'active' | 'inactive'
 
+// ErledigtHaekchen rendert das Häkchen des erledigten Schritts. Es poppt
+// (Motion-Inventar „Statuswechsel", 350 ms), wenn der Schritt gerade auf
+// „erledigt" wechselt — nicht, wenn die Seite bereits erledigt lädt. Der
+// Pop-Zustand wird beim Mounten erfasst, damit ein späteres Neurendern (z. B.
+// eintreffender Kassenbestand) die Animation nicht abreißt.
+function ErledigtHaekchen({ animiert }: { animiert: boolean }) {
+  const [poppen] = useState(animiert)
+  return <Check className={cn('size-4', poppen && 'animate-pop')} />
+}
+
 // StepperRow rendert die Nummern-Schiene (Kreis + Verbindungslinie) links und den
 // Schritt-Inhalt rechts. Der erledigte Schritt (done) bekommt ein Häkchen, der
 // aktive Schritt einen umrandeten Kreis, inaktive Schritte sind ausgegraut.
@@ -31,11 +41,15 @@ function StepperRow({
   nummer,
   state,
   istLetzter,
+  markerAnimiert,
   children,
 }: {
   nummer: number
   state: StepState
   istLetzter?: boolean
+  // Lässt das erledigt-Häkchen einmalig poppen, wenn der Schritt gerade auf
+  // „erledigt" wechselt (nur Schritt 1 nach dem Eröffnen).
+  markerAnimiert?: boolean
   children: ReactNode
 }) {
   return (
@@ -51,7 +65,11 @@ function StepperRow({
               'border-2 border-border bg-background text-muted-foreground',
           )}
         >
-          {state === 'done' ? <Check className="size-4" /> : nummer}
+          {state === 'done' ? (
+            <ErledigtHaekchen animiert={markerAnimiert ?? false} />
+          ) : (
+            nummer
+          )}
         </span>
         {!istLetzter && <span className="mt-1 w-0.5 flex-1 bg-border" />}
       </div>
@@ -70,16 +88,28 @@ function StepperRow({
 function EroeffnetKarte({
   kassensitzung,
   anfangsbestandCents,
+  animieren,
 }: {
   kassensitzung: OffeneKassensitzung
   anfangsbestandCents: number | null
+  // Lässt die Karte einmalig mit fadeUp eintreten, wenn sie gerade durch das
+  // Eröffnen erscheint (nicht beim Laden einer bereits offenen Kasse).
+  animieren: boolean
 }) {
   const eroeffnetAm = new Date(kassensitzung.eroeffnetAm).toLocaleString(
     'de-DE',
     { dateStyle: 'medium', timeStyle: 'short' },
   )
+  // Beim Mount erfasst, damit ein späteres Neurendern die Animation nicht abreißt.
+  const [initialAnimieren] = useState(animieren)
   return (
-    <Card className="bg-muted/30">
+    <Card
+      className={cn(
+        'bg-muted/30',
+        initialAnimieren &&
+          'animate-fade-up [animation-duration:450ms] [animation-timing-function:cubic-bezier(0.2,0.7,0.3,1)]',
+      )}
+    >
       <CardContent className="py-4">
         <div className="text-sm font-semibold">1 · Kasse eröffnet</div>
         <p className="mt-0.5 text-sm text-muted-foreground">
@@ -100,6 +130,22 @@ export function KassensitzungPage() {
   // dedupliziert mit dem Abruf innerhalb von LaufenderBetriebSection.
   const { kassenbestand } = useKassenbestand(kassensitzung?.zNr ?? null)
   const queryClient = useQueryClient()
+
+  // „Gerade eröffnet" erkennt den Wechsel von geschlossener zu offener Kasse,
+  // um die erledigt-Karte nur nach dem Eröffnen zu animieren — nicht beim Laden
+  // einer bereits offenen Kasse. Der Ref bleibt `null`, solange die erste
+  // Abfrage lädt (`isPending`), damit der Anfangszustand nicht als Wechsel gilt.
+  // Er liegt bewusst in einem Ref (kein zusätzliches Rendern, das die Animation
+  // abreißen würde); der Schreibzugriff erfolgt nur im Effekt.
+  const istOffen = kassensitzung != null
+  const zuletztOffenRef = useRef<boolean | null>(null)
+  // eslint-disable-next-line react-hooks/refs
+  const geradeEroeffnet = zuletztOffenRef.current === false && istOffen
+  useEffect(() => {
+    if (!isPending) {
+      zuletztOffenRef.current = istOffen
+    }
+  }, [isPending, istOffen])
 
   const titel = kassensitzung
     ? `Kassentag Nr. ${String(kassensitzung.zNr)} — ${kassensitzung.bezeichnung}`
@@ -153,10 +199,15 @@ export function KassensitzungPage() {
       <div className="mt-6 flex flex-col gap-4">
         {kassensitzung ? (
           <>
-            <StepperRow nummer={1} state="done">
+            <StepperRow
+              nummer={1}
+              state="done"
+              markerAnimiert={geradeEroeffnet}
+            >
               <EroeffnetKarte
                 kassensitzung={kassensitzung}
                 anfangsbestandCents={kassenbestand?.anfangsbestandCents ?? null}
+                animieren={geradeEroeffnet}
               />
             </StepperRow>
 

--- a/frontend/src/admin/kasse/KassensitzungPage.tsx
+++ b/frontend/src/admin/kasse/KassensitzungPage.tsx
@@ -108,7 +108,13 @@ export function KassensitzungPage() {
     ? `${formatDatumLang(kassensitzung.datum)} · Ein Kassentag läuft von der Eröffnung bis zum Tagesabschluss (Z-Bon).`
     : 'Ein Kassentag läuft von der Eröffnung bis zum Tagesabschluss (Z-Bon).'
 
-  const header = <AdminPageHeader titel={titel} unterzeile={unterzeile} />
+  const header = (
+    <AdminPageHeader
+      titel={titel}
+      unterzeile={unterzeile}
+      glowFarben={['orange', 'teal']}
+    />
+  )
 
   if (isPending) {
     return (

--- a/frontend/src/admin/products/AdminProductsPage.tsx
+++ b/frontend/src/admin/products/AdminProductsPage.tsx
@@ -56,6 +56,7 @@ export function AdminProductsPage() {
       <AdminPageHeader
         titel="Produkte & Preise"
         unterzeile={produktUnterzeile(produkte)}
+        glowFarben={['green', 'blue']}
         aktionen={
           <NewProductDialog
             backend={produktBackend}

--- a/frontend/src/admin/reporting/LiveReportingSection.tsx
+++ b/frontend/src/admin/reporting/LiveReportingSection.tsx
@@ -21,6 +21,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '@/components/ui/empty'
+import { useCountUp } from '@/hooks/use-count-up'
 import { formatCents } from '@/lib/utils'
 
 import { AdminPageHeader } from '../components/AdminPageHeader'
@@ -49,6 +50,9 @@ export function LiveReportingSection({
   statusZeile?: ReactNode
 }) {
   const [tischeAusgeklappt, setTischeAusgeklappt] = useState(false)
+  // Hero-Kennzahl zählt bei Refetch animiert; vor dem Laden fehlt liveData, der
+  // Hook startet dann bei 0 (Hook-Aufruf muss vor den frühen Returns stehen).
+  const heroUmsatz = useCountUp(liveData?.summary.gesamtUmsatzCents ?? 0)
 
   if (loading) {
     return (
@@ -127,7 +131,7 @@ export function LiveReportingSection({
             Kassierter Umsatz
           </span>
           <span className="text-3xl font-extrabold tracking-tight whitespace-nowrap tabular-nums">
-            {formatCents(summary.gesamtUmsatzCents)} €
+            {formatCents(heroUmsatz)} €
           </span>
           <span className="text-xs text-muted-foreground">
             bereits bezahlt, Stornos abgezogen
@@ -135,22 +139,22 @@ export function LiveReportingSection({
         </div>
         <SummaryCard
           title="Noch offen"
-          value={`${formatCents(liveData.offeneSaldiCents)} €`}
+          valueCents={liveData.offeneSaldiCents}
           sub={`auf ${String(offeneTische.length)} Tischen bestellt, noch nicht bezahlt`}
         />
         <SummaryCard
           title="Bestellt gesamt"
-          value={`${formatCents(summary.gesamtBestellungenCents)} €`}
+          valueCents={summary.gesamtBestellungenCents}
           sub="bezahlt + offen zusammen"
         />
         <SummaryCard
           title="Direktverkauf"
-          value={`${formatCents(summary.direktverkaufUmsatzCents)} €`}
+          valueCents={summary.direktverkaufUmsatzCents}
           sub={`${String(summary.anzahlDirektverkaeufe)} Verkäufe ohne Tisch`}
         />
         <SummaryCard
           title="Storniert"
-          value={`${formatCents(summary.gesamtStornierungenCents)} €`}
+          valueCents={summary.gesamtStornierungenCents}
           sub={`${String(summary.anzahlStornierungen)} Stornierungen`}
         />
       </div>

--- a/frontend/src/admin/reporting/LiveReportingSection.tsx
+++ b/frontend/src/admin/reporting/LiveReportingSection.tsx
@@ -106,7 +106,7 @@ export function LiveReportingSection({
         aktionen={
           <>
             <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground">
-              <StatusDot zustand="ok" label="Live" />
+              <StatusDot zustand="ok" label="Live" puls />
               Live · aktualisiert {formatStand(dataUpdatedAt)}
             </span>
             <Button variant="outline" size="sm" onClick={onRefresh}>

--- a/frontend/src/admin/reporting/LiveReportingSection.tsx
+++ b/frontend/src/admin/reporting/LiveReportingSection.tsx
@@ -117,11 +117,16 @@ export function LiveReportingSection({
 
       {/* Kennzahlen: Hero-Karte „Kassierter Umsatz" plus vier Nebenkarten */}
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
-        <div className="col-span-2 flex flex-col gap-1.5 rounded-xl bg-card p-5 shadow-xs ring-1 ring-foreground/10 lg:col-span-1">
+        <div className="relative flex flex-col gap-1.5 overflow-hidden rounded-xl bg-card p-5 shadow-xs ring-1 ring-foreground/10 col-span-2 lg:col-span-1">
+          {/* Dekorative Spektral-Kante als oberste Linie der Hero-Karte. */}
+          <span
+            aria-hidden
+            className="absolute inset-x-0 top-0 h-0.5 bg-[image:var(--spectral)] opacity-60"
+          />
           <span className="text-sm font-medium text-muted-foreground">
             Kassierter Umsatz
           </span>
-          <span className="text-3xl font-extrabold tracking-tight">
+          <span className="text-3xl font-extrabold tracking-tight whitespace-nowrap tabular-nums">
             {formatCents(summary.gesamtUmsatzCents)} €
           </span>
           <span className="text-xs text-muted-foreground">

--- a/frontend/src/admin/reporting/SummaryCard.tsx
+++ b/frontend/src/admin/reporting/SummaryCard.tsx
@@ -1,21 +1,24 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useCountUp } from '@/hooks/use-count-up'
+import { formatCents } from '@/lib/utils'
 
 export function SummaryCard({
   title,
-  value,
+  valueCents,
   sub,
 }: {
   title: string
-  value: string
+  valueCents: number
   sub?: string
 }) {
+  const wert = useCountUp(valueCents)
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-sm text-muted-foreground">{title}</CardTitle>
       </CardHeader>
       <CardContent>
-        <p className="text-xl font-bold">{value}</p>
+        <p className="text-xl font-bold tabular-nums">{formatCents(wert)} €</p>
         {sub && <p className="mt-0.5 text-sm text-muted-foreground">{sub}</p>}
       </CardContent>
     </Card>

--- a/frontend/src/admin/users/AdminUsersPage.tsx
+++ b/frontend/src/admin/users/AdminUsersPage.tsx
@@ -103,6 +103,7 @@ export function AdminUsersPage() {
       <AdminPageHeader
         titel="Helfer & Zugänge"
         unterzeile={unterzeile}
+        glowFarben={['blue', 'red']}
         aktionen={
           <NewUserDialog
             backend={userBackend}

--- a/frontend/src/components/common/AuthLayout.tsx
+++ b/frontend/src/components/common/AuthLayout.tsx
@@ -1,8 +1,44 @@
 import type { ReactNode } from 'react'
 
+// Login-Glows (Handoff Delta B): drei stark geblurte, dekorative Farbkreise
+// hinter der Karte. Rein dekorativ (aria-hidden, pointer-events-none) und im
+// Druck ausgeblendet; overflow-hidden am Wrapper clippt den Überhang, isolate
+// hält sie über dem Hintergrund und hinter der Karte. Die langsame Drift ist je
+// Kreis in Dauer und Delay versetzt (Inline-Override der animate-drift-Dauer),
+// damit sich die Kreise unabhängig bewegen — die zentrale Reduced-Motion-Regel
+// stoppt sie.
 export function AuthLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="flex flex-col min-h-screen max-h-screen items-center justify-start pt-16 sm:justify-center sm:pt-4 p-4 bg-primary/5">
+    <div className="relative isolate flex flex-col min-h-screen max-h-screen items-center justify-start overflow-hidden pt-16 sm:justify-center sm:pt-4 p-4 bg-primary/5">
+      <div
+        aria-hidden
+        className="animate-drift pointer-events-none absolute -top-20 -left-16 -z-10 size-80 rounded-full opacity-25 blur-[60px] print:hidden"
+        style={{
+          background:
+            'radial-gradient(circle, color-mix(in oklab, var(--sp-teal) 55%, transparent), transparent 65%)',
+          animationDuration: '16s',
+        }}
+      />
+      <div
+        aria-hidden
+        className="animate-drift pointer-events-none absolute -right-20 -bottom-24 -z-10 size-[340px] rounded-full opacity-20 blur-[64px] print:hidden"
+        style={{
+          background:
+            'radial-gradient(circle, color-mix(in oklab, var(--sp-violet) 45%, transparent), transparent 65%)',
+          animationDuration: '20s',
+          animationDelay: '-5s',
+        }}
+      />
+      <div
+        aria-hidden
+        className="animate-drift pointer-events-none absolute top-1/3 -right-12 -z-10 size-50 rounded-full opacity-[0.18] blur-[56px] print:hidden"
+        style={{
+          background:
+            'radial-gradient(circle, color-mix(in oklab, var(--sp-orange) 40%, transparent), transparent 65%)',
+          animationDuration: '22s',
+          animationDelay: '-9s',
+        }}
+      />
       {children}
       <footer className="mt-6">
         <p className="text-muted-foreground text-sm">

--- a/frontend/src/components/common/LoginForm.tsx
+++ b/frontend/src/components/common/LoginForm.tsx
@@ -13,6 +13,7 @@ import { type AuthBackend, LoginSchema } from '@/lib/AuthBackend'
 import { getActionErrorMessage } from '@/lib/errorMessages'
 
 import { PasswordField, UsernameField } from './FormFields'
+import { Wortmarke } from './Wortmarke'
 
 type FormData = z.infer<typeof LoginSchema>
 
@@ -64,7 +65,7 @@ export function LoginForm(props: LoginFormProps) {
   return (
     <Card className="w-full max-w-sm">
       <CardHeader>
-        <h1 className="text-4xl text-center font-extrabold">jotti</h1>
+        <Wortmarke as="h1" className="text-[38px] text-center" />
       </CardHeader>
       <CardContent>
         <form

--- a/frontend/src/components/common/PasswordForm.tsx
+++ b/frontend/src/components/common/PasswordForm.tsx
@@ -17,6 +17,7 @@ import { useFormActionSubmit } from '@/hooks/use-form-action-submit'
 import { AuthBackend, SetPasswordSchema } from '@/lib/AuthBackend'
 
 import { NewPasswordField, OTPField, UsernameField } from './FormFields'
+import { Wortmarke } from './Wortmarke'
 
 type FormData = z.infer<typeof SetPasswordSchema>
 
@@ -60,7 +61,7 @@ export function PasswordForm(props: PasswordFormProps) {
   return (
     <Card className="w-full max-w-sm">
       <CardHeader>
-        <h1 className="text-4xl text-center font-extrabold">jotti</h1>
+        <Wortmarke as="h1" className="text-[38px] text-center" />
       </CardHeader>
       <CardDescription className="text-center mb-4 px-8">
         Lege ein neues Passwort für dein Konto fest.

--- a/frontend/src/components/common/Wortmarke.tsx
+++ b/frontend/src/components/common/Wortmarke.tsx
@@ -1,0 +1,30 @@
+import type { ElementType } from 'react'
+
+import { cn } from '@/lib/utils'
+
+interface WortmarkeProps {
+  // HTML-Element der Einsatzstelle. Erhält die bestehende Semantik: wo heute
+  // ein h1 steht, wird `as="h1"` übergeben; der mobile Admin-Kopf bleibt span.
+  as?: ElementType
+  className?: string
+}
+
+// Die Wortmarke „jotti" als selektierbarer Text (kein Bild) in Space Grotesk
+// 700 mit dem Spektralverlauf als Text-Füllung. Größe und Ausrichtung kommen
+// über className der Einsatzstelle; der Verlauf folgt automatisch dem Theme,
+// weil --spectral im Dark Mode überschrieben ist.
+export function Wortmarke({
+  as: Component = 'span',
+  className,
+}: WortmarkeProps) {
+  return (
+    <Component
+      className={cn(
+        'bg-[image:var(--spectral)] bg-clip-text font-heading font-bold text-transparent',
+        className,
+      )}
+    >
+      jotti
+    </Component>
+  )
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px active:not-aria-[haspopup]:scale-[.99] disabled:pointer-events-none aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -41,12 +41,14 @@ const buttonVariants = cva(
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),8px)] px-2 text-xs in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-8 gap-1 rounded-[min(var(--radius-md),10px)] px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
         lg: "h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        icon: "size-9",
+        // Icon-Buttons drücken sich beim Tippen etwas stärker ein (scale .96
+        // statt .99), weil die kleinere Fläche sonst weniger Press-Feedback gibt.
+        icon: "size-9 active:not-aria-[haspopup]:scale-[.96]",
         "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),8px)] in-data-[slot=button-group]:rounded-md [&_svg:not([class*='size-'])]:size-3",
+          "size-6 rounded-[min(var(--radius-md),8px)] in-data-[slot=button-group]:rounded-md active:not-aria-[haspopup]:scale-[.96] [&_svg:not([class*='size-'])]:size-3",
         "icon-sm":
-          "size-8 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md",
-        "icon-lg": "size-10",
+          "size-8 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md active:not-aria-[haspopup]:scale-[.96]",
+        "icon-lg": "size-10 active:not-aria-[haspopup]:scale-[.96]",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow,border-color] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn("skeleton-shimmer rounded-md", className)}
       {...props}
     />
   )

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -175,7 +175,10 @@ function TabsContent({
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn('flex-1 text-sm outline-none', className)}
+      // Radix hängt den inaktiven Tab-Inhalt aus dem DOM aus; beim Aktivieren
+      // mountet er neu, wodurch die fadeUp-Animation (250 ms) jedes Mal neu
+      // startet (Motion-Inventar „Tab-/Detail-Wechsel").
+      className={cn('flex-1 text-sm outline-none animate-fade-up', className)}
       {...props}
     />
   )

--- a/frontend/src/hooks/use-count-up.test.ts
+++ b/frontend/src/hooks/use-count-up.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useCountUp } from './use-count-up'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('useCountUp', () => {
+  it('liefert beim ersten Rendern den Ausgangswert ohne Animation', () => {
+    const { result } = renderHook(({ ziel }) => useCountUp(ziel), {
+      initialProps: { ziel: 1250 },
+    })
+
+    expect(result.current).toBe(1250)
+  })
+
+  it('liefert ohne Animationsumgebung bei Änderung sofort den Endwert', () => {
+    // jsdom kennt kein window.matchMedia — der Hook stuft die Umgebung als
+    // nicht animierbar ein und springt direkt auf den Zielwert.
+    const { result, rerender } = renderHook(({ ziel }) => useCountUp(ziel), {
+      initialProps: { ziel: 1250 },
+    })
+
+    act(() => {
+      rerender({ ziel: 2000 })
+    })
+
+    expect(result.current).toBe(2000)
+  })
+
+  it('endet bei Änderung in einer Animationsumgebung exakt am Zielwert', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }))
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+    let frames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      frames.push(cb)
+      return frames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    const flush = (t: number) => {
+      const anstehend = frames
+      frames = []
+      act(() => {
+        anstehend.forEach((cb) => {
+          cb(t)
+        })
+      })
+    }
+
+    const { result, rerender } = renderHook(({ ziel }) => useCountUp(ziel), {
+      initialProps: { ziel: 1000 },
+    })
+
+    act(() => {
+      rerender({ ziel: 2001 })
+    })
+
+    // Auf halber Strecke zählt der Hook, hat den Zielwert aber noch nicht erreicht.
+    flush(350)
+    expect(result.current).toBeGreaterThan(1000)
+    expect(result.current).toBeLessThan(2001)
+
+    // Nach Ablauf der Dauer steht exakt der Zielwert (auch bei ungeradem Delta).
+    flush(700)
+    expect(result.current).toBe(2001)
+  })
+})

--- a/frontend/src/hooks/use-count-up.ts
+++ b/frontend/src/hooks/use-count-up.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react'
+
+const DAUER_MS = 700
+
+/**
+ * Zählt einen ganzzahligen Wert (z. B. Cent-Beträge) bei Änderung über 700 ms
+ * animiert vom alten zum neuen Wert (ease-out-cubic `1-(1-p)^3`, per
+ * `requestAnimationFrame`) und endet exakt am Zielwert. Beim ersten Rendern
+ * wird nicht animiert — der Startwert steht bereits.
+ *
+ * Ohne Animationsumgebung — reduzierte Bewegung, fehlendes
+ * `requestAnimationFrame` oder `matchMedia` (jsdom/Testumgebung) — erscheint
+ * sofort der Zielwert. In jsdom hat rAF keine echte Zeitbasis; Tests prüfen
+ * deshalb den Endzustand, nicht die Zwischenwerte.
+ */
+export function useCountUp(ziel: number): number {
+  const [wert, setWert] = useState(ziel)
+  // Zuletzt angezeigter Wert: Startpunkt der nächsten Animation und Grundlage
+  // der Änderungserkennung. Liegt in einem Ref, um kein zusätzliches Rendern
+  // auszulösen (der Ref wird nur im Effekt gelesen und geschrieben).
+  const angezeigtRef = useRef(ziel)
+
+  useEffect(() => {
+    const von = angezeigtRef.current
+    // Kein Wechsel (u. a. erstes Rendern): nichts zu animieren.
+    if (von === ziel) return
+    if (!animierbar()) {
+      // Ohne Animation direkt auf den Zielwert springen. Das synchrone setState
+      // ist hier gewollt und unvermeidbar (das gerenderte Ergebnis muss den
+      // neuen Wert zeigen), daher die Ausnahme von der set-state-in-effect-Regel.
+      angezeigtRef.current = ziel
+      // eslint-disable-next-line react-x/set-state-in-effect
+      setWert(ziel)
+      return
+    }
+    const t0 = performance.now()
+    let frame = requestAnimationFrame(function schritt(t) {
+      const p = Math.min(1, (t - t0) / DAUER_MS)
+      const e = 1 - Math.pow(1 - p, 3)
+      const aktuell = Math.round(von + (ziel - von) * e)
+      angezeigtRef.current = aktuell
+      setWert(aktuell)
+      if (p < 1) frame = requestAnimationFrame(schritt)
+    })
+    return () => {
+      cancelAnimationFrame(frame)
+    }
+  }, [ziel])
+
+  return wert
+}
+
+/**
+ * Prüft, ob animiert werden darf: nur mit echter rAF-Zeitbasis und ohne die
+ * Nutzerpräferenz für reduzierte Bewegung. Fehlt `matchMedia` (jsdom), gilt die
+ * Umgebung als nicht animierbar, sodass der Hook sofort den Zielwert liefert.
+ */
+function animierbar(): boolean {
+  return (
+    typeof requestAnimationFrame === 'function' &&
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  )
+}

--- a/frontend/src/hooks/use-erst-aufbau.ts
+++ b/frontend/src/hooks/use-erst-aufbau.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Meldet `true` genau beim ersten Rendern, in dem `bereit` gilt (dem „ersten
+ * Aufbau" einer Liste), danach dauerhaft `false`. So animiert der
+ * Listen-Eintritt nur beim ersten Aufbau und nie bei späteren Daten-Refetches.
+ *
+ * `bereit` überspringt das Skeleton-Vorspiel: Solange die Liste noch lädt
+ * (`bereit === false`), zählt kein Aufbau; erst das erste Rendern mit Daten
+ * löst den Eintritt aus.
+ *
+ * Das Flag liegt bewusst in einem Ref: Es darf kein zusätzliches Rendern
+ * auslösen, sonst würde die frisch gestartete Animation abgerissen. Der Ref wird
+ * ausschließlich im Effekt geschrieben und beim Rendern gelesen — Letzteres
+ * meldet die Lint-Regel `react-hooks/refs`, hier ist es aber genau das gewollte
+ * Verhalten (der Wert steuert nur die Animationsklasse, nicht die Darstellung).
+ */
+export function useErstAufbau(bereit: boolean): boolean {
+  const aufgebautRef = useRef(false)
+  useEffect(() => {
+    if (bereit) {
+      aufgebautRef.current = true
+    }
+  }, [bereit])
+  // eslint-disable-next-line react-hooks/refs
+  return bereit && !aufgebautRef.current
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -356,7 +356,11 @@
   *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    /* Auch Verzögerungen nullen: gestaffelte Listen-Eintritte (animation-delay)
+       dürfen Inhalte sonst trotz fill-mode:both sekundenlang verborgen halten. */
+    animation-delay: 0ms !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
     scroll-behavior: auto !important;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,7 @@
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
 @import '@fontsource-variable/inter';
+@import '@fontsource-variable/space-grotesk';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -45,7 +46,7 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
-  --font-heading: var(--font-sans);
+  --font-heading: 'Space Grotesk Variable', 'Inter Variable', sans-serif;
   --font-sans: 'Inter Variable', sans-serif;
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
@@ -125,6 +126,28 @@
   /* olive-200 */
   --sidebar-ring: oklch(0.62 0.031 106.9);
   /* olive-600, wie --ring */
+
+  /* Spektral-Marke (Light) — wertidentisch aus website/src/styles/brand.css.
+     Erscheint nur an den vier erlaubten Stellen (Wortmarke, Glows, Skeletons,
+     Hairlines); --spectral-v und die --sp-*-text-Varianten der Website werden
+     nicht übernommen (kein Konsument in der App). */
+  --sp-red: #d24a2a;
+  --sp-orange: #c8781e;
+  --sp-yellow: #8f9a2c;
+  --sp-green: #4f9636;
+  --sp-teal: #1f9b8a;
+  --sp-blue: #2f6fc4;
+  --sp-indigo: #4a4fc0;
+  --sp-violet: #8b3fc0;
+  --spectral: linear-gradient(
+    100deg,
+    #d24a2a,
+    #c8781e,
+    #4f9636,
+    #1f9b8a,
+    #2f6fc4,
+    #8b3fc0
+  );
 }
 
 .dark {
@@ -199,6 +222,25 @@
   /* white 10% */
   --sidebar-ring: oklch(0.58 0.031 107.3);
   /* olive-500 */
+
+  /* Spektral-Marke (Dark) — wertidentisch aus website/src/styles/brand.css.
+     Die Website überschreibt im Dunkeln nur fünf Töne (red, green, teal, blue,
+     violet); der Dark-Verlauf ist aus den effektiven Dark-Tönen rekomponiert
+     (Orange bleibt der Light-Ton). */
+  --sp-red: #e2603f;
+  --sp-green: #5fb045;
+  --sp-teal: #28b8a3;
+  --sp-blue: #4b86dd;
+  --sp-violet: #a457dd;
+  --spectral: linear-gradient(
+    100deg,
+    #e2603f,
+    #c8781e,
+    #5fb045,
+    #28b8a3,
+    #4b86dd,
+    #a457dd
+  );
 }
 
 @layer base {
@@ -212,5 +254,109 @@
 
   html {
     @apply font-sans;
+  }
+}
+
+/* Zentrales Animations-Inventar (Handoff „Motion-Inventar"). Keyframes global,
+   Utilities über @utility — Einsatzstellen konsumieren nur die benannten
+   Klassen, keine Ad-hoc-Animationen pro Stelle. Dauern/Easings sind die
+   kanonischen Werte des Inventars; Stellen mit variabler Dauer (Listen-Stagger,
+   Login-Glows) setzen die Dauer je Instanz zusätzlich. */
+@keyframes shimmer {
+  0% {
+    background-position: 150% 0;
+  }
+  100% {
+    background-position: -50% 0;
+  }
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(7px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.07);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes pulsedot {
+  0% {
+    box-shadow: 0 0 0 0 rgb(16 185 129 / 0.5);
+  }
+  70% {
+    box-shadow: 0 0 0 7px transparent;
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+@keyframes drift {
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(16px, -12px);
+  }
+}
+
+@utility animate-fade-up {
+  animation: fadeUp 250ms ease both;
+}
+
+@utility animate-pop {
+  animation: pop 350ms ease both;
+}
+
+@utility animate-pulsedot {
+  animation: pulsedot 2.4s ease-out infinite;
+}
+
+@utility animate-drift {
+  animation: drift 18s ease-in-out infinite alternate;
+}
+
+/* Skeleton-Shimmer: Muted-Verlauf mit leichter Teal-/Violett-Tönung
+   (Handoff-Rezept), löst in Phase 4 das graue animate-pulse ab. */
+@utility skeleton-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--muted) 20%,
+    color-mix(in oklab, var(--sp-teal) 14%, var(--muted)) 40%,
+    color-mix(in oklab, var(--sp-violet) 10%, var(--muted)) 55%,
+    var(--muted) 80%
+  );
+  background-size: 220% 100%;
+  animation: shimmer 1.6s linear infinite;
+}
+
+/* Barrierefreiheit: reduzierte Bewegung nullt alle Animationen und Transitions
+   global (erfasst auch tw-animate-css und die Bestands-Übergänge). */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -335,7 +335,7 @@
 }
 
 /* Skeleton-Shimmer: Muted-Verlauf mit leichter Teal-/Violett-Tönung
-   (Handoff-Rezept), löst in Phase 4 das graue animate-pulse ab. */
+   (Handoff-Rezept), löst den früheren grauen Puls-Platzhalter ab. */
 @utility skeleton-shimmer {
   background: linear-gradient(
     90deg,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -297,8 +297,12 @@
 }
 
 @keyframes pulsedot {
+  /* Ring-Farbe aus --primary abgeleitet (nicht die Handoff-Festfarbe
+     rgb(16 185 129)), damit der Puls in Hell und Dunkel zum grünen
+     StatusDot (bg-primary) passt — die Festfarbe entspricht nur dem
+     Dark-Primary. */
   0% {
-    box-shadow: 0 0 0 0 rgb(16 185 129 / 0.5);
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--primary) 50%, transparent);
   }
   70% {
     box-shadow: 0 0 0 7px transparent;

--- a/frontend/src/pages/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage.tsx
@@ -1,6 +1,7 @@
 import { isRouteErrorResponse, useNavigate, useRouteError } from 'react-router'
 
 import { AuthLayout } from '@/components/common/AuthLayout'
+import { Wortmarke } from '@/components/common/Wortmarke'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
 
@@ -18,7 +19,7 @@ function FehlerAnzeige({ titel, text }: FehlerAnzeigeProps) {
     <AuthLayout>
       <Card className="w-full max-w-sm">
         <CardHeader>
-          <h1 className="text-4xl text-center font-extrabold">jotti</h1>
+          <Wortmarke as="h1" className="text-[38px] text-center" />
         </CardHeader>
         <CardContent className="text-center space-y-2">
           <h2 className="text-lg font-semibold">{titel}</h2>

--- a/frontend/src/pages/HydrateFallbackPage.tsx
+++ b/frontend/src/pages/HydrateFallbackPage.tsx
@@ -1,3 +1,4 @@
+import { Wortmarke } from '@/components/common/Wortmarke'
 import { Spinner } from '@/components/ui/spinner'
 
 // Wird von React Router beim Erstladen gerendert, solange der initiale
@@ -6,7 +7,7 @@ import { Spinner } from '@/components/ui/spinner'
 export function HydrateFallbackPage() {
   return (
     <div className="flex flex-col min-h-screen items-center justify-center gap-4 bg-primary/5">
-      <h1 className="text-4xl text-center font-extrabold">jotti</h1>
+      <Wortmarke as="h1" className="text-[38px] text-center" />
       <Spinner className="size-6" />
     </div>
   )

--- a/frontend/src/service/DirektverkaufPage.tsx
+++ b/frontend/src/service/DirektverkaufPage.tsx
@@ -1,8 +1,11 @@
+import { useCallback, useState } from 'react'
+
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { BackendSingleton } from '@/lib/Backend'
 
 import { Direktverkauf } from './components/direktverkauf/Direktverkauf'
 import { DirektverkaufHistorie } from './components/direktverkauf/DirektverkaufHistorie'
+import { ErfolgsPop } from './components/ErfolgsPop'
 import { ServiceDock } from './components/ServiceDock'
 import { DirektverkaufBackend } from './direktverkauf/DirektverkaufBackend'
 import { useDirektverkaufHistorie } from './direktverkauf/hooks'
@@ -23,41 +26,58 @@ export function DirektverkaufPage() {
     refetch: reloadHistorie,
   } = useDirektverkaufHistorie()
 
+  // Erfolgs-Pop: Der abgeschlossene Verkauf öffnet ihn mit seiner Meldung (statt
+  // eines Erfolgs-Toasts). Der Refetch der Historie läuft erst beim Schließen,
+  // damit der neue Eintrag dem Pop folgt. Der Storno-Pfad lädt weiterhin sofort.
+  const [erfolg, setErfolg] = useState({ open: false, text: '' })
+  const zeigeErfolg = useCallback((nachricht: string) => {
+    setErfolg({ open: true, text: nachricht })
+  }, [])
+  const erfolgSchliessen = useCallback(() => {
+    setErfolg((prev) => ({ ...prev, open: false }))
+    void reloadHistorie()
+  }, [reloadHistorie])
+
   return (
-    <Tabs defaultValue="verkaufen">
-      <ServiceDock
-        leiste={
-          <TabsList className="h-10 w-full">
-            <TabsTrigger value="verkaufen" className="flex-1">
-              Verkaufen
-            </TabsTrigger>
-            <TabsTrigger value="historie" className="flex-1">
-              Historie
-            </TabsTrigger>
-          </TabsList>
-        }
-      >
-        <TabsContent value="verkaufen" className={dockFreiraum}>
-          <Direktverkauf
-            backend={direktverkaufBackend}
-            products={produkte}
-            productsLoading={isPending}
-            onVerkauft={() => {
-              void reloadHistorie()
-            }}
-          />
-        </TabsContent>
-        <TabsContent value="historie" className={dockFreiraum}>
-          <DirektverkaufHistorie
-            historie={historie}
-            historieLoading={historieLoading}
-            backend={direktverkaufBackend}
-            onStorniert={() => {
-              void reloadHistorie()
-            }}
-          />
-        </TabsContent>
-      </ServiceDock>
-    </Tabs>
+    <>
+      <Tabs defaultValue="verkaufen">
+        <ServiceDock
+          leiste={
+            <TabsList className="h-10 w-full">
+              <TabsTrigger value="verkaufen" className="flex-1">
+                Verkaufen
+              </TabsTrigger>
+              <TabsTrigger value="historie" className="flex-1">
+                Historie
+              </TabsTrigger>
+            </TabsList>
+          }
+        >
+          <TabsContent value="verkaufen" className={dockFreiraum}>
+            <Direktverkauf
+              backend={direktverkaufBackend}
+              products={produkte}
+              productsLoading={isPending}
+              onErfolg={zeigeErfolg}
+            />
+          </TabsContent>
+          <TabsContent value="historie" className={dockFreiraum}>
+            <DirektverkaufHistorie
+              historie={historie}
+              historieLoading={historieLoading}
+              backend={direktverkaufBackend}
+              onStorniert={() => {
+                void reloadHistorie()
+              }}
+            />
+          </TabsContent>
+        </ServiceDock>
+      </Tabs>
+      <ErfolgsPop
+        open={erfolg.open}
+        text={erfolg.text}
+        onDismiss={erfolgSchliessen}
+      />
+    </>
   )
 }

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -67,7 +67,7 @@ export function TablePage() {
     <>
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-[22px] font-semibold leading-tight">
+          <h1 className="font-heading text-[22px] font-semibold leading-tight">
             {stateLoading ? 'Tisch ??' : tisch.name}
           </h1>
           {!stateLoading && (

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react'
 import { useParams } from 'react-router'
 
 import { LadefehlerAlert } from '@/components/common/LadefehlerAlert'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useErstAufbau } from '@/hooks/use-erst-aufbau'
 import { BackendSingleton } from '@/lib/Backend'
 import { formatCents } from '@/lib/utils'
 
@@ -15,6 +17,41 @@ import { useTischHistorie, useTischState } from './table/hooks'
 import { TischBackend } from './table/TischBackend'
 
 const tischBackend = new TischBackend(BackendSingleton)
+
+// Das Status-Badge poppt bei jedem Wertwechsel (Motion-Inventar „Statuswechsel",
+// 350 ms), aber nicht beim ersten Aufbau. Der key-Wechsel auf den Zählwert
+// remountet StatusBadgeInhalt, das seine Pop-Entscheidung beim Mount erfasst:
+// Beim ersten Aufbau ist `animieren` noch false; nach dem ersten Aufbau mountet
+// jeder neue Wert mit true und poppt.
+function TischStatusBadge({ anzahlUnbezahlt }: { anzahlUnbezahlt: number }) {
+  const erstAufbau = useErstAufbau(true)
+  return (
+    <StatusBadgeInhalt
+      key={anzahlUnbezahlt}
+      anzahlUnbezahlt={anzahlUnbezahlt}
+      animieren={!erstAufbau}
+    />
+  )
+}
+
+function StatusBadgeInhalt({
+  anzahlUnbezahlt,
+  animieren,
+}: {
+  anzahlUnbezahlt: number
+  animieren: boolean
+}) {
+  const [poppen] = useState(animieren)
+  const popKlasse = poppen ? 'animate-pop' : undefined
+
+  return anzahlUnbezahlt > 0 ? (
+    <Badge variant="destructive" className={popKlasse}>
+      {anzahlUnbezahlt} unbezahlt
+    </Badge>
+  ) : (
+    <Badge className={popKlasse}>Alles bezahlt</Badge>
+  )
+}
 
 // Unterer Freiraum des Tab-Inhalts in Dock-Höhe, damit die letzte Listenzeile
 // über dem fixierten ServiceDock endet und antippbar bleibt. Das Dock ist der
@@ -72,11 +109,7 @@ export function TablePage() {
           </h1>
           {!stateLoading && (
             <div className="mt-1.5 flex flex-wrap items-center gap-2">
-              {anzahlUnbezahlt > 0 ? (
-                <Badge variant="destructive">{anzahlUnbezahlt} unbezahlt</Badge>
-              ) : (
-                <Badge>Alles bezahlt</Badge>
-              )}
+              <TischStatusBadge anzahlUnbezahlt={anzahlUnbezahlt} />
               <span className="text-sm text-muted-foreground">
                 {state.fuerMichErledigt
                   ? 'Für dich erledigt'

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useParams } from 'react-router'
 
 import { LadefehlerAlert } from '@/components/common/LadefehlerAlert'
@@ -8,6 +8,7 @@ import { useErstAufbau } from '@/hooks/use-erst-aufbau'
 import { BackendSingleton } from '@/lib/Backend'
 import { formatCents } from '@/lib/utils'
 
+import { ErfolgsPop } from './components/ErfolgsPop'
 import { ServiceDock } from './components/ServiceDock'
 import { Bestellung } from './components/table/Bestellung'
 import { TischHistorie } from './components/table/TischHistorie'
@@ -75,10 +76,23 @@ export function TablePage() {
     refetch: reloadHistorie,
   } = useTischHistorie(Number(tischId))
 
-  const reload = () => {
+  const reload = useCallback(() => {
     void reloadState()
     void reloadHistorie()
-  }
+  }, [reloadState, reloadHistorie])
+
+  // Erfolgs-Pop: Bestellen und Kassieren öffnen ihn mit ihrer Meldung (statt
+  // eines Erfolgs-Toasts). Der nachgelagerte Refetch (reload) läuft erst beim
+  // Schließen, damit sichtbare Statuswechsel (Saldo, Badge, Listen) dem Pop
+  // folgen. Der Stornierungs-/Umbuchungspfad der Historie lädt weiterhin sofort.
+  const [erfolg, setErfolg] = useState({ open: false, text: '' })
+  const zeigeErfolg = useCallback((nachricht: string) => {
+    setErfolg({ open: true, text: nachricht })
+  }, [])
+  const erfolgSchliessen = useCallback(() => {
+    setErfolg((prev) => ({ ...prev, open: false }))
+    reload()
+  }, [reload])
 
   // Expliziter Fehlerzustand statt der Leer-Defaults (Saldo 0,00 €) — sonst
   // wirkt der Tisch bei Netzabbruch abgerechnet.
@@ -172,7 +186,7 @@ export function TablePage() {
                 tisch={tisch}
                 products={produkte}
                 productsLoading={isPending}
-                onBestellungAufgenommen={reload}
+                onErfolg={zeigeErfolg}
               />
             )}
           </TabsContent>
@@ -182,7 +196,7 @@ export function TablePage() {
                 backend={tischBackend}
                 tisch={tisch}
                 positionen={state.unbezahltePositionen}
-                onZahlungKassiert={reload}
+                onErfolg={zeigeErfolg}
               />
             )}
           </TabsContent>
@@ -200,6 +214,11 @@ export function TablePage() {
           </TabsContent>
         </ServiceDock>
       </Tabs>
+      <ErfolgsPop
+        open={erfolg.open}
+        text={erfolg.text}
+        onDismiss={erfolgSchliessen}
+      />
     </>
   )
 }

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router'
 import { LadefehlerAlert } from '@/components/common/LadefehlerAlert'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useCountUp } from '@/hooks/use-count-up'
 import { useErstAufbau } from '@/hooks/use-erst-aufbau'
 import { BackendSingleton } from '@/lib/Backend'
 import { formatCents } from '@/lib/utils'
@@ -76,6 +77,10 @@ export function TablePage() {
     refetch: reloadHistorie,
   } = useTischHistorie(Number(tischId))
 
+  // Der Saldo zählt bei jeder Änderung animiert zum neuen Wert (u. a. nach dem
+  // Schließen des Erfolgs-Pops, wenn der Refetch den Tischzustand aktualisiert).
+  const animierterSaldo = useCountUp(state.saldoCents)
+
   const reload = useCallback(() => {
     void reloadState()
     void reloadHistorie()
@@ -140,7 +145,7 @@ export function TablePage() {
             data-slot="tisch-saldo"
             className="text-xl font-bold tabular-nums"
           >
-            {stateLoading ? '?' : <>{formatCents(state.saldoCents)}&nbsp;€</>}
+            {stateLoading ? '?' : <>{formatCents(animierterSaldo)}&nbsp;€</>}
           </div>
         </div>
       </div>

--- a/frontend/src/service/TableSelectionPage.tsx
+++ b/frontend/src/service/TableSelectionPage.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from '@/components/common/EmptyState'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
+import { useErstAufbau } from '@/hooks/use-erst-aufbau'
 
 import { EigeneUebersichtKarten } from './components/EigeneUebersicht'
 import { MeinTischCard } from './components/MeinTischCard'
@@ -32,6 +33,13 @@ export function TableSelectionPage() {
   )
   const erledigteTische = gefilterteTische.filter(
     (state) => state.unbezahltePositionen.length === 0,
+  )
+
+  // Der Listen-Eintritt staffelt nur beim ersten Aufbau mit Daten (nicht beim
+  // Skeleton, nicht bei späteren Refetches). Beide Gruppen teilen sich eine
+  // fortlaufende Staffelung: „Erledigt" setzt hinter „Noch offen" fort.
+  const erstAufbau = useErstAufbau(
+    !tischeLoading && gefilterteTische.length > 0,
   )
 
   return (
@@ -88,10 +96,18 @@ export function TableSelectionPage() {
       ) : (
         <div className="space-y-6">
           {offeneTische.length > 0 && (
-            <TischGruppe titel="Noch offen" tische={offeneTische} />
+            <TischGruppe
+              titel="Noch offen"
+              tische={offeneTische}
+              eintrittAb={erstAufbau ? 0 : null}
+            />
           )}
           {erledigteTische.length > 0 && (
-            <TischGruppe titel="Erledigt" tische={erledigteTische} />
+            <TischGruppe
+              titel="Erledigt"
+              tische={erledigteTische}
+              eintrittAb={erstAufbau ? offeneTische.length : null}
+            />
           )}
         </div>
       )}
@@ -119,9 +135,13 @@ export function TableSelectionPage() {
 function TischGruppe({
   titel,
   tische,
+  eintrittAb,
 }: {
   titel: string
   tische: TischSession[]
+  // Start-Index der Eintritts-Staffelung oder `null`, wenn nicht animiert
+  // eingetreten werden soll.
+  eintrittAb: number | null
 }) {
   return (
     <section className="space-y-3">
@@ -129,8 +149,12 @@ function TischGruppe({
         {titel} · {tische.length}
       </h2>
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 2xl:grid-cols-3">
-        {tische.map((state) => (
-          <MeinTischCard key={state.tischId} state={state} />
+        {tische.map((state, index) => (
+          <MeinTischCard
+            key={state.tischId}
+            state={state}
+            eintrittIndex={eintrittAb === null ? undefined : eintrittAb + index}
+          />
         ))}
       </div>
     </section>

--- a/frontend/src/service/components/ErfolgsPop.test.tsx
+++ b/frontend/src/service/components/ErfolgsPop.test.tsx
@@ -1,0 +1,166 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Produkt } from '../product/Produkt'
+import { Direktverkauf } from './direktverkauf/Direktverkauf'
+import { ErfolgsPop } from './ErfolgsPop'
+import { ServiceDock } from './ServiceDock'
+
+// toast wird über useActionSubmit (Fehlerpfad) importiert; die Erfolgs-Flows
+// dürfen ihn nicht mehr aufrufen, was der Flow-Test unten prüft.
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+describe('ErfolgsPop', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  it('zeigt bei geöffnetem Pop den Bestätigungstext als Status-Region', () => {
+    render(<ErfolgsPop open text="Zahlung erfolgreich." onDismiss={vi.fn()} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Zahlung erfolgreich.')
+  })
+
+  it('rendert nichts, solange es geschlossen ist', () => {
+    render(
+      <ErfolgsPop
+        open={false}
+        text="Zahlung erfolgreich."
+        onDismiss={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('schließt nach Ablauf der Anzeigedauer automatisch', () => {
+    const onDismiss = vi.fn()
+    render(<ErfolgsPop open text="Fertig" onDismiss={onDismiss} />)
+
+    expect(onDismiss).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(1400)
+    })
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('schließt beim Antippen sofort, noch vor der Auto-Dismiss-Zeit', () => {
+    const onDismiss = vi.fn()
+    render(<ErfolgsPop open text="Fertig" onDismiss={onDismiss} />)
+
+    fireEvent.click(screen.getByRole('status'))
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+})
+
+const testProdukt: Produkt = {
+  id: 1,
+  name: 'Bratwurst',
+  kategorie: 'essen',
+  status: 'active',
+  varianten: [
+    {
+      id: 1,
+      name: 'Normal',
+      preisCents: 350,
+      status: 'active',
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    },
+  ],
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+}
+
+// Spiegelt die Verdrahtung der Buchungsseiten wider: Der Erfolg öffnet den Pop
+// (statt eines Toasts), und der nachgelagerte Refetch (hier `reload`) läuft erst
+// beim Schließen.
+function DirektverkaufMitPop({
+  direktverkaufTaetigen,
+  reload,
+}: {
+  direktverkaufTaetigen: () => Promise<void>
+  reload: () => void
+}) {
+  const [erfolg, setErfolg] = useState({ open: false, text: '' })
+  return (
+    <ServiceDock leiste={null}>
+      <Direktverkauf
+        backend={{ direktverkaufTaetigen }}
+        products={[testProdukt]}
+        productsLoading={false}
+        onErfolg={(nachricht) => {
+          setErfolg({ open: true, text: nachricht })
+        }}
+      />
+      <ErfolgsPop
+        open={erfolg.open}
+        text={erfolg.text}
+        onDismiss={() => {
+          setErfolg((prev) => ({ ...prev, open: false }))
+          reload()
+        }}
+      />
+    </ServiceDock>
+  )
+}
+
+describe('Erfolgs-Pop im Buchungsflow', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('öffnet den Pop ohne Erfolgs-Toast und lädt erst nach dem Schließen nach', async () => {
+    const { toast } = await import('sonner')
+    const user = userEvent.setup()
+    const reload = vi.fn()
+    const direktverkaufTaetigen = vi.fn().mockResolvedValue(undefined)
+    render(
+      <DirektverkaufMitPop
+        direktverkaufTaetigen={direktverkaufTaetigen}
+        reload={reload}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Variante hinzufügen' }),
+    )
+    await user.click(screen.getByRole('button', { name: /Kassieren/ }))
+    await screen.findByRole('dialog')
+    await user.click(
+      screen.getByRole('button', { name: 'Verkauf abschließen' }),
+    )
+
+    // Der Pop erscheint mit der Bestätigung; der Refetch läuft noch nicht und es
+    // gibt keinen Erfolgs-Toast mehr.
+    const pop = await screen.findByText('Verkauf abgeschlossen.')
+    expect(reload).not.toHaveBeenCalled()
+    expect(toast.success).not.toHaveBeenCalled()
+
+    // Tap schließt den Pop und löst erst dann den nachgelagerten Refetch aus.
+    await user.click(pop)
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Verkauf abgeschlossen.'),
+      ).not.toBeInTheDocument()
+    })
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/service/components/ErfolgsPop.tsx
+++ b/frontend/src/service/components/ErfolgsPop.tsx
@@ -1,0 +1,47 @@
+import { Check } from 'lucide-react'
+import { useEffect } from 'react'
+
+// Anzeigedauer bis zum automatischen Schließen (Motion-Inventar „Erfolgs-Pop",
+// ~1,4 s). Ein Tippen schließt jederzeit früher.
+const ANZEIGE_DAUER_MS = 1400
+
+interface ErfolgsPopProps {
+  open: boolean
+  text: string
+  onDismiss: () => void
+}
+
+// Unübersehbare Buchungsbestätigung im Service: Vollbild-Overlay mit geblurtem
+// Backdrop und Häkchen-Kreis in Primärgrün, das nach kurzer Zeit automatisch
+// wieder verschwindet. Ersetzt in den drei Buchungsflows (Bestellen, Kassieren,
+// Direktverkauf) den bisherigen Erfolgs-Toast. role="status" lässt Screenreader
+// den Text wie zuvor den Toast ankündigen. Der Pop meldet das Schließen (Auto
+// oder Tap) über onDismiss; der nachgelagerte Statuswechsel/Refetch folgt erst
+// dann, sodass sichtbare Änderungen dem Pop folgen.
+export function ErfolgsPop({ open, text, onDismiss }: ErfolgsPopProps) {
+  useEffect(() => {
+    if (!open) return
+    const timer = setTimeout(onDismiss, ANZEIGE_DAUER_MS)
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [open, onDismiss])
+
+  if (!open) return null
+
+  return (
+    <div
+      role="status"
+      onClick={onDismiss}
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-5 bg-[color-mix(in_oklab,var(--background)_55%,transparent)] backdrop-blur-[6px]"
+    >
+      {/* Spring-Pop (450 ms) statt der kanonischen 350 ms von animate-pop. */}
+      <div className="flex size-[76px] items-center justify-center rounded-full bg-primary text-white ring-8 ring-primary/15 animate-pop [animation-duration:450ms] [animation-timing-function:cubic-bezier(0.34,1.56,0.64,1)]">
+        <Check className="size-[34px]" strokeWidth={3} aria-hidden />
+      </div>
+      <p className="animate-fade-up text-[17px] font-semibold [animation-delay:100ms] [animation-duration:350ms]">
+        {text}
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/service/components/MeinTischCard.tsx
+++ b/frontend/src/service/components/MeinTischCard.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight } from 'lucide-react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { AuthSingleton } from '@/lib/Auth'
@@ -8,10 +9,16 @@ import type { TischSession } from '../table/Tisch'
 
 interface MeinTischCardProps {
   state: TischSession
+  // Position in der Eintritts-Staffelung (0-basiert) oder `undefined`, wenn die
+  // Karte nicht animiert eintreten soll (z. B. nach einem Refetch).
+  eintrittIndex?: number
 }
 
-export function MeinTischCard({ state }: MeinTischCardProps) {
+export function MeinTischCard({ state, eintrittIndex }: MeinTischCardProps) {
   const navigate = useNavigate()
+  // Beim Mount erfasst: so bleibt die Staffelung stabil, wenn die Elternliste
+  // während der Animation neu rendert (Übersicht-Query trifft separat ein).
+  const [eintritt] = useState(eintrittIndex)
 
   const handleClick = () => {
     void navigate(`/service/tische/${state.tischId.toString()}`)
@@ -30,9 +37,19 @@ export function MeinTischCard({ state }: MeinTischCardProps) {
     <button
       type="button"
       onClick={handleClick}
+      // Listen-Eintritt (Handoff): fadeUp 450 ms, 60 ms Stagger je Karte, nur
+      // beim ersten Aufbau. Der Verzögerungswert ist dynamisch und steht daher
+      // inline; die weiche Kurve überschreibt die kanonische 250-ms-ease-Utility.
+      style={
+        eintritt === undefined
+          ? undefined
+          : { animationDelay: `${(eintritt * 60).toString()}ms` }
+      }
       className={cn(
         'flex w-full items-center gap-3 rounded-xl bg-card p-4 text-left ring-1 ring-foreground/10 transition-colors hover:bg-accent/50',
         alleErledigt && 'opacity-75',
+        eintritt !== undefined &&
+          'animate-fade-up [animation-duration:450ms] [animation-timing-function:cubic-bezier(0.2,0.7,0.3,1)]',
       )}
     >
       <span

--- a/frontend/src/service/components/Stepper.tsx
+++ b/frontend/src/service/components/Stepper.tsx
@@ -18,6 +18,9 @@ interface StepperProps {
 // hat feste Breite, damit der Zustandswechsel keinen Layout-Shift auslöst.
 // addDisabled deckelt das Plus dort, wo eine Höchstmenge gilt (z. B. die
 // unbezahlte Menge einer Position).
+// Beide Tasten geben ein deutlich stärkeres Press-Feedback als der Standard-
+// Button (scale .92 statt .99); die transform-only-Transition (100 ms linear)
+// hält das Eindrücken knackig gemäß Motion-Inventar.
 export function Stepper({
   menge,
   onAdd,
@@ -33,7 +36,7 @@ export function Stepper({
       <Button
         size="icon"
         variant="outline"
-        className="size-11 rounded-full"
+        className="size-11 rounded-full transition-transform duration-100 ease-linear active:not-aria-[haspopup]:scale-[.92]"
         aria-label={removeLabel}
         disabled={leer}
         onClick={(e) => {
@@ -48,7 +51,7 @@ export function Stepper({
       </span>
       <Button
         size="icon"
-        className="size-11 rounded-full"
+        className="size-11 rounded-full transition-transform duration-100 ease-linear active:not-aria-[haspopup]:scale-[.92]"
         aria-label={addLabel}
         disabled={addDisabled}
         onClick={(e) => {

--- a/frontend/src/service/components/direktverkauf/Direktverkauf.tsx
+++ b/frontend/src/service/components/direktverkauf/Direktverkauf.tsx
@@ -1,5 +1,3 @@
-import { toast } from 'sonner'
-
 import { useMengen } from '@/hooks/use-mengen'
 
 import type { DirektverkaufBackend } from '../../direktverkauf/DirektverkaufBackend'
@@ -12,14 +10,16 @@ interface DirektverkaufProps {
   backend: Pick<DirektverkaufBackend, 'direktverkaufTaetigen'>
   products: Produkt[]
   productsLoading: boolean
-  onVerkauft?: () => void
+  // Meldet den abgeschlossenen Verkauf samt Bestätigungstext an die Seite, die
+  // den Erfolgs-Pop hostet (früher ein toast.success plus direkter Refetch).
+  onErfolg?: (nachricht: string) => void
 }
 
 export function Direktverkauf({
   backend,
   products,
   productsLoading,
-  onVerkauft,
+  onErfolg,
 }: DirektverkaufProps) {
   const { mengen, add, remove, reset } = useMengen<number>()
 
@@ -41,8 +41,7 @@ export function Direktverkauf({
         totalCents={total}
         verkaufAbgeschlossen={() => {
           reset()
-          toast.success('Verkauf abgeschlossen.')
-          onVerkauft?.()
+          onErfolg?.('Verkauf abgeschlossen.')
         }}
       />
       <ProductList

--- a/frontend/src/service/components/table/Bestellung.test.tsx
+++ b/frontend/src/service/components/table/Bestellung.test.tsx
@@ -48,7 +48,7 @@ describe('Bestellung Aktionsleiste', () => {
           tisch={tisch}
           products={[testProdukt]}
           productsLoading={false}
-          onBestellungAufgenommen={vi.fn()}
+          onErfolg={vi.fn()}
         />
       </ServiceDock>,
     )

--- a/frontend/src/service/components/table/Bestellung.tsx
+++ b/frontend/src/service/components/table/Bestellung.tsx
@@ -1,5 +1,3 @@
-import { toast } from 'sonner'
-
 import { useMengen } from '@/hooks/use-mengen'
 
 import type { Produkt } from '../../product/Produkt'
@@ -13,7 +11,9 @@ interface BestellungProps {
   tisch: Tisch
   products: Produkt[]
   productsLoading: boolean
-  onBestellungAufgenommen: () => void
+  // Meldet die erfolgreiche Buchung samt Bestätigungstext an die Seite, die den
+  // Erfolgs-Pop hostet (früher ein toast.success plus direkter Refetch).
+  onErfolg: (nachricht: string) => void
 }
 
 export function Bestellung({
@@ -21,7 +21,7 @@ export function Bestellung({
   tisch,
   products,
   productsLoading,
-  onBestellungAufgenommen,
+  onErfolg,
 }: BestellungProps) {
   const { mengen, add, remove, reset } = useMengen<number>()
 
@@ -38,8 +38,7 @@ export function Bestellung({
         mengen={mengen}
         bestellungAufgenommen={() => {
           reset()
-          toast.success(`Bestellung wurde aufgenommen.`)
-          onBestellungAufgenommen()
+          onErfolg('Bestellung wurde aufgenommen.')
         }}
       />
       <ProductList

--- a/frontend/src/service/components/table/DockActionButton.tsx
+++ b/frontend/src/service/components/table/DockActionButton.tsx
@@ -36,7 +36,13 @@ export function DockActionButton({
         {...props}
       >
         <span className="flex items-center gap-2">
-          <span className="rounded-full bg-primary-foreground/20 px-2 py-0.5 text-sm font-semibold tabular-nums">
+          {/* Die Mengen-Pill poppt bei jeder Mengenänderung: der key-Wechsel
+              remountet den Span, wodurch die pop-Animation neu startet. 250 ms
+              statt der kanonischen 350 ms gemäß Handoff-Delta. */}
+          <span
+            key={anzahl}
+            className="animate-pop rounded-full bg-primary-foreground/20 px-2 py-0.5 text-sm font-semibold tabular-nums [animation-duration:250ms]"
+          >
             {anzahl}
           </span>
           {label}

--- a/frontend/src/service/components/table/Zahlung.test.tsx
+++ b/frontend/src/service/components/table/Zahlung.test.tsx
@@ -57,7 +57,7 @@ function renderZahlung(positionen: Position[] = [position]) {
         }}
         tisch={tisch}
         positionen={positionen}
-        onZahlungKassiert={vi.fn()}
+        onErfolg={vi.fn()}
       />
     </ServiceDock>,
   )

--- a/frontend/src/service/components/table/Zahlung.tsx
+++ b/frontend/src/service/components/table/Zahlung.tsx
@@ -1,6 +1,5 @@
 import { ChevronDown, CircleCheck } from 'lucide-react'
 import { useState } from 'react'
-import { toast } from 'sonner'
 
 import {
   Item,
@@ -30,14 +29,16 @@ interface ZahlungProps {
   backend: Pick<TischBackend, 'zahlungKassieren'>
   tisch: Tisch
   positionen: Position[]
-  onZahlungKassiert: () => void
+  // Meldet die erfolgreiche Zahlung samt Bestätigungstext an die Seite, die den
+  // Erfolgs-Pop hostet (früher ein toast.success plus direkter Refetch).
+  onErfolg: (nachricht: string) => void
 }
 
 export function Zahlung({
   tisch,
   backend,
   positionen,
-  onZahlungKassiert,
+  onErfolg,
 }: ZahlungProps) {
   const [andereOffen, setAndereOffen] = useState(false)
   // Positionen treten nur beim ersten Aufbau gestaffelt ein; nach einer Zahlung
@@ -144,8 +145,7 @@ export function Zahlung({
         restNachZahlungCents={restNachZahlung}
         zahlungKassiert={() => {
           reset()
-          toast.success(`Zahlung erfolgreich.`)
-          onZahlungKassiert()
+          onErfolg('Zahlung erfolgreich.')
         }}
       />
       <div className="my-4 space-y-3">

--- a/frontend/src/service/components/table/Zahlung.tsx
+++ b/frontend/src/service/components/table/Zahlung.tsx
@@ -10,6 +10,7 @@ import {
   ItemGroup,
   ItemTitle,
 } from '@/components/ui/item'
+import { useErstAufbau } from '@/hooks/use-erst-aufbau'
 import { useMengen } from '@/hooks/use-mengen'
 import { AuthSingleton } from '@/lib/Auth'
 import {
@@ -39,6 +40,9 @@ export function Zahlung({
   onZahlungKassiert,
 }: ZahlungProps) {
   const [andereOffen, setAndereOffen] = useState(false)
+  // Positionen treten nur beim ersten Aufbau gestaffelt ein; nach einer Zahlung
+  // (Refetch) bleiben die verbleibenden Zeilen unbewegt.
+  const erstAufbau = useErstAufbau(true)
 
   const unbezahlteMengen: Record<string, number> = {}
   positionen.forEach((position) => {
@@ -109,13 +113,18 @@ export function Zahlung({
     0,
   )
 
-  const renderPosition = (position: Position, showBesteller: boolean) => (
+  const renderPosition = (
+    position: Position,
+    showBesteller: boolean,
+    eintrittIndex?: number,
+  ) => (
     <PositionItem
       key={position.positionId}
       position={position}
       showBesteller={showBesteller}
       menge={mengen[position.positionId] || 0}
       unbezahlteMenge={unbezahlteMengen[position.positionId] || 0}
+      eintrittIndex={eintrittIndex}
       onAdd={() => {
         onAdd(position.positionId)
       }}
@@ -156,7 +165,9 @@ export function Zahlung({
           </button>
         )}
         <ItemGroup className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
-          {meinePositionen.map((position) => renderPosition(position, false))}
+          {meinePositionen.map((position, index) =>
+            renderPosition(position, false, erstAufbau ? index : undefined),
+          )}
         </ItemGroup>
         {anderePositionen.length > 0 && (
           <div className="space-y-2">
@@ -207,6 +218,9 @@ interface PositionItemProps {
   menge: number
   unbezahlteMenge: number
   showBesteller: boolean
+  // Position in der Eintritts-Staffelung (0-basiert) oder `undefined` ohne
+  // animierten Eintritt (z. B. Fremdpositionen oder nach einem Refetch).
+  eintrittIndex?: number
   onAdd: () => void
   onRemove: () => void
 }
@@ -216,18 +230,32 @@ function PositionItem({
   menge,
   unbezahlteMenge,
   showBesteller,
+  eintrittIndex,
   onAdd,
   onRemove,
 }: PositionItemProps) {
   const ausgewaehlt = menge > 0
   const zeilenSumme = menge * position.einzelpreisCents
   const unbezahltSumme = unbezahlteMenge * position.einzelpreisCents
+  // Beim Mount erfasst, damit ein Refetch die Staffelung nicht mittendrin abreißt.
+  const [eintritt] = useState(eintrittIndex)
 
   return (
     <Item
       key={position.positionId}
       variant="outline"
-      className={cn(ausgewaehlt && 'border-primary/60 bg-primary/5')}
+      // Listen-Eintritt (Handoff): fadeUp 450 ms, 60 ms Stagger, weiche Kurve,
+      // nur beim ersten Aufbau. Verzögerung dynamisch → inline.
+      style={
+        eintritt === undefined
+          ? undefined
+          : { animationDelay: `${(eintritt * 60).toString()}ms` }
+      }
+      className={cn(
+        ausgewaehlt && 'border-primary/60 bg-primary/5',
+        eintritt !== undefined &&
+          'animate-fade-up [animation-duration:450ms] [animation-timing-function:cubic-bezier(0.2,0.7,0.3,1)]',
+      )}
     >
       <ItemContent>
         <ItemTitle className="text-[15px]">


### PR DESCRIPTION
Überträgt die Spektral-Markensprache der Website dezent auf das App-Frontend (Login, Service, Verwaltung) und führt das verbindliche Motion-Inventar der PRD ein — als reiner Restyling-Layer, umgesetzt in zehn Phasen (ein Commit je Phase) nach `docs/plans/plan-spektral-redesign-frontend.md`. Spezifikation: `docs/prds/prd-spektral-redesign-frontend.md` + Handoff-Bundle.

**Spektrum nur an vier Stellen:** Wortmarke (`Wortmarke`-Komponente, Gradient-Text-Fill an sechs Einsatzorten), Hintergrund-Glows (drei driftende Login-Kreise, `HeaderGlow`-Ellipsenpaar mit Farbpaar-Prop hinter allen acht Admin-Seitenköpfen), Ladezustände (Spektral-Shimmer statt grauem Pulse an allen Skeletons), Hairline-Akzente (2-px-Kante der Hero-Kennzahlkarte, 3-px-Marker am aktiven Sidebar-Eintrag). Grün bleibt Primärfarbe, Status-Semantik und Layouts unverändert.

**Motion:** Press-Feedback (Buttons scale .99/.96, Stepper .92) · Tab-fadeUp 250 ms · Listen-Stagger 450 ms/60 ms nur beim ersten Aufbau (`useErstAufbau`) · Badge-/Häkchen-Pop 350 ms · Erfolgs-Pop 450 ms Spring mit Tap-to-dismiss (ersetzt die Erfolgs-Toasts in Bestellen/Kassieren/Direktverkauf; Refetch erst nach Dismiss) · Zahlen zählen 700 ms (`useCountUp`, Tisch-Saldo + Übersicht-Kennzahlen) · Skeleton-Shimmer 1,6 s · Live-Puls 2,4 s (nur Kassentag-Chip bei offener Kasse + Live-Punkt) · Login-Glow-Drift 14–22 s. Eine zentrale `prefers-reduced-motion`-Regel nullt sämtliche Animationen, Transitions und Delays.

**Typografie:** Space Grotesk Variable (`@fontsource-variable/space-grotesk`, einzige neue Dependency) als `--font-heading`; Beträge und Fließtext bleiben Inter (tabellarische Ziffern).

**ADR:** `docs/adrs/06_spektral-branding-app.md` löst die Frontend-Ausnahme aus ADR 05 ab (Vier-Stellen-Regel als neue Leitplanke); ADR 05 trägt den Ablöse-Vermerk, die README-Tabelle den neuen Eintrag.

## Checkliste (aus PRD)

- [x] Spektrum nur an den vier definierten Stellen (Light + Dark geprüft)
- [x] Erfolgs-Pop + animierter Saldo beim Kassieren (neue Fake-Timer- und Flow-Tests)
- [x] Skeletons shimmern spektral; `grep animate-pulse frontend/src` ohne Treffer
- [x] Reduced-Motion-Check (Drift/Puls/Shimmer/Transitions stehen, Stagger-Inhalte bleiben sichtbar) · AA-Kontrast über Glows (axe-E2E-Spec grün)
- [x] Lint/Tests/Build grün · Druckansicht der Kassenberichte ohne Glows/Hairlines

## Verifikation

- `make check` nach jeder Phase grün; Frontend-Suite von 381 auf 389 Tests gewachsen (ErfolgsPop, useCountUp).
- Volle Playwright-E2E-Suite (33 Specs, Desktop-Admin + Pixel-7-Service) grün gegen den nativ aufgesetzten Stack, inklusive Kontrast- (axe) und Viewport-Überlauf-Specs.
- Integrationstests (`go test -tags=integration`) grün gegen lokale PostgreSQL-Instanz (Docker steht in der Cloud-Session nicht zur Verfügung; identische Schritte wie `scripts/test-integration.sh`, nur ohne Wegwerf-Container).
- Sichtabnahme-Screenshot-Satz: alle Screens in Hell/Dunkel auf Mobile (Pixel 7), Desktop (1440 px) und Tablet (iPad) erstellt und gegen den Prototyp geprüft.

## Bewusste Abweichungen (Reviewer-Entscheid erbeten)

- **Button-Press-Timing:** Das Press-Feedback der allgemeinen Buttons reitet auf dem bestehenden `transition-all` (150 ms ease) statt der 100 ms linear des Motion-Inventars — eine Per-Property-Transition auf der geteilten shadcn-Primitive wäre deutlich unleserlicher für einen kaum wahrnehmbaren Unterschied. Die Stepper haben die spezifizierten 100 ms transform-only.
- **Pulsedot-Ringfarbe:** `color-mix(… var(--primary) 50 %)` statt des hartkodierten `rgb(16 185 129)` aus dem Handoff — der Handoff-Wert entspricht nur dem Dark-Mode-Primärgrün; der Ring soll in beiden Themes zum Punkt passen.
- **Sidebar-Wortmarke `w-fit`:** Der Verlauf spannt sich über den Text selbst (volles Spektrum) wie im Prototyp (`width:fit-content` dort), nicht über die Sidebar-Breite.

## Offen (Human-Gate)

Nach bestandener Sichtabnahme durch den Betreiber wird das Handoff-Bundle `docs/prds/design_handoff_spektral_redesign/` gelöscht und der abgeschlossene Plan aus `docs/plans/` entfernt (letzte offene Checkbox im Plan).