### PR TITLE
docs(terms): simplify usage agreement to a single one-way email

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
              JOTTI — PROPRIETARY SOURCE-AVAILABLE LICENSE
 
-                    Version 1.0, 21 March 2026
+                    Version 1.1, 14 July 2026
 
 Copyright (c) 2025-2026 Nico Gräf, Freiburg im Breisgau, Germany.
 All rights reserved.
@@ -44,12 +44,13 @@ license agreement in text form (Textform, § 126b BGB).
    requires a prior license agreement in text form (Textform, § 126b BGB
    German Civil Code) with the Author.
 
-   A license agreement in text form is concluded by email exchange: the
+   A license agreement in text form is concluded by a single email: the
    organization sends an email to graef.nico@gmail.com identifying itself
-   (name, legal form, registration number, contact person) and explicitly
+   (name, legal form, registered office, contact person) and explicitly
    confirming acceptance of the terms of use in the version dated in the
-   document. The Author confirms by reply email. No printed form or
-   signature is required. See TERMS.md for the full process and a
+   document. No reply or confirmation by the Author, no proof of status,
+   no printed form, and no signature is required — use may begin as soon
+   as the email has been sent. See TERMS.md for the full process and a
    ready-to-use email template.
 
    The Author offers free-of-charge license agreements for non-commercial

--- a/SERVICE.md
+++ b/SERVICE.md
@@ -37,7 +37,7 @@ d) Schulung: Einweisung der Helferinnen und Helfer des Auftraggebers in die Bedi
 
 (2) Der Autor schuldet insbesondere nicht die Herstellung eines gesetzeskonformen, betriebsprüfungssicheren oder „finanzamtssicheren" Kassensystems. Einrichtung, TSE-Anbindung, Konfiguration und Schulung erfolgen unterstützend; die Verantwortung für die Einhaltung der gesetzlichen Vorschriften (insbesondere KassenSichV, § 146a AO, GoBD, DSFinV-K, DSGVO) verbleibt beim Auftraggeber.
 
-(3) Eine Gewähr für Fehlerfreiheit, Vollständigkeit, Verfügbarkeit oder Eignung der Software für einen bestimmten Zweck wird nicht übernommen; insoweit gilt § 7 der Nutzungsbedingungen.
+(3) Eine Gewähr für Fehlerfreiheit, Vollständigkeit, Verfügbarkeit oder Eignung der Software für einen bestimmten Zweck wird nicht übernommen; insoweit gilt § 6 der Nutzungsbedingungen.
 
 ---
 
@@ -69,7 +69,7 @@ e) die eigenständige Prüfung und Freigabe der Einrichtung vor dem produktiven 
 
 (1) Der Autor erstellt auf Anfrage ein Angebot mit Leistungsumfang und Vergütung. Es gibt keine allgemeine Preisliste; die Konditionen werden individuell vereinbart.
 
-(2) Der Auftrag kommt mit der Auftragsbestätigung in Textform zustande (§ 12 des nachfolgenden Prozesses).
+(2) Der Auftrag kommt mit der Auftragsbestätigung in Textform zustande (Schritt 3 des nachfolgenden Prozesses).
 
 (3) Ob Umsatzsteuer ausgewiesen wird, ergibt sich aus dem jeweiligen Angebot. Reisekosten und sonstige Auslagen werden nur erstattet, soweit sie im Angebot ausgewiesen oder vorab vereinbart sind.
 

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,8 +1,8 @@
 # Nutzungsbedingungen — jotti
 
-**Stand: 3. Juni 2026**
+**Stand: 14. Juli 2026**
 
-Diese Nutzungsbedingungen regeln die Nutzung der Software „jotti" durch Organisationen, die eine Nutzungsvereinbarung mit dem Autor abschließen. Der Abschluss erfolgt in Textform per E-Mail (§ 126b BGB) — kein Formular, keine Unterschrift erforderlich. Der Prozess und eine fertige E-Mail-Vorlage befinden sich am Ende dieses Dokuments.
+Diese Nutzungsbedingungen regeln die kostenlose Nutzung der Software „jotti" durch gemeinnützige Organisationen. Die Nutzungsvereinbarung kommt durch eine einzige E-Mail an den Autor zustande — kein Formular, keine Unterschrift, kein Nachweis, keine Bestätigung durch den Autor. Der Ablauf und eine fertige E-Mail-Vorlage stehen am Ende dieses Dokuments.
 
 > Autor: Nico Gräf, Freiburg im Breisgau, Deutschland — graef.nico@gmail.com
 
@@ -10,228 +10,97 @@ Diese Nutzungsbedingungen regeln die Nutzung der Software „jotti" durch Organi
 
 ## § 1 Gegenstand
 
-(1) Der Autor stellt der Organisation die Software „jotti" zur unentgeltlichen Nutzung zur Verfügung. Die Software umfasst den Quellcode, die Dokumentation und die zugehörigen Konfigurationsdateien, wie im Repository unter https://github.com/nicograef/jotti veröffentlicht.
+(1) Der Autor stellt der Organisation die Software „jotti" — Quellcode, Dokumentation und Konfigurationsdateien, wie unter https://github.com/nicograef/jotti veröffentlicht — unentgeltlich zur Verfügung.
 
-(2) Die Software ist ein persönliches Projekt des Autors. Die Organisation hat die Entwicklung weder beauftragt noch finanziert. Es besteht kein Auftrags-, Dienst- oder Werkvertragsverhältnis.
-
-(3) Der Autor stellt ausschließlich Quellcode zur Verfügung. Er betreibt kein SaaS-Produkt, vertreibt keine kompilierte Software und bietet keine gehostete Lösung an.
+(2) Die Software ist ein persönliches Projekt des Autors. Er stellt ausschließlich Quellcode bereit: kein SaaS, keine gehostete Lösung, kein Auftrags-, Dienst- oder Werkvertragsverhältnis.
 
 ---
 
-## § 2 Berechtigung zur unentgeltlichen Nutzung
+## § 2 Berechtigte Organisationen
 
-(1) Die unentgeltliche Nutzung steht ausschließlich offiziell eingetragenen und nicht-gewinnorientierten Organisationen offen, insbesondere:
+(1) Die kostenlose Nutzung steht eingetragenen, nicht-gewinnorientierten Organisationen offen — insbesondere eingetragenen Vereinen (e.V.), gemeinnützigen Stiftungen, gGmbH und gUG sowie sonstigen eingetragenen gemeinnützigen Körperschaften.
 
-- eingetragenen Vereinen (e.V.) gemäß §§ 21 ff. BGB,
-- eingetragenen gemeinnützigen Stiftungen,
-- gemeinnützigen GmbH (gGmbH) und gemeinnützigen UG (gUG),
-- sonstigen eingetragenen gemeinnützigen Körperschaften ohne Gewinnerzielungsabsicht.
+(2) Die Organisation sichert mit dem Abschluss der Nutzungsvereinbarung zu, diese Voraussetzungen zu erfüllen. Ein Nachweis ist nicht erforderlich.
 
-(2) Die Organisation sichert zu, die Voraussetzungen nach Abs. 1 zu erfüllen, und weist dies auf Verlangen des Autors nach (z. B. Vereinsregisterauszug, Freistellungsbescheid).
-
-(3) Entfallen die Voraussetzungen nach Abs. 1, informiert die Organisation den Autor unverzüglich. Die unentgeltliche Nutzungslizenz endet in diesem Fall automatisch.
-
-(4) Gewerbliche oder kommerzielle Nutzung ist ohne gesonderte kostenpflichtige Lizenz nicht gestattet.
+(3) Entfallen die Voraussetzungen, endet die kostenlose Nutzungslizenz automatisch. Gewerbliche oder kommerzielle Nutzung erfordert eine gesonderte kommerzielle Lizenz des Autors.
 
 ---
 
-## § 3 Geistiges Eigentum
+## § 3 Nutzungslizenz
 
-(1) Die Software — einschließlich Quellcode, Dokumentation, Architektur und Design — ist das alleinige geistige Eigentum des Autors. Sämtliche Urheber-, Marken- und sonstigen Schutzrechte verbleiben beim Autor.
+(1) Die Organisation erhält eine unentgeltliche, nicht-exklusive, nicht übertragbare Lizenz zur Nutzung der Software für den eigenen Kassenbetrieb bei eigenen Veranstaltungen. Die Nutzung umfasst Installation, Konfiguration, Betrieb und Aktualisierung auf von der Organisation verantworteter Infrastruktur.
 
-(2) Durch die Nutzung der Software erwirbt die Organisation keinerlei Rechte an der Software über die in § 4 gewährte Lizenz hinaus. Insbesondere geht kein Eigentum, kein Urheberrecht und kein sonstiges Schutzrecht auf die Organisation über.
-
-(3) Der Autor behält sich das Recht vor, die Software jederzeit unter weiteren Lizenzen zu veröffentlichen, zu vermarkten oder anderweitig zu verwerten.
+(2) Nicht umfasst sind insbesondere: Modifikation, Weitergabe an Dritte, abgeleitete Werke sowie der Betrieb für Dritte (SaaS, Multi-Tenant, White-Label). Alle Rechte an der Software verbleiben beim Autor; ergänzend gilt die proprietäre Source-Available-Lizenz aus der [`LICENSE`](LICENSE)-Datei des Repositories.
 
 ---
 
-## § 4 Nutzungslizenz
+## § 4 Betrieb und Datenschutz
 
-(1) Die Organisation erhält eine unentgeltliche, nicht-exklusive, widerrufliche, nicht übertragbare Lizenz zur Nutzung der Software für den organisationsinternen Kassenbetrieb bei eigenen Veranstaltungen.
+(1) Die Organisation ist alleinige Betreiberin der Software und verantwortet die eingesetzte Infrastruktur (Server, Datenbank, Netzwerk, Backups, Sicherheit). Der Autor stellt weder Hosting noch Infrastruktur bereit; freiwillige Hilfe bei der Einrichtung begründet keinen Anspruch auf laufende Betreuung.
 
-(2) Die Nutzung umfasst: Installation, Konfiguration, Betrieb und Aktualisierung auf von der Organisation verantworteter Infrastruktur.
-
-(3) Die Lizenz umfasst nicht: Modifikation des Quellcodes, Weitergabe an Dritte, Unterlizenzierung, öffentliches Zugänglichmachen, Einbindung in andere Software, Nutzung als Grundlage für abgeleitete Werke oder White-Label-Betrieb.
-
-(4) Es gelten zusätzlich die Bestimmungen der proprietären Source-Available-Lizenz aus der `LICENSE`-Datei des Repositories.
+(2) Die Organisation ist Verantwortliche im Sinne der DSGVO (Art. 4 Nr. 7) für alle in der Software verarbeiteten personenbezogenen Daten. Der Autor hat keinen Zugriff auf die Installation oder deren Daten und ist kein Auftragsverarbeiter. Lässt die Organisation die Infrastruktur durch einen Hosting-Anbieter betreiben, schließt sie mit diesem einen Auftragsverarbeitungsvertrag (Art. 28 DSGVO).
 
 ---
 
-## § 5 Hosting und Betrieb
+## § 5 Compliance-Verantwortung
 
-(1) Die Organisation ist alleinige Betreiberin der Software und verantwortet die hierfür eingesetzte Infrastruktur (Server, Datenbank, Netzwerk, Backups, Sicherheit).
-
-(2) Der Autor stellt weder Hosting noch Infrastruktur bereit.
-
-(3) Die Organisation kann die Infrastruktur durch einen externen Hosting-Anbieter betreiben lassen. In diesem Fall ist die Organisation für den Abschluss eines Auftragsverarbeitungsvertrags (Art. 28 DSGVO) mit dem Hoster verantwortlich.
-
-(4) Ein Multi-Tenant-Betrieb, bei dem ein Dritter jotti als Dienst für mehrere Organisationen anbietet, ist ohne separate kommerzielle Lizenz des Autors nicht gestattet.
-
-(5) Der Autor kann freiwillig bei der Ersteinrichtung unterstützen. Daraus entsteht kein Anspruch auf laufende Betreuung oder Betrieb.
+Die Organisation ist allein verantwortlich für die Einhaltung der gesetzlichen Vorschriften beim Betrieb eines elektronischen Aufzeichnungssystems — insbesondere KassenSichV und § 146a AO (TSE-Pflicht, Belegausgabe, Kassenmeldung), GoBD, DSFinV-K und DSGVO. Sie prüft die Software vor dem produktiven Einsatz eigenständig auf Eignung, im Zweifel mit steuerlicher Beratung. Der Autor implementiert technische Schnittstellen zur Unterstützung der Compliance, garantiert jedoch nicht deren Vollständigkeit oder Eignung.
 
 ---
 
-## § 6 Datenschutz
+## § 6 Gewährleistung, Haftung und Freistellung
 
-(1) Die Organisation ist Verantwortliche im Sinne der DSGVO (Art. 4 Nr. 7) für alle in der Software verarbeiteten personenbezogenen Daten.
+(1) Die Software wird ohne Gewähr bereitgestellt („as-is") — insbesondere ohne Gewähr für Fehlerfreiheit, Verfügbarkeit, die Richtigkeit von Berechnungen oder die Einhaltung gesetzlicher Vorschriften.
 
-(2) Der Autor ist kein Auftragsverarbeiter, da er keinen Zugriff auf den Server oder die gespeicherten Daten hat. Zwischen dem Autor und der Organisation besteht kein Auftragsverarbeitungsverhältnis.
+(2) Da die Software unentgeltlich überlassen wird, haftet der Autor nach den Grundsätzen des Schenkungsrechts (§ 521 BGB) nur für Vorsatz und grobe Fahrlässigkeit. Unberührt bleiben die Haftung für die Verletzung von Leben, Körper oder Gesundheit sowie die Haftung nach dem Produkthaftungsgesetz.
 
-(3) Die Organisation ist verpflichtet, die einschlägigen Datenschutzbestimmungen einzuhalten — insbesondere die Betroffenen (Servicekräfte) über die Datenverarbeitung zu informieren und mit einem etwaigen Hosting-Anbieter einen AV-Vertrag abzuschließen.
-
----
-
-## § 7 Gewährleistungsausschluss
-
-(1) Die Software wird ohne jede Gewähr bereitgestellt („as-is"). Der Autor übernimmt keinerlei Gewährleistung — weder ausdrücklich noch stillschweigend — für Fehlerfreiheit, Funktionalität, Verfügbarkeit, Richtigkeit, Vollständigkeit oder Eignung für einen bestimmten Zweck.
-
-(2) Insbesondere übernimmt der Autor keine Gewähr für:
-
-- die Einhaltung gesetzlicher Vorschriften (KassenSichV, GoBD, DSFinV-K, TSE-Anforderungen),
-- die Richtigkeit von Berechnungen (Saldo, Steuersätze, Abrechnungen),
-- die Datensicherheit oder Datenverfügbarkeit,
-- die Kompatibilität mit bestimmten Systemen, Browsern oder Endgeräten.
-
-(3) Die Organisation ist verpflichtet, die Software vor dem produktiven Einsatz eigenständig auf Eignung und Compliance zu prüfen — ggf. unter Hinzuziehung eines Steuerberaters oder einer fachkundigen Person.
+(3) Die Organisation stellt den Autor von Ansprüchen Dritter frei, die aus ihrem Betrieb der Software oder aus der Verletzung gesetzlicher Pflichten durch die Organisation entstehen — soweit der Autor nicht vorsätzlich oder grob fahrlässig gehandelt hat.
 
 ---
 
-## § 8 Haftungsbegrenzung
+## § 7 Support
 
-(1) Da die Software unentgeltlich überlassen wird, haftet der Autor nach den Grundsätzen des Schenkungsrechts (§ 521 BGB) nur für Vorsatz und grobe Fahrlässigkeit.
-
-(2) Die Haftung für einfache Fahrlässigkeit ist — soweit gesetzlich zulässig — ausgeschlossen.
-
-(3) Die Haftung für Verletzung von Leben, Körper oder Gesundheit bleibt unberührt (§ 309 Nr. 7a BGB).
-
-(4) Die Haftung nach dem Produkthaftungsgesetz bleibt unberührt, soweit dessen Anwendungsbereich eröffnet ist. Der Autor weist darauf hin, dass er lediglich Quellcode zur Verfügung stellt und kein Produkt im Sinne des ProdHaftG herstellt oder in Verkehr bringt.
-
-(5) Der Autor haftet insbesondere nicht für Schäden aus: Datenverlust, Fehlberechnungen, Systemausfällen, Betriebsprüfungen, steuerlichen Beanstandungen, Ordnungswidrigkeiten, Bußgeldern oder Nachforderungen, die im Zusammenhang mit der Nutzung der Software stehen.
+Es besteht kein Anspruch auf Support, Fehlerbehebung, Weiterentwicklung oder Aktualisierung. Unterstützung durch den Autor erfolgt freiwillig und unverbindlich; entgeltliche Leistungen regeln die [Leistungsbedingungen (SERVICE.md)](SERVICE.md).
 
 ---
 
-## § 9 Freistellung
+## § 8 Laufzeit und Beendigung
 
-(1) Die Organisation stellt den Autor von sämtlichen Ansprüchen, Schäden, Verlusten, Kosten und Aufwendungen (einschließlich angemessener Rechtsanwalts- und Gerichtskosten) frei, die aus den folgenden Umständen entstehen oder damit zusammenhängen:
+(1) Die Nutzungsvereinbarung gilt auf unbestimmte Zeit. Beide Seiten können sie jederzeit ohne Angabe von Gründen und ohne Frist in Textform (E-Mail genügt) beenden.
 
-a) der Nutzung, dem Deployment oder dem Betrieb der Software durch die Organisation;  
-b) der Nichteinhaltung geltender Gesetze, Vorschriften oder dieser Nutzungsbedingungen durch die Organisation;  
-c) Ansprüchen Dritter (einschließlich Finanzbehörden, Aufsichtsbehörden, Mitarbeitern, Kunden oder Endnutzern), die aus der Nutzung der Software resultieren;  
-d) Datenschutzverstößen, die aus dem Betrieb der Software resultieren;  
-e) steuerlichen Beanstandungen, Ordnungswidrigkeiten oder Bußgeldern im Zusammenhang mit der Nutzung der Software als Kassensystem.
-
-(2) Die Freistellungspflicht gilt auch nach Beendigung dieser Vereinbarung fort, soweit die zugrundeliegenden Ansprüche auf Handlungen oder Unterlassungen während der Vertragslaufzeit zurückzuführen sind.
+(2) Mit der Beendigung erlischt die Nutzungslizenz; die Organisation entfernt die Software von ihrer Infrastruktur. § 6 gilt über die Beendigung hinaus fort.
 
 ---
 
-## § 10 Compliance-Verantwortung
+## § 9 Schlussbestimmungen
 
-(1) Die Organisation ist allein verantwortlich für die Einhaltung sämtlicher gesetzlicher Vorschriften im Zusammenhang mit dem Betrieb eines elektronischen Aufzeichnungssystems, insbesondere:
+(1) Änderungen und Ergänzungen der Nutzungsvereinbarung bedürfen der Textform (E-Mail genügt). Sollten einzelne Bestimmungen unwirksam sein, bleibt die Wirksamkeit der übrigen Bestimmungen unberührt.
 
-a) KassenSichV und § 146a AO (TSE-Pflicht, Belegausgabe, Kassenmeldung),  
-b) GoBD (ordnungsgemäße Buchführung und Aufbewahrung),  
-c) DSFinV-K (digitale Schnittstelle der Finanzverwaltung),  
-d) DSGVO (Datenschutz),  
-e) sonstige steuer- und handelsrechtliche Vorschriften.
-
-(2) Der Autor implementiert technische Schnittstellen zur Unterstützung der Compliance, übernimmt jedoch keinerlei Garantie für deren Vollständigkeit, Richtigkeit oder Eignung.
-
-(3) Die Organisation ist verpflichtet, sich vor dem Einsatz der Software eigenständig über die geltenden gesetzlichen Anforderungen zu informieren und deren Einhaltung sicherzustellen.
-
----
-
-## § 11 Support und Weiterentwicklung
-
-(1) Es besteht kein Anspruch auf Support, Fehlerbehebung, Weiterentwicklung oder Aktualisierung.
-
-(2) Unterstützung durch den Autor erfolgt freiwillig und unverbindlich.
-
-(3) Feature-Wünsche der Organisation werden zur Kenntnis genommen, begründen jedoch keinen Umsetzungsanspruch.
-
----
-
-## § 12 Laufzeit und Kündigung
-
-(1) Die Nutzungsvereinbarung gilt auf unbestimmte Zeit.
-
-(2) Beide Seiten können die Vereinbarung jederzeit ohne Angabe von Gründen und ohne Einhaltung einer Frist beenden. Die Beendigung hat in Textform (E-Mail genügt) zu erfolgen.
-
-(3) Bei Beendigung erlischt die Nutzungslizenz nach § 4 Abs. 1. Die Organisation hat die Software innerhalb von 30 Tagen nach Beendigung von ihrer Infrastruktur zu entfernen und den Autor über die erfolgte Löschung zu informieren.
-
-(4) Die Freistellungspflicht (§ 9) und der Haftungsausschluss (§§ 7, 8) gelten über die Beendigung hinaus fort.
-
----
-
-## § 13 Schlussbestimmungen
-
-(1) Änderungen und Ergänzungen der Nutzungsvereinbarung bedürfen der Textform (E-Mail genügt).
-
-(2) Sollten einzelne Bestimmungen unwirksam sein, bleibt die Wirksamkeit der übrigen Bestimmungen unberührt. An die Stelle der unwirksamen Bestimmung tritt eine wirksame Regelung, die dem wirtschaftlichen Zweck der unwirksamen Bestimmung am nächsten kommt.
-
-(3) Es gilt das Recht der Bundesrepublik Deutschland unter Ausschluss des UN-Kaufrechts (CISG).
-
-(4) Gerichtsstand für alle Streitigkeiten aus oder im Zusammenhang mit dieser Vereinbarung ist — soweit gesetzlich zulässig — Freiburg im Breisgau.
-
-(5) Mit dem Abschluss der Nutzungsvereinbarung (§ 1 des nachfolgenden Prozesses) bestätigt die Organisation, diese Nutzungsbedingungen in der Fassung vom angegebenen Stand-Datum vollständig gelesen, verstanden und akzeptiert zu haben.
+(2) Es gilt das Recht der Bundesrepublik Deutschland unter Ausschluss des UN-Kaufrechts (CISG). Gerichtsstand ist — soweit gesetzlich zulässig — Freiburg im Breisgau.
 
 ---
 
 ## Prozess: Nutzungsvereinbarung abschließen
 
-Die Nutzungsvereinbarung kommt in Textform (§ 126b BGB) durch E-Mail-Austausch zustande. Kein Formular, keine Unterschrift, kein Postversand.
+Diese Nutzungsbedingungen sind das Angebot des Autors an alle berechtigten Organisationen (§ 2). Die Nutzungsvereinbarung kommt in Textform (§ 126b BGB) durch **eine einzige E-Mail** der Organisation an **graef.nico@gmail.com** zustande: Die E-Mail nennt die Organisation und erklärt die Annahme der Nutzungsbedingungen (Vorlage unten).
 
-### Schritt 1 — E-Mail der Organisation
+Eine Antwort oder Bestätigung des Autors ist **nicht erforderlich** — die Organisation kann die Software direkt nach dem Absenden der E-Mail installieren und betreiben.
 
-Die Organisation sendet eine E-Mail an **graef.nico@gmail.com** mit den folgenden Pflichtangaben (Vorlage unten).
-
-### Schritt 2 — Bestätigung durch den Autor
-
-Der Autor antwortet mit einer Bestätigungs-E-Mail. **Erst nach Eingang dieser Bestätigung** darf die Organisation die Software installieren und betreiben.
-
----
-
-### E-Mail-Vorlage für die Organisation
+### E-Mail-Vorlage
 
 ```
 Betreff: Nutzungsvereinbarung jotti — [Organisationsname]
 
-Sehr geehrter Herr Gräf,
+Hallo Herr Gräf,
 
-hiermit beantragt [vollständiger Name der Organisation] eine Nutzungsvereinbarung
-für die Software „jotti".
+wir sind [vollständiger Name, Rechtsform und Sitz der Organisation —
+z. B. TSV Musterhausen e.V., Musterhausen] und akzeptieren die
+Nutzungsbedingungen für jotti in der Fassung vom 14. Juli 2026
+(https://github.com/nicograef/jotti/blob/main/TERMS.md).
 
-Angaben zur Organisation:
-- Name: [vollständiger Name]
-- Rechtsform: [z. B. eingetragener Verein (e.V.)]
-- Registernummer: [z. B. VR 12345, Amtsgericht Musterstadt]
-- Ansprechperson: [Vorname Nachname, Funktion]
-- E-Mail: [E-Mail-Adresse der Ansprechperson]
-
-Wir bestätigen hiermit, dass wir die Nutzungsbedingungen für jotti in der Fassung
-vom Stand 3. Juni 2026 (https://github.com/nicograef/jotti/blob/main/TERMS.md)
-vollständig gelesen, verstanden und akzeptiert haben.
+Ansprechperson: [Vorname Nachname, E-Mail-Adresse]
 
 Mit freundlichen Grüßen
-[Name, Funktion]
+[Name]
 [Organisationsname]
-```
-
----
-
-### Mustertext für die Autor-Bestätigung
-
-```
-Betreff: Re: Nutzungsvereinbarung jotti — [Organisationsname]
-
-Hallo [Name],
-
-vielen Dank für Ihre Anfrage. Ich bestätige hiermit den Abschluss der Nutzungsvereinbarung
-für die Software „jotti" mit [Organisationsname] in der Fassung vom Stand 3. Juni 2026.
-
-Sie können die Software ab sofort installieren und betreiben.
-
-Bei Fragen stehe ich per E-Mail zur Verfügung.
-
-Mit freundlichen Grüßen
-Nico Gräf
 ```

--- a/docs/lizenzmodell.md
+++ b/docs/lizenzmodell.md
@@ -13,7 +13,7 @@ Die Software jotti (Quellcode, Dokumentation, Architektur, Design und alle zugeh
 
 ## 2. Source-Available, nicht Open Source
 
-jotti steht unter einer proprietären Source-Available-Lizenz: Der Quellcode ist öffentlich einsehbar, aber Nutzungsrechte werden nicht automatisch gewährt. Jede Nutzung erfordert eine vorherige Nutzungsvereinbarung in Textform; Ablauf und E-Mail-Vorlage: [TERMS.md → Prozess](../TERMS.md#prozess-nutzungsvereinbarung-abschließen).
+jotti steht unter einer proprietären Source-Available-Lizenz: Der Quellcode ist öffentlich einsehbar, aber Nutzungsrechte werden nicht automatisch gewährt. Jede Nutzung erfordert eine vorherige Nutzungsvereinbarung in Textform — eine einzige E-Mail an den Autor genügt, ohne Nachweis und ohne Bestätigung durch den Autor; Ablauf und E-Mail-Vorlage: [TERMS.md → Prozess](../TERMS.md#prozess-nutzungsvereinbarung-abschließen).
 
 | Eigenschaft                       | Source-Available (jotti) | Open Source (z. B. MIT, Apache) |
 | --------------------------------- | ------------------------ | ------------------------------- |
@@ -41,7 +41,7 @@ Kostenlose Nutzungsvereinbarungen erhalten ausschließlich eingetragene Organisa
 | Eingetragene Vereine (e.V.)               | Eintragung im Vereinsregister gemäß §§ 21 ff. BGB                    |
 | Eingetragene gemeinnützige Stiftungen     | Stiftungsregister + Anerkennung der Gemeinnützigkeit                 |
 | Gemeinnützige GmbH / UG (gGmbH, gUG)       | Handelsregister + steuerliche Anerkennung der Gemeinnützigkeit       |
-| Sonstige eingetragene NGOs / NPOs         | Nachweisbare Registereintragung und fehlende Gewinnerzielungsabsicht |
+| Sonstige eingetragene NGOs / NPOs         | Registereintragung und fehlende Gewinnerzielungsabsicht              |
 
 Keine kostenlose Vereinbarung erhalten gewerbliche Unternehmen, Organisationen ohne gemeinnützigen Status, gewerblich nutzende Einzelpersonen und Dritte, die jotti als Dienstleistung betreiben wollen (SaaS). Sie benötigen eine kostenpflichtige kommerzielle Lizenz (→ [Abschnitt 5](#5-kommerzialisierung-und-dual-licensing)). Entfallen die Voraussetzungen, endet die kostenlose Nutzungslizenz automatisch ([TERMS.md § 2 Abs. 3](../TERMS.md)).
 
@@ -75,4 +75,4 @@ Jeder Beitrag (Pull Request, Patch, Code-Einreichung) unterliegt dem [Contributo
 
 ## 7. Verbindliche Regelungen in den Nutzungsbedingungen
 
-Hosting und Betrieb, Datenschutz (DSGVO), Gewährleistungsausschluss, Haftungsbegrenzung, Freistellung und Compliance-Verantwortung (KassenSichV / TSE) sind abschließend in [TERMS.md §§ 5–10](../TERMS.md) geregelt. Kurzfassung: Die nutzende Organisation ist alleinige Betreiberin und datenschutzrechtlich Verantwortliche; der Autor stellt ausschließlich Quellcode bereit („as-is", Haftung nach Schenkungsrecht § 521 BGB nur für Vorsatz und grobe Fahrlässigkeit) und wird von Ansprüchen Dritter freigestellt. Die fachlichen Compliance-Pflichten der Betreiber beschreibt [compliance.md](compliance.md).
+Hosting und Betrieb, Datenschutz (DSGVO), Compliance-Verantwortung (KassenSichV / TSE), Gewährleistungsausschluss, Haftungsbegrenzung und Freistellung sind abschließend in [TERMS.md §§ 4–6](../TERMS.md) geregelt. Kurzfassung: Die nutzende Organisation ist alleinige Betreiberin und datenschutzrechtlich Verantwortliche; der Autor stellt ausschließlich Quellcode bereit („as-is", Haftung nach Schenkungsrecht § 521 BGB nur für Vorsatz und grobe Fahrlässigkeit) und wird von Ansprüchen Dritter freigestellt. Die fachlichen Compliance-Pflichten der Betreiber beschreibt [compliance.md](compliance.md).


### PR DESCRIPTION
## Was

Das Vertragswerk wird vereinfacht und entschärft — Kern ist eine Neufassung der Nutzungsbedingungen (`TERMS.md`): von 13 Paragraphen mit Zwei-Schritt-Abschluss (E-Mail + Bestätigung des Autors) auf 9 Paragraphen mit **einer einzigen Einweg-E-Mail**.

- **Abschluss per Einweg-Mail:** Die Nutzungsbedingungen sind als stehendes Angebot formuliert; die E-Mail der Organisation („wir sind [TSV Musterhausen e.V.] und akzeptieren die Nutzungsbedingungen …") ist die Annahme. Keine Bestätigung durch den Autor nötig — Nutzung darf direkt nach dem Absenden beginnen. Der Bestätigungs-Mustertext entfällt.
- **Kein Nachweis:** Die Zusicherung der Gemeinnützigkeit in der E-Mail genügt (§ 2 Abs. 2); Registerauszug/Freistellungsbescheid und Registernummer entfallen. Pflichtangaben: Name, Rechtsform, Sitz, Ansprechperson.
- **Entschärft:** eigenständiger IP-Paragraph auf einen Satz mit LICENSE-Verweis reduziert; fünfteilige Freistellung auf einen Satz gekürzt und an Vorsatz/grobe Fahrlässigkeit des Autors gekoppelt (wie in SERVICE.md); redundante Schadensaufzählung gestrichen; 30-Tage-Frist und Lösch-Meldepflicht bei Kündigung entfallen; „widerruflich" aus der Lizenzformel entfernt (jederzeitiges Kündigungsrecht deckt das ab).
- **Behalten:** Berechtigtenkreis, Lizenzumfang (kein SaaS, keine Weitergabe), Betreiber- und DSGVO-Rolle, Compliance-Verantwortung, „as-is"-Gewährleistungsausschluss, Haftung nur für Vorsatz/grobe Fahrlässigkeit (§ 521 BGB).

Folgeänderungen für Konsistenz:

- **LICENSE** (→ v1.1, 14 July 2026): Abschnitt 3 beschreibt jetzt den Single-Email-Abschluss ohne Autor-Bestätigung; „registration number" → „registered office".
- **docs/lizenzmodell.md:** Prozess-Satz („eine E-Mail genügt, ohne Nachweis und ohne Bestätigung"), §-Verweis „§§ 5–10" → „§§ 4–6", „Nachweisbare Registereintragung" entschärft.
- **SERVICE.md:** Verweis „§ 7 der Nutzungsbedingungen" → „§ 6" (neue Nummerierung); Verweisfehler „(§ 12 des nachfolgenden Prozesses)" → „(Schritt 3 …)" behoben.

## Warum

Der bisherige Prozess (Nachweis auf Verlangen, Warten auf Bestätigung) war für die Zielgruppe — ehrenamtlich geführte Vereine — unnötig bürokratisch, und der Vertragstext insgesamt übermäßig defensiv.

## Review-Hinweise

- Heikelster Punkt: die stark gekürzte Freistellung (TERMS § 6 Abs. 3) — deckt weiterhin Ansprüche Dritter aus Betrieb und Rechtsverstößen der Organisation, aber ohne Aufzählung (Bußgelder, Anwaltskosten) und ohne separate Fortgeltungsklausel (§ 8 Abs. 2 erklärt § 6 pauschal für fortgeltend).
- Der Einweg-Abschluss bedeutet: keine aktive Kontrolle vor der Erstnutzung mehr; Hebel ist das jederzeitige Kündigungsrecht (§ 8).
- CLA.md und der Inhalt von SERVICE.md bleiben unverändert; README und Website-Formular bleiben konsistent (das Anfrage-Formular ist eine reine Kontaktanfrage).