### PR TITLE
fix: address multi-expert-review findings across app, website, and contract

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -173,6 +173,9 @@ license agreement in text form (Textform, § 126b BGB).
    d) Any data protection violations resulting from the licensee's
    operation of the Software.
 
+   This indemnification does not apply to the extent the Author acted with
+   intent (Vorsatz) or gross negligence (grobe Fahrlässigkeit).
+
 10. NO SUPPORT, NO MAINTENANCE
 
     The Author is under no obligation to provide support, maintenance,
@@ -194,10 +197,9 @@ license agreement in text form (Textform, § 126b BGB).
 12. SEVERABILITY
 
     If any provision of this license is held to be invalid, illegal, or
-    unenforceable by a court of competent jurisdiction, such provision
-    shall be modified to the minimum extent necessary to make it valid
-    and enforceable, or if modification is not possible, shall be severed.
-    The remaining provisions shall continue in full force and effect.
+    unenforceable by a court of competent jurisdiction, that provision
+    shall be severed and the remaining provisions shall continue in full
+    force and effect.
 
 13. ENTIRE AGREEMENT
 

--- a/docs/plans/plan-review-findings.md
+++ b/docs/plans/plan-review-findings.md
@@ -1,0 +1,306 @@
+# Plan: Behebung der Multi-Experten-Review-Befunde
+
+> Source PRD: n/a (aus Review der Commits 68d7916..713b247, 2026-07-14)
+
+## Goal
+
+Alle bestätigten Befunde des Multi-Experten-Reviews sowie die dabei
+verifizierten, bereits vor dem Review-Bereich bestehenden Layout-Defekte
+beheben. Der Review ergab: das Spektral-Redesign und die Refactor-Welle sind
+im Kern gesund (Backend, Event-Contracts und DSFinV-K-Format unangetastet,
+Frontend-Suite grün) — die offenen Punkte sind fünf Low-Findings im Frontend,
+zwei Vertragswerk-Findings (ein Medium, ein Low) und vier pre-existing
+Tablet-/Phone-Layout-Defekte im Admin-Bereich. Alle Änderungen sind
+Korrektheits-, Robustheits- und Konsistenzfixes; kein neues Feature, keine
+Änderung an persistierten Daten, kein Eingriff in die Freeze-Disziplin.
+
+## Architectural decisions
+
+Durable decisions, die für alle Phasen gelten:
+
+- **Erfolgs-Pop bleibt.** Das Vollbild-Overlay wird nicht durch Toasts ersetzt;
+  es wird gehärtet (Interaktion, Alt-Browser-Fallback, Screenreader). Der
+  bewusste Redesign-Entwurf bleibt erhalten.
+- **Alt-Browser-Fallback-Muster.** Neue dekorative `color-mix()`-Flächen
+  bekommen eine solide bzw. rgba-Vorab-Deklaration, sodass bei fehlendem
+  `color-mix()`-Support (iOS Safari 16.0–16.1) ein sichtbarer Ersatz bleibt.
+  Backdrop-Blur wird — wie bei den bestehenden Overlays (`drawer`, `dialog`,
+  `alert-dialog`, `sheet`) — hinter `supports-[backdrop-filter]` gegatet.
+- **Glow-Clipping isoliert.** Dekorative Glows werden in einer eigenen,
+  absolut positionierten `aria-hidden`-Ebene (`inset-0 overflow-hidden -z-10`)
+  geclippt; der Inhalts-/Scroll-Container behält normalen Überlauf, damit hohe
+  Karten scrollbar bleiben.
+- **Admin-Chrome ab `md`.** Im Band 768–1023px besitzt die feste Desktop-Sidebar
+  das Chrome; der mobile Hamburger-Header wird ab `md` ausgeblendet
+  (`md:hidden` statt `lg:hidden`), passend zum Sichtbarkeitsbreakpoint der
+  Sidebar (`md:block`/`md:flex`). Folge: die effektive Inhaltsbreite bei 768px
+  beträgt ~512px — die Overflow-Fixes in Phase 4 müssen auf diese Breite zielen.
+- **Geld-Formatierung mit geschütztem Leerzeichen.** Betrag und `€` werden nie
+  durch ein normales Leerzeichen getrennt (Umbruchgefahr in Kacheln/Tabellen).
+  Neuer Helper `formatEuro(cents)` in `frontend/src/lib/utils.ts` liefert
+  `` `${formatCents(cents)} €` `` (NBSP); die Betrag-plus-`€`-Anzeigestellen
+  konsumieren ihn. Der bereits bestehende ` €`-Gebrauch in
+  `formatAlleAuswaehlenLabel` wird auf denselben Helper umgestellt.
+- **Vertrags-Fassungsbezug.** Wo die Website die Annahme erklärt, referenziert
+  sie wortgleich die geltende Fassung „14. Juli 2026" und die TERMS-URL
+  (`https://github.com/nicograef/jotti/blob/main/TERMS.md`), konsistent mit der
+  E-Mail-Vorlage in `TERMS.md`.
+
+## Inventory
+
+Bestätigte In-Range-Findings (Frontend):
+
+- `frontend/src/service/components/ErfolgsPop.tsx — ErfolgsPop()` — Vollbild-
+  Overlay: `onClick={onDismiss}` ohne `pointer-events-none` (verschluckt einen
+  Tap), `bg-[color-mix(...)] backdrop-blur-[6px]` ohne Fallback/Guard, und
+  `role="status"`-Live-Region wird erst beim Öffnen befüllt gemountet.
+- `frontend/src/components/ui/skeleton.tsx — Skeleton()` +
+  `frontend/src/index.css — @utility skeleton-shimmer` — einziger `background`
+  ist ein Gradient mit `color-mix()`-Stops ohne soliden Vorab-Fallback.
+- `frontend/src/components/common/AuthLayout.tsx — AuthLayout()` —
+  `min-h-screen max-h-screen … overflow-hidden` am Wrapper, der auch die Karte
+  hält; clippt hohe Karten (Passwort-Setzen) auf kurzen/Landscape-Viewports.
+
+Bestätigte In-Range-Findings (Vertragswerk):
+
+- `website/src/lib/anfrage-mailto.ts — buildMailtoUrl()` — Betreff
+  „Nutzungsvereinbarung anfragen", Body ist ein Feld-Abzug ohne
+  Annahmeerklärung und ohne Fassungsbezug.
+- `website/src/pages/fuer-vereine.astro — schritte` — beschreibt den
+  abgeschafften Drei-Schritte-Prozess (Anfrage → Vereinbarung in Textform →
+  Loslegen) mit Autor-Bestätigung.
+- `LICENSE — Section 9 (INDEMNIFICATION)` — carve-out-freie „indemnify, defend,
+  and hold harmless … from any and all claims"; `Section 12 (SEVERABILITY)` —
+  geltungserhaltende Reduktion („modified to the minimum extent necessary").
+- `TERMS.md — § 6(3)` + `TERMS.md — Prozess / E-Mail-Vorlage` — Referenz für die
+  schlanke Freistellung (mit Vorsatz/grobe-Fahrlässigkeit-Carve-out) und den
+  Ein-E-Mail-Wortlaut.
+
+Pre-existing Layout-Defekte (per A/B gegen 68d7916^ als bestandsalt verifiziert):
+
+- `frontend/src/admin/AdminLayout.tsx — AdminMobileHeader()` — `lg:hidden`,
+  während die Sidebar (`frontend/src/components/ui/sidebar.tsx`) ab `md:block`
+  erscheint → doppeltes Top-Chrome im 768–1023px-Band. Mobile-Breakpoint-Quelle:
+  `frontend/src/hooks/use-mobile.ts — MOBILE_BREAKPOINT = 768`.
+- `frontend/src/admin/reporting/KassenberichtePage.tsx` — DSFinV-K-Hinweiszeile:
+  `flex items-center gap-4` ohne Umbruch, mit nicht-schrumpfendem Button „Archiv
+  herunterladen (ZIP)" → horizontaler Überlauf auf Phone- und 768px-Breite.
+- `frontend/src/admin/kasse/LaufenderBetriebSection.tsx — BewegungZeile()` —
+  `truncate`-Span in `flex … justify-between` verursacht Überlauf bei 768px.
+- Geldanzeige-Stellen mit `{formatCents(x)} €` (normales Leerzeichen), u. a.
+  `frontend/src/admin/reporting/LiveReportingSection.tsx`,
+  `ReportingResults.tsx`, `SummaryCard.tsx`, `SitzungsListe.tsx`,
+  `StornoItem.tsx` — `€` kann in schmale Kacheln/Steuertabelle umbrechen.
+
+Bestehende Muster zum Nachnutzen:
+
+- `frontend/src/lib/utils.ts — formatCents()`, `formatAlleAuswaehlenLabel()`
+  (nutzt bereits ` €`).
+- Overlay-Fallback-Muster: `frontend/src/components/ui/dialog.tsx`,
+  `drawer.tsx`, `alert-dialog.tsx`, `sheet.tsx`
+  (`bg-black/10 … supports-[backdrop-filter]:backdrop-blur-xs`).
+
+## Resolved decisions
+
+- **Erfolgs-Pop:** bleibt erhalten, wird nur gehärtet (nicht durch Toast
+  ersetzt).
+- **Admin-Tablet-Chrome:** Desktop-Sidebar besitzt 768px+ (Hamburger-Header
+  `md:hidden`); die feste Sidebar gilt bewusst ab `md`.
+- Alle pre-existing Layout-Defekte werden mitbehoben (ausdrücklich gewünscht).
+
+## Open questions / Risks
+
+- Die Sidebar belegt bei 768px ~256px Breite; nach der Chrome-Angleichung
+  müssen die Overflow-Fixes (Phase 4) für ~512px effektive Inhaltsbreite
+  greifen — Verifikation bei 768px mit sichtbarer Sidebar, nicht nur am nackten
+  Viewport.
+- Vertragswerk-Änderungen sind eine Umsetzung der Review-Einschätzung, keine
+  Rechtsberatung; der finale Wortlaut sollte vom Autor gegengelesen werden.
+
+---
+
+## Phase 1: Erfolgs-Pop härten
+
+### Context
+
+- `frontend/src/service/components/ErfolgsPop.tsx — ErfolgsPop()` — die drei
+  Befunde (Tap-Verschlucken, fehlender Backdrop-Fallback, unzuverlässige
+  Live-Region) sitzen alle in dieser Komponente.
+- `frontend/src/components/ui/dialog.tsx` u. a. — kanonisches
+  `supports-[backdrop-filter]`-Backdrop-Muster als Vorlage.
+- `frontend/src/service/components/ErfolgsPop.test.tsx` (falls vorhanden) bzw.
+  die Testdatei neben der Komponente — deckt Auto-Dismiss und Rendern ab.
+
+### What to build
+
+Den Erfolgs-Pop so anpassen, dass (1) ein Tap im Anzeigefenster sein
+eigentliches Ziel erreicht: der Backdrop erhält `pointer-events-none`, der
+Auto-Dismiss-Timer bleibt die alleinige Schließ-Logik (der bisherige
+Tap-zum-Schließen entfällt, da er den Folgetap kostete); (2) die Tönung auf
+Browsern ohne `color-mix()` sichtbar bleibt: solider/rgba-Vorab-Hintergrund vor
+der `color-mix()`-Deklaration und Blur hinter `supports-[backdrop-filter]`
+gegatet, analog zu den anderen Overlays; (3) die Erfolgsmeldung zuverlässig
+angesagt wird: die `role="status"`-Live-Region wird dauerhaft gemountet und nur
+ihr Inhalt getoggelt (statt die befüllte Region frisch zu mounten).
+
+### Acceptance criteria
+
+- [ ] Ein Tap auf den sichtbaren Pop schließt ihn nicht mehr vorzeitig und wird
+      nicht mehr verschluckt; der darunterliegende Zielbutton empfängt den Tap
+      (`pointer-events-none` am Backdrop, verifiziert im laufenden Service-Flow
+      bei 360×800 im Direktverkauf-Wiederholungspfad).
+- [ ] Auf simuliertem fehlendem `color-mix()`-Support bleibt eine sichtbare
+      Abdunklung; mit `supports`-Guard bleibt der Blur nur dort aktiv, wo
+      `backdrop-filter` unterstützt wird (Muster identisch zu `dialog.tsx`).
+- [ ] Die Live-Region ist im gemounteten Service-Screen dauerhaft vorhanden und
+      wechselt nur ihren Textinhalt; der Erfolgstext wird bei Bestellen,
+      Kassieren und Direktverkauf angesagt.
+- [ ] Auto-Dismiss nach `ANZEIGE_DAUER_MS` funktioniert unverändert; Timer wird
+      bei Unmount aufgeräumt; bestehende Tests grün, ergänzt um einen Test, der
+      belegt, dass der Backdrop `pointer-events-none` trägt.
+- [ ] `prefers-reduced-motion` stellt den Pop weiterhin still (globale Regel in
+      `index.css` unverändert wirksam).
+
+---
+
+## Phase 2: Redesign-Robustheit auf Alt-Browsern und kurzen Viewports
+
+### Context
+
+- `frontend/src/index.css — @utility skeleton-shimmer` +
+  `frontend/src/components/ui/skeleton.tsx — Skeleton()` — Gradient ohne soliden
+  Fallback.
+- `frontend/src/components/common/AuthLayout.tsx — AuthLayout()` —
+  `overflow-hidden` am höhengedeckelten Wrapper clippt hohe Karten.
+- `frontend/src/pages/PasswordPage.tsx` / das Passwort-Setzen-Formular — der
+  höchste Auth-Inhalt, an dem das Clipping auftritt.
+
+### What to build
+
+Zwei Alt-Browser-/Kleingerät-Robustheitsfixes ohne sichtbare Änderung auf
+modernen Browsern: (1) `skeleton-shimmer` bekommt eine solide
+`background: var(--muted)`-Deklaration vor dem Gradient, sodass Skeletons bei
+verworfener Gradient-Deklaration (fehlendes `color-mix()`) grau statt
+transparent rendern; der Shimmer bleibt, wo unterstützt. (2) `AuthLayout`
+verlagert das Glow-Clipping in eine eigene absolut positionierte
+`inset-0 overflow-hidden -z-10 aria-hidden`-Ebene, die die drei Glow-Divs
+aufnimmt; der äußere Container verliert `max-h-screen` und `overflow-hidden`
+und behält `min-h-screen` mit normalem (scrollbarem) Überlauf, sodass hohe
+Karten (Passwort setzen) auf kurzen und Landscape-Viewports vollständig
+erreichbar bleiben.
+
+### Acceptance criteria
+
+- [ ] Skeleton rendert bei simuliert fehlendem `color-mix()`-Support als solide
+      `--muted`-Fläche (nicht transparent); auf modernen Browsern erscheint der
+      Shimmer unverändert.
+- [ ] Das Passwort-Setzen-Formular ist auf 375×667 und in Landscape vollständig
+      scrollbar erreichbar — „Passwort festlegen"-Button, „Zum Login"-Link und
+      Footer sind nicht abgeschnitten (verifiziert per Screenshot bei 375×667
+      und 667×375).
+- [ ] Die dekorativen Glows werden weiterhin am Rand geclippt (kein
+      horizontaler Dokument-Überlauf durch die Glows) und bleiben `aria-hidden`
+      / `print:hidden`.
+- [ ] Login-Screen (kurzer Inhalt) rendert visuell unverändert zu vorher.
+
+---
+
+## Phase 3: Vertragswerk und Website-Funnel konsistent machen
+
+### Context
+
+- `website/src/lib/anfrage-mailto.ts — buildMailtoUrl()` — Betreff und Body der
+  mailto-URL.
+- `website/src/pages/fuer-vereine.astro — schritte` — die drei Prozess-Schritte.
+- `website/src/components/AnfrageFormular.tsx` — Island, die den Button-Text
+  rendert und `buildMailtoUrl` aufruft (Button-/CTA-Beschriftung).
+- `TERMS.md — § 6(3)`, `TERMS.md — Prozess / E-Mail-Vorlage` — verbindlicher
+  Wortlaut für Annahme und Fassungsbezug.
+- `LICENSE — Section 9`, `LICENSE — Section 12` — anzugleichende Klauseln.
+
+### What to build
+
+Den öffentlichen Akquise-Pfad und die LICENSE an den in 713b247 eingeführten
+Ein-E-Mail-Vertragsschluss angleichen: (1) `buildMailtoUrl` erzeugt eine
+Annahme-E-Mail statt einer Anfrage — Betreff auf „Nutzungsvereinbarung jotti —
+<Verein>" (Vorlagen-konform), und der Body enthält den Annahmesatz „… und
+akzeptieren die Nutzungsbedingungen für jotti in der Fassung vom 14. Juli 2026
+(<TERMS-URL>)" zusätzlich zu den Kontaktfeldern; die CTA-/Button-Beschriftung
+wechselt von „anfragen" auf „abschließen"-Semantik. (2) Die drei Schritte in
+`fuer-vereine.astro` beschreiben den Ein-E-Mail-Prozess (kein Autor-
+Bestätigungsschritt mehr): eine einzige Annahme-E-Mail, danach direkt loslegen.
+(3) `LICENSE` Section 9 erhält denselben Vorsatz/grobe-Fahrlässigkeit-Carve-out
+wie `TERMS.md § 6(3)`; Section 12 ersetzt die geltungserhaltende Reduktion durch
+eine schlichte Salvatorik (Unwirksames entfällt, der Rest bleibt wirksam).
+
+### Acceptance criteria
+
+- [ ] Die vom Formular erzeugte mailto-URL enthält den wörtlichen Annahmesatz
+      mit Fassungsdatum „14. Juli 2026" und der TERMS-URL; Betreff und
+      Button-/CTA-Text spiegeln einen Vertragsabschluss, keine Anfrage.
+- [ ] `anfrage-mailto`-Tests decken den neuen Body ab (Annahmesatz vorhanden,
+      Fassungsbezug vorhanden, Pflichtfeld-Validierung unverändert); bestehende
+      Tests angepasst.
+- [ ] `fuer-vereine.astro` beschreibt keinen Autor-Bestätigungsschritt mehr und
+      ist konsistent mit `TERMS.md`-Prozess und E-Mail-Vorlage.
+- [ ] `LICENSE` Section 9 enthält den Vorsatz/grobe-Fahrlässigkeit-Carve-out
+      (wortgleich zur Intention von `TERMS.md § 6(3)`); Section 12 ist eine
+      schlichte Salvatorik ohne geltungserhaltende Reduktion.
+- [ ] Kein weiterer Verweis im Repo beschreibt den alten Drei-Schritte-/
+      Bestätigungs-Prozess (`grep` nach „Bestätigung", „anfragen",
+      „Vereinbarung in Textform" in `website/` und Doku bereinigt).
+
+---
+
+## Phase 4: Admin-Layout auf Tablet und schmalen Phones (pre-existing)
+
+### Context
+
+- `frontend/src/admin/AdminLayout.tsx — AdminMobileHeader()` — Header-Sichtbarkeit
+  (`lg:hidden` → `md:hidden`).
+- `frontend/src/components/ui/sidebar.tsx`,
+  `frontend/src/hooks/use-mobile.ts — MOBILE_BREAKPOINT` — Sidebar erscheint ab
+  `md` (768px); Bezug für die Angleichung.
+- `frontend/src/admin/reporting/KassenberichtePage.tsx` — DSFinV-K-Hinweiszeile
+  mit ZIP-Button.
+- `frontend/src/admin/kasse/LaufenderBetriebSection.tsx — BewegungZeile()` —
+  `truncate`-Span im Flex-Row.
+- `frontend/src/lib/utils.ts — formatCents()`, `formatAlleAuswaehlenLabel()` —
+  Ziel für den neuen `formatEuro()`-Helper.
+- Geldanzeige-Konsumenten: `LiveReportingSection.tsx`, `ReportingResults.tsx`,
+  `SummaryCard.tsx`, `SitzungsListe.tsx`, `StornoItem.tsx`.
+
+### What to build
+
+Die vier bestandsalten Layout-Defekte im Admin-Bereich beheben, jeweils
+verifiziert bei 768px mit sichtbarer Sidebar (~512px Inhaltsbreite): (1)
+Doppel-Chrome auflösen — `AdminMobileHeader` ab `md` ausblenden (`md:hidden`),
+sodass im 768–1023px-Band nur die Desktop-Sidebar das Chrome trägt. (2)
+`KassenberichtePage`-Hinweiszeile darf umbrechen: die Zeile stapelt auf
+schmalen Breiten (`flex-col`, ab `sm`/`md` wieder Row) bzw. erlaubt Umbruch,
+sodass der ZIP-Button keinen horizontalen Überlauf mehr erzeugt. (3)
+`BewegungZeile` so anpassen, dass der `truncate`-Span innerhalb der verfügbaren
+Breite bleibt (korrekte `min-w-0`-Kette / Flex-Constraints), kein Überlauf bei
+768px. (4) `formatEuro(cents)`-Helper einführen (`` `${formatCents(cents)} €` ``)
+und die Betrag-plus-`€`-Anzeigestellen sowie `formatAlleAuswaehlenLabel` darauf
+umstellen, damit `€` nie vom Betrag getrennt umbricht.
+
+### Acceptance criteria
+
+- [ ] Im 768–1023px-Band zeigt der Admin-Bereich nur die Desktop-Sidebar, kein
+      zusätzliches Hamburger-Header-Chrome; bei <768px bleibt der Hamburger-
+      Header sichtbar und die Sidebar off-canvas (verifiziert bei 767px und
+      768px).
+- [ ] `/admin/kassenberichte` erzeugt keinen horizontalen Überlauf mehr bei
+      375×667, 360×800, 390×844, 414×896 und 768×1024 (mit sichtbarer Sidebar);
+      `scrollWidth === clientWidth`.
+- [ ] `/admin/kasse` (Kassentag-Stepper, laufender Betrieb) erzeugt keinen
+      horizontalen Überlauf mehr bei 768×1024; `BewegungZeile`-Text kürzt per
+      Ellipse statt zu überlaufen.
+- [ ] `formatEuro()` existiert in `frontend/src/lib/utils.ts`; alle im Inventory
+      genannten Anzeigestellen und `formatAlleAuswaehlenLabel` nutzen ihn;
+      Betrag und `€` brechen in Kacheln (`SummaryCard`) und Steuertabelle
+      (`ReportingResults`) nicht mehr getrennt um.
+- [ ] Frontend-Suite grün (`make check-frontend` bzw. `pnpm test --run` +
+      `pnpm lint`); die vorab automatisiert gemessenen Overflow-Stellen der
+      betroffenen Routen sind auf allen sieben Referenz-Viewports sauber.

--- a/docs/plans/plan-review-findings.md
+++ b/docs/plans/plan-review-findings.md
@@ -19,8 +19,15 @@ Korrektheits-, Robustheits- und Konsistenzfixes; kein neues Feature, keine
 Durable decisions, die für alle Phasen gelten:
 
 - **Erfolgs-Pop bleibt.** Das Vollbild-Overlay wird nicht durch Toasts ersetzt;
-  es wird gehärtet (Interaktion, Alt-Browser-Fallback, Screenreader). Der
-  bewusste Redesign-Entwurf bleibt erhalten.
+  es wird gehärtet (Alt-Browser-Fallback, Screenreader). Der bewusste
+  Redesign-Entwurf bleibt erhalten. **Wichtig:** Das Overlay bleibt bewusst
+  klick-blockierend (kein `pointer-events-none`) — der nachgelagerte Refetch
+  (`onDismiss` → `reload` in `TablePage`) ist an das Schließen gekoppelt, sodass
+  das Overlay die nächste Interaktion so lange hält, bis die frischen Daten
+  geladen sind. Ein Tap schließt weiterhin früher (`onClick={onDismiss}`). Der
+  ursprünglich geplante Tap-Durchgriff (`pointer-events-none`) würde erlauben,
+  auf noch nicht aktualisierten Bildschirmzustand zu tippen (Bestellen →
+  Kassieren rennt der Projektion davon) und wird deshalb nicht umgesetzt.
 - **Alt-Browser-Fallback-Muster.** Neue dekorative `color-mix()`-Flächen
   bekommen eine solide bzw. rgba-Vorab-Deklaration, sodass bei fehlendem
   `color-mix()`-Support (iOS Safari 16.0–16.1) ein sichtbarer Ersatz bleibt.
@@ -133,22 +140,25 @@ Bestehende Muster zum Nachnutzen:
 
 ### What to build
 
-Den Erfolgs-Pop so anpassen, dass (1) ein Tap im Anzeigefenster sein
-eigentliches Ziel erreicht: der Backdrop erhält `pointer-events-none`, der
-Auto-Dismiss-Timer bleibt die alleinige Schließ-Logik (der bisherige
-Tap-zum-Schließen entfällt, da er den Folgetap kostete); (2) die Tönung auf
-Browsern ohne `color-mix()` sichtbar bleibt: solider/rgba-Vorab-Hintergrund vor
-der `color-mix()`-Deklaration und Blur hinter `supports-[backdrop-filter]`
-gegatet, analog zu den anderen Overlays; (3) die Erfolgsmeldung zuverlässig
-angesagt wird: die `role="status"`-Live-Region wird dauerhaft gemountet und nur
-ihr Inhalt getoggelt (statt die befüllte Region frisch zu mounten).
+Den Erfolgs-Pop so anpassen, dass (1) das Overlay klick-blockierend bleibt und
+ein Tap es weiterhin früher schließt (`onClick={onDismiss}`): der ursprünglich
+geplante `pointer-events-none`-Durchgriff wird **nicht** umgesetzt, weil der
+nachgelagerte Refetch an `onDismiss` hängt — ein durchgereichter Tap würde auf
+noch nicht aktualisiertem Zustand landen (Bestellen → Kassieren, die Projektion
+ist noch nicht nachgeladen); (2) die Tönung auf Browsern ohne `color-mix()`
+sichtbar bleibt: solider/rgba-Vorab-Hintergrund vor der `color-mix()`-Deklaration
+und Blur hinter `supports-[backdrop-filter]` gegatet, analog zu den anderen
+Overlays; (3) die Erfolgsmeldung zuverlässig angesagt wird: die
+`role="status"`-Live-Region wird dauerhaft gemountet und nur ihr Inhalt
+getoggelt (statt die befüllte Region frisch zu mounten).
 
 ### Acceptance criteria
 
-- [x] Ein Tap auf den sichtbaren Pop schließt ihn nicht mehr vorzeitig und wird
-      nicht mehr verschluckt; der darunterliegende Zielbutton empfängt den Tap
-      (`pointer-events-none` am Backdrop, verifiziert im laufenden Service-Flow
-      bei 360×800 im Direktverkauf-Wiederholungspfad).
+- [x] Das Overlay bleibt klick-blockierend, sodass der an `onDismiss` gekoppelte
+      Refetch vor der nächsten Interaktion greift (verifiziert im
+      Bestellen→Kassieren-Flow: der Tab-Klick wartet ~1,7 s auf Pop-Schließen +
+      Nachladen, danach ist der Kassieren-Button aktiv); ein Tap schließt den Pop
+      weiterhin früher (`onClick={onDismiss}`).
 - [x] Auf simuliertem fehlendem `color-mix()`-Support bleibt eine sichtbare
       Abdunklung; mit `supports`-Guard bleibt der Blur nur dort aktiv, wo
       `backdrop-filter` unterstützt wird (Muster identisch zu `dialog.tsx`).
@@ -156,8 +166,8 @@ ihr Inhalt getoggelt (statt die befüllte Region frisch zu mounten).
       wechselt nur ihren Textinhalt; der Erfolgstext wird bei Bestellen,
       Kassieren und Direktverkauf angesagt.
 - [x] Auto-Dismiss nach `ANZEIGE_DAUER_MS` funktioniert unverändert; Timer wird
-      bei Unmount aufgeräumt; bestehende Tests grün, ergänzt um einen Test, der
-      belegt, dass der Backdrop `pointer-events-none` trägt.
+      bei Unmount aufgeräumt; bestehende Tests grün, inkl. Test, der belegt, dass
+      ein Tap den Pop schließt.
 - [x] `prefers-reduced-motion` stellt den Pop weiterhin still (globale Regel in
       `index.css` unverändert wirksam).
 

--- a/docs/plans/plan-review-findings.md
+++ b/docs/plans/plan-review-findings.md
@@ -145,20 +145,20 @@ ihr Inhalt getoggelt (statt die befüllte Region frisch zu mounten).
 
 ### Acceptance criteria
 
-- [ ] Ein Tap auf den sichtbaren Pop schließt ihn nicht mehr vorzeitig und wird
+- [x] Ein Tap auf den sichtbaren Pop schließt ihn nicht mehr vorzeitig und wird
       nicht mehr verschluckt; der darunterliegende Zielbutton empfängt den Tap
       (`pointer-events-none` am Backdrop, verifiziert im laufenden Service-Flow
       bei 360×800 im Direktverkauf-Wiederholungspfad).
-- [ ] Auf simuliertem fehlendem `color-mix()`-Support bleibt eine sichtbare
+- [x] Auf simuliertem fehlendem `color-mix()`-Support bleibt eine sichtbare
       Abdunklung; mit `supports`-Guard bleibt der Blur nur dort aktiv, wo
       `backdrop-filter` unterstützt wird (Muster identisch zu `dialog.tsx`).
-- [ ] Die Live-Region ist im gemounteten Service-Screen dauerhaft vorhanden und
+- [x] Die Live-Region ist im gemounteten Service-Screen dauerhaft vorhanden und
       wechselt nur ihren Textinhalt; der Erfolgstext wird bei Bestellen,
       Kassieren und Direktverkauf angesagt.
-- [ ] Auto-Dismiss nach `ANZEIGE_DAUER_MS` funktioniert unverändert; Timer wird
+- [x] Auto-Dismiss nach `ANZEIGE_DAUER_MS` funktioniert unverändert; Timer wird
       bei Unmount aufgeräumt; bestehende Tests grün, ergänzt um einen Test, der
       belegt, dass der Backdrop `pointer-events-none` trägt.
-- [ ] `prefers-reduced-motion` stellt den Pop weiterhin still (globale Regel in
+- [x] `prefers-reduced-motion` stellt den Pop weiterhin still (globale Regel in
       `index.css` unverändert wirksam).
 
 ---
@@ -191,17 +191,17 @@ erreichbar bleiben.
 
 ### Acceptance criteria
 
-- [ ] Skeleton rendert bei simuliert fehlendem `color-mix()`-Support als solide
+- [x] Skeleton rendert bei simuliert fehlendem `color-mix()`-Support als solide
       `--muted`-Fläche (nicht transparent); auf modernen Browsern erscheint der
       Shimmer unverändert.
-- [ ] Das Passwort-Setzen-Formular ist auf 375×667 und in Landscape vollständig
+- [x] Das Passwort-Setzen-Formular ist auf 375×667 und in Landscape vollständig
       scrollbar erreichbar — „Passwort festlegen"-Button, „Zum Login"-Link und
       Footer sind nicht abgeschnitten (verifiziert per Screenshot bei 375×667
       und 667×375).
-- [ ] Die dekorativen Glows werden weiterhin am Rand geclippt (kein
+- [x] Die dekorativen Glows werden weiterhin am Rand geclippt (kein
       horizontaler Dokument-Überlauf durch die Glows) und bleiben `aria-hidden`
       / `print:hidden`.
-- [ ] Login-Screen (kurzer Inhalt) rendert visuell unverändert zu vorher.
+- [x] Login-Screen (kurzer Inhalt) rendert visuell unverändert zu vorher.
 
 ---
 
@@ -235,18 +235,18 @@ eine schlichte Salvatorik (Unwirksames entfällt, der Rest bleibt wirksam).
 
 ### Acceptance criteria
 
-- [ ] Die vom Formular erzeugte mailto-URL enthält den wörtlichen Annahmesatz
+- [x] Die vom Formular erzeugte mailto-URL enthält den wörtlichen Annahmesatz
       mit Fassungsdatum „14. Juli 2026" und der TERMS-URL; Betreff und
       Button-/CTA-Text spiegeln einen Vertragsabschluss, keine Anfrage.
-- [ ] `anfrage-mailto`-Tests decken den neuen Body ab (Annahmesatz vorhanden,
+- [x] `anfrage-mailto`-Tests decken den neuen Body ab (Annahmesatz vorhanden,
       Fassungsbezug vorhanden, Pflichtfeld-Validierung unverändert); bestehende
       Tests angepasst.
-- [ ] `fuer-vereine.astro` beschreibt keinen Autor-Bestätigungsschritt mehr und
+- [x] `fuer-vereine.astro` beschreibt keinen Autor-Bestätigungsschritt mehr und
       ist konsistent mit `TERMS.md`-Prozess und E-Mail-Vorlage.
-- [ ] `LICENSE` Section 9 enthält den Vorsatz/grobe-Fahrlässigkeit-Carve-out
+- [x] `LICENSE` Section 9 enthält den Vorsatz/grobe-Fahrlässigkeit-Carve-out
       (wortgleich zur Intention von `TERMS.md § 6(3)`); Section 12 ist eine
       schlichte Salvatorik ohne geltungserhaltende Reduktion.
-- [ ] Kein weiterer Verweis im Repo beschreibt den alten Drei-Schritte-/
+- [x] Kein weiterer Verweis im Repo beschreibt den alten Drei-Schritte-/
       Bestätigungs-Prozess (`grep` nach „Bestätigung", „anfragen",
       „Vereinbarung in Textform" in `website/` und Doku bereinigt).
 
@@ -287,20 +287,20 @@ umstellen, damit `€` nie vom Betrag getrennt umbricht.
 
 ### Acceptance criteria
 
-- [ ] Im 768–1023px-Band zeigt der Admin-Bereich nur die Desktop-Sidebar, kein
+- [x] Im 768–1023px-Band zeigt der Admin-Bereich nur die Desktop-Sidebar, kein
       zusätzliches Hamburger-Header-Chrome; bei <768px bleibt der Hamburger-
       Header sichtbar und die Sidebar off-canvas (verifiziert bei 767px und
       768px).
-- [ ] `/admin/kassenberichte` erzeugt keinen horizontalen Überlauf mehr bei
+- [x] `/admin/kassenberichte` erzeugt keinen horizontalen Überlauf mehr bei
       375×667, 360×800, 390×844, 414×896 und 768×1024 (mit sichtbarer Sidebar);
       `scrollWidth === clientWidth`.
-- [ ] `/admin/kasse` (Kassentag-Stepper, laufender Betrieb) erzeugt keinen
+- [x] `/admin/kasse` (Kassentag-Stepper, laufender Betrieb) erzeugt keinen
       horizontalen Überlauf mehr bei 768×1024; `BewegungZeile`-Text kürzt per
       Ellipse statt zu überlaufen.
-- [ ] `formatEuro()` existiert in `frontend/src/lib/utils.ts`; alle im Inventory
+- [x] `formatEuro()` existiert in `frontend/src/lib/utils.ts`; alle im Inventory
       genannten Anzeigestellen und `formatAlleAuswaehlenLabel` nutzen ihn;
       Betrag und `€` brechen in Kacheln (`SummaryCard`) und Steuertabelle
       (`ReportingResults`) nicht mehr getrennt um.
-- [ ] Frontend-Suite grün (`make check-frontend` bzw. `pnpm test --run` +
+- [x] Frontend-Suite grün (`make check-frontend` bzw. `pnpm test --run` +
       `pnpm lint`); die vorab automatisiert gemessenen Overflow-Stellen der
       betroffenen Routen sind auf allen sieben Referenz-Viewports sauber.

--- a/frontend/src/admin/AdminLayout.tsx
+++ b/frontend/src/admin/AdminLayout.tsx
@@ -12,7 +12,7 @@ function AdminMobileHeader() {
   const { toggleSidebar } = useSidebar()
 
   return (
-    <header className="sticky top-0 h-14 border-b bg-background z-40 flex items-center justify-between px-4 lg:hidden print:hidden">
+    <header className="sticky top-0 h-14 border-b bg-background z-40 flex items-center justify-between px-4 md:hidden print:hidden">
       <div className="flex items-center gap-2">
         <Button
           variant="ghost"
@@ -34,7 +34,7 @@ export function AdminLayout() {
   return (
     <SidebarProvider defaultOpen={true}>
       <AdminSidebar />
-      <main className="min-h-screen w-full">
+      <main className="min-h-screen w-full min-w-0">
         <AdminMobileHeader />
         <div className="px-4 py-2 md:px-8 md:py-4 xl:px-12 xl:py-6">
           <Outlet />

--- a/frontend/src/admin/components/AdminPageHeader.tsx
+++ b/frontend/src/admin/components/AdminPageHeader.tsx
@@ -20,7 +20,7 @@ export function AdminPageHeader({
   glowFarben?: readonly [SpektralFarbe, SpektralFarbe]
 }) {
   return (
-    <div className="relative isolate flex items-start justify-between gap-4">
+    <div className="relative isolate flex flex-wrap items-start justify-between gap-4">
       <HeaderGlow farben={glowFarben} />
       <div>
         <h1 className="font-heading text-2xl font-bold leading-8">{titel}</h1>

--- a/frontend/src/admin/kasse/LaufenderBetriebSection.tsx
+++ b/frontend/src/admin/kasse/LaufenderBetriebSection.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 
 import { formatStand } from '@/admin/reporting/utils'
 import { Button } from '@/components/ui/button'
-import { formatCents } from '@/lib/utils'
+import { formatEuro } from '@/lib/utils'
 
 import { GeldtransitDialog } from './GeldtransitDialog'
 import { useGeldtransitListe, useKassenbestand } from './hooks'
@@ -31,7 +31,7 @@ function AufschluesselungKachel({
     <div className="rounded-lg bg-muted/60 px-3 py-2.5">
       <div className="text-xs text-muted-foreground">{label}</div>
       <div className="mt-0.5 text-sm font-semibold">
-        {betragCents !== null ? `${formatCents(betragCents)} €` : '—'}
+        {betragCents !== null ? formatEuro(betragCents) : '—'}
       </div>
     </div>
   )
@@ -43,14 +43,14 @@ function BewegungZeile({ buchung }: { buchung: GeldtransitBuchung }) {
   const vorzeichen = istEntnahme ? '−' : '+'
   return (
     <div className="flex items-center justify-between gap-3 px-3.5 py-2 text-sm">
-      <span className="min-w-0 truncate text-muted-foreground">
+      <span className="min-w-0 flex-1 truncate text-muted-foreground">
         {formatBewegungZeit(buchung.zeitpunkt)} · {richtungLabel} · „
         {buchung.kommentar}" · {buchung.gebuchtVon}
       </span>
       <span
         className={`shrink-0 font-semibold ${istEntnahme ? 'text-destructive' : ''}`}
       >
-        {vorzeichen} {formatCents(buchung.betragCents)} €
+        {vorzeichen} {formatEuro(buchung.betragCents)}
       </span>
     </div>
   )
@@ -82,7 +82,7 @@ export function LaufenderBetriebSection({
         <div className="text-right">
           <div className="text-3xl font-extrabold tracking-tight tabular-nums">
             {kassenbestand !== null
-              ? `${formatCents(kassenbestand.sollBestandCents)} €`
+              ? formatEuro(kassenbestand.sollBestandCents)
               : '—'}
           </div>
           <div className="text-xs text-muted-foreground">

--- a/frontend/src/admin/reporting/KassenberichtePage.tsx
+++ b/frontend/src/admin/reporting/KassenberichtePage.tsx
@@ -27,7 +27,7 @@ function ExportBlock({ kassensitzungNr }: { kassensitzungNr: number }) {
   const { exportieren, isPending } = useDsfinvkExport()
 
   return (
-    <div className="flex items-center gap-4 rounded-xl border bg-sidebar p-4 print:hidden">
+    <div className="flex flex-col gap-4 rounded-xl border bg-sidebar p-4 sm:flex-row sm:items-center print:hidden">
       <Building2 className="size-5 shrink-0 text-primary" aria-hidden />
       <div className="flex-1">
         <p className="text-sm font-semibold">Für Steuerberater & Finanzamt</p>
@@ -102,7 +102,7 @@ export function KassenberichtePage() {
           </EmptyHeader>
         </Empty>
       ) : (
-        <div className="mt-4 grid grid-cols-1 gap-5 md:grid-cols-[280px_1fr]">
+        <div className="mt-4 grid grid-cols-1 gap-5 lg:grid-cols-[280px_minmax(0,1fr)]">
           <div className="print:hidden">
             <SitzungsListe
               sitzungen={kassensitzungen}

--- a/frontend/src/admin/reporting/LiveReportingSection.tsx
+++ b/frontend/src/admin/reporting/LiveReportingSection.tsx
@@ -22,7 +22,7 @@ import {
   EmptyTitle,
 } from '@/components/ui/empty'
 import { useCountUp } from '@/hooks/use-count-up'
-import { formatCents } from '@/lib/utils'
+import { formatEuro } from '@/lib/utils'
 
 import { AdminPageHeader } from '../components/AdminPageHeader'
 import { StatusDot } from '../components/StatusDot'
@@ -131,7 +131,7 @@ export function LiveReportingSection({
             Kassierter Umsatz
           </span>
           <span className="text-3xl font-extrabold tracking-tight whitespace-nowrap tabular-nums">
-            {formatCents(heroUmsatz)} €
+            {formatEuro(heroUmsatz)}
           </span>
           <span className="text-xs text-muted-foreground">
             bereits bezahlt, Stornos abgezogen
@@ -166,7 +166,7 @@ export function LiveReportingSection({
             <h2 className="text-base font-semibold">Offene Tische</h2>
             <span className="text-sm text-muted-foreground">
               {offeneTische.length} Tische ·{' '}
-              {formatCents(liveData.offeneSaldiCents)} €
+              {formatEuro(liveData.offeneSaldiCents)}
             </span>
           </div>
           {offeneTische.length === 0 ? (
@@ -182,7 +182,7 @@ export function LiveReportingSection({
                 >
                   <span>{t.tischName}</span>
                   <span className="font-semibold">
-                    {formatCents(t.saldoCents)} €
+                    {formatEuro(t.saldoCents)}
                   </span>
                 </div>
               ))}
@@ -237,7 +237,7 @@ export function LiveReportingSection({
                         <span className="text-xs text-muted-foreground">
                           Offen:{' '}
                           <span className="whitespace-nowrap font-medium">
-                            {formatCents(sk.offenCents)} €
+                            {formatEuro(sk.offenCents)}
                           </span>{' '}
                           auf {sk.offeneTische.length}{' '}
                           {sk.offeneTische.length === 1 ? 'Tisch' : 'Tischen'}
@@ -255,7 +255,7 @@ export function LiveReportingSection({
                       )}
                     </div>
                     <span className="whitespace-nowrap text-sm font-semibold">
-                      {formatCents(sk.zahlungenCents)} €
+                      {formatEuro(sk.zahlungenCents)}
                     </span>
                   </div>
                 )
@@ -277,7 +277,7 @@ export function LiveReportingSection({
                     {summary.anzahlStornierungen} Stornierung
                     {summary.anzahlStornierungen === 1 ? '' : 'en'}
                   </strong>{' '}
-                  · {formatCents(summary.gesamtStornierungenCents)} €
+                  · {formatEuro(summary.gesamtStornierungenCents)}
                 </p>
                 {stornierungenProServicekraft.length > 0 && (
                   <StornoAggregat

--- a/frontend/src/admin/reporting/ReportingResults.tsx
+++ b/frontend/src/admin/reporting/ReportingResults.tsx
@@ -2,7 +2,7 @@ import { Loader2, Printer } from 'lucide-react'
 
 import { STEUERSATZ_LABEL } from '@/admin/products/Produkt'
 import { Button } from '@/components/ui/button'
-import { formatCents } from '@/lib/utils'
+import { formatEuro } from '@/lib/utils'
 
 import { StornoItem } from './StornoItem'
 import { StornoMarker } from './StornoServicekraft'
@@ -33,7 +33,7 @@ function BerichtsMeta({
   }
   if (metadaten.kassensturzDifferenzCents !== null) {
     teile.push(
-      `Kassensturz-Differenz ${formatCents(metadaten.kassensturzDifferenzCents)} €`,
+      `Kassensturz-Differenz ${formatEuro(metadaten.kassensturzDifferenzCents)}`,
     )
   }
   return (
@@ -117,7 +117,7 @@ export function ReportingResults({
       <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
         <Kennzahl
           label="Kassierter Umsatz"
-          wert={`${formatCents(summary.gesamtUmsatzCents)} €`}
+          wert={formatEuro(summary.gesamtUmsatzCents)}
         />
         <Kennzahl
           label="Bestellungen"
@@ -125,11 +125,11 @@ export function ReportingResults({
         />
         <Kennzahl
           label="Direktverkauf"
-          wert={`${formatCents(summary.direktverkaufUmsatzCents)} €`}
+          wert={formatEuro(summary.direktverkaufUmsatzCents)}
         />
         <Kennzahl
           label="Storniert"
-          wert={`${formatCents(summary.gesamtStornierungenCents)} €`}
+          wert={formatEuro(summary.gesamtStornierungenCents)}
           destructive={summary.gesamtStornierungenCents > 0}
         />
       </div>
@@ -155,13 +155,13 @@ export function ReportingResults({
               >
                 <span>{STEUERSATZ_LABEL[umsatz.satz]}</span>
                 <span className="text-right font-semibold">
-                  {formatCents(umsatz.bruttoCents)} €
+                  {formatEuro(umsatz.bruttoCents)}
                 </span>
                 <span className="text-right">
-                  {formatCents(umsatz.nettoCents)} €
+                  {formatEuro(umsatz.nettoCents)}
                 </span>
                 <span className="text-right">
-                  {formatCents(umsatz.steuerCents)} €
+                  {formatEuro(umsatz.steuerCents)}
                 </span>
               </div>
             ))}
@@ -194,7 +194,7 @@ export function ReportingResults({
                       )}
                     </span>
                     <span className="whitespace-nowrap font-semibold">
-                      {formatCents(sk.zahlungenCents)} €
+                      {formatEuro(sk.zahlungenCents)}
                     </span>
                   </div>
                 )
@@ -208,7 +208,7 @@ export function ReportingResults({
             Stornierungen{' '}
             <span className="font-normal text-muted-foreground">
               ({summary.anzahlStornierungen} ·{' '}
-              {formatCents(summary.gesamtStornierungenCents)} €)
+              {formatEuro(summary.gesamtStornierungenCents)})
             </span>
           </div>
           {result.stornierungen.length === 0 ? (

--- a/frontend/src/admin/reporting/SitzungsListe.tsx
+++ b/frontend/src/admin/reporting/SitzungsListe.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from 'react-router'
 
 import type { OffeneKassensitzung } from '@/admin/kasse/KasseBackend'
-import { cn, formatCents } from '@/lib/utils'
+import { cn, formatEuro } from '@/lib/utils'
 
 import type { AbgeschlosseneSitzung } from './types'
 import { formatDatumKurz } from './utils'
@@ -65,7 +65,7 @@ export function SitzungsListe({
                 {formatDatumKurz(sitzung.datum)} · Nr. {sitzung.zNr}
               </span>
               <span className="text-sm font-semibold">
-                {formatCents(sitzung.umsatzGesamtCents)} €
+                {formatEuro(sitzung.umsatzGesamtCents)}
               </span>
             </div>
             <span className="text-xs text-muted-foreground">

--- a/frontend/src/admin/reporting/StornoItem.tsx
+++ b/frontend/src/admin/reporting/StornoItem.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@/components/ui/badge'
 import { Item, ItemContent } from '@/components/ui/item'
-import { formatCents, formatPositionName } from '@/lib/utils'
+import { formatEuro, formatPositionName } from '@/lib/utils'
 
 import type { StornierungDetail } from './types'
 import { formatBediener, formatLocalTime } from './utils'
@@ -29,7 +29,7 @@ export function StornoItem({ storno }: { storno: StornierungDetail }) {
               {storno.barRueckgabe ? 'Bar-Rückgabe' : 'Geldneutral'}
             </Badge>
             <span className="whitespace-nowrap text-sm font-semibold">
-              {formatCents(storno.betragCents)} €
+              {formatEuro(storno.betragCents)}
             </span>
           </div>
         </div>
@@ -50,7 +50,7 @@ export function StornoItem({ storno }: { storno: StornierungDetail }) {
                   {formatPositionName(pos.produktName, pos.varianteName)}
                 </span>
                 <span className="whitespace-nowrap">
-                  {formatCents(pos.einzelpreisCents)} €
+                  {formatEuro(pos.einzelpreisCents)}
                 </span>
               </li>
             ))}

--- a/frontend/src/admin/reporting/SummaryCard.tsx
+++ b/frontend/src/admin/reporting/SummaryCard.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useCountUp } from '@/hooks/use-count-up'
-import { formatCents } from '@/lib/utils'
+import { formatEuro } from '@/lib/utils'
 
 export function SummaryCard({
   title,
@@ -18,7 +18,7 @@ export function SummaryCard({
         <CardTitle className="text-sm text-muted-foreground">{title}</CardTitle>
       </CardHeader>
       <CardContent>
-        <p className="text-xl font-bold tabular-nums">{formatCents(wert)} €</p>
+        <p className="text-xl font-bold tabular-nums">{formatEuro(wert)}</p>
         {sub && <p className="mt-0.5 text-sm text-muted-foreground">{sub}</p>}
       </CardContent>
     </Card>

--- a/frontend/src/components/common/AuthLayout.tsx
+++ b/frontend/src/components/common/AuthLayout.tsx
@@ -2,43 +2,47 @@ import type { ReactNode } from 'react'
 
 // Login-Glows (Handoff Delta B): drei stark geblurte, dekorative Farbkreise
 // hinter der Karte. Rein dekorativ (aria-hidden, pointer-events-none) und im
-// Druck ausgeblendet; overflow-hidden am Wrapper clippt den Überhang, isolate
-// hält sie über dem Hintergrund und hinter der Karte. Die langsame Drift ist je
-// Kreis in Dauer und Delay versetzt (Inline-Override der animate-drift-Dauer),
-// damit sich die Kreise unabhängig bewegen — die zentrale Reduced-Motion-Regel
-// stoppt sie.
+// Druck ausgeblendet. Das Clipping des Überhangs liegt in einer eigenen absolut
+// positionierten Ebene (inset-0 overflow-hidden -z-10), damit der äußere
+// Container normalen Überlauf behält und hohe Karten (Passwort setzen) auf
+// kurzen/Landscape-Viewports scrollbar bleiben. isolate hält die Glows über dem
+// Hintergrund und hinter der Karte. Die langsame Drift ist je Kreis in Dauer und
+// Delay versetzt (Inline-Override der animate-drift-Dauer), damit sich die Kreise
+// unabhängig bewegen — die zentrale Reduced-Motion-Regel stoppt sie.
 export function AuthLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="relative isolate flex flex-col min-h-screen max-h-screen items-center justify-start overflow-hidden pt-16 sm:justify-center sm:pt-4 p-4 bg-primary/5">
+    <div className="relative isolate flex flex-col min-h-screen items-center justify-start pt-16 sm:justify-center sm:pt-4 p-4 bg-primary/5">
       <div
         aria-hidden
-        className="animate-drift pointer-events-none absolute -top-20 -left-16 -z-10 size-80 rounded-full opacity-25 blur-[60px] print:hidden"
-        style={{
-          background:
-            'radial-gradient(circle, color-mix(in oklab, var(--sp-teal) 55%, transparent), transparent 65%)',
-          animationDuration: '16s',
-        }}
-      />
-      <div
-        aria-hidden
-        className="animate-drift pointer-events-none absolute -right-20 -bottom-24 -z-10 size-[340px] rounded-full opacity-20 blur-[64px] print:hidden"
-        style={{
-          background:
-            'radial-gradient(circle, color-mix(in oklab, var(--sp-violet) 45%, transparent), transparent 65%)',
-          animationDuration: '20s',
-          animationDelay: '-5s',
-        }}
-      />
-      <div
-        aria-hidden
-        className="animate-drift pointer-events-none absolute top-1/3 -right-12 -z-10 size-50 rounded-full opacity-[0.18] blur-[56px] print:hidden"
-        style={{
-          background:
-            'radial-gradient(circle, color-mix(in oklab, var(--sp-orange) 40%, transparent), transparent 65%)',
-          animationDuration: '22s',
-          animationDelay: '-9s',
-        }}
-      />
+        className="pointer-events-none absolute inset-0 -z-10 overflow-hidden print:hidden"
+      >
+        <div
+          className="animate-drift absolute -top-20 -left-16 size-80 rounded-full opacity-25 blur-[60px]"
+          style={{
+            background:
+              'radial-gradient(circle, color-mix(in oklab, var(--sp-teal) 55%, transparent), transparent 65%)',
+            animationDuration: '16s',
+          }}
+        />
+        <div
+          className="animate-drift absolute -right-20 -bottom-24 size-[340px] rounded-full opacity-20 blur-[64px]"
+          style={{
+            background:
+              'radial-gradient(circle, color-mix(in oklab, var(--sp-violet) 45%, transparent), transparent 65%)',
+            animationDuration: '20s',
+            animationDelay: '-5s',
+          }}
+        />
+        <div
+          className="animate-drift absolute top-1/3 -right-12 size-50 rounded-full opacity-[0.18] blur-[56px]"
+          style={{
+            background:
+              'radial-gradient(circle, color-mix(in oklab, var(--sp-orange) 40%, transparent), transparent 65%)',
+            animationDuration: '22s',
+            animationDelay: '-9s',
+          }}
+        />
+      </div>
       {children}
       <footer className="mt-6">
         <p className="text-muted-foreground text-sm">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -341,6 +341,10 @@
 /* Skeleton-Shimmer: Muted-Verlauf mit leichter Teal-/Violett-Tönung
    (Handoff-Rezept), löst den früheren grauen Puls-Platzhalter ab. */
 @utility skeleton-shimmer {
+  /* Solider Fallback zuerst: Browser ohne color-mix()-Support (iOS Safari
+     16.0–16.1) verwerfen die Gradient-Deklaration und behalten diese muted
+     Fläche statt transparent zu rendern. Der Shimmer bleibt, wo unterstützt. */
+  background: var(--muted);
   background: linear-gradient(
     90deg,
     var(--muted) 20%,

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   formatCents,
+  formatEuro,
   formatPositionName,
   formatRelativeTime,
   parseCents,
@@ -19,6 +20,21 @@ describe('formatCents', () => {
     [10, '0,10'],
   ])('formatCents(%i) = %s', (input, expected) => {
     expect(formatCents(input)).toBe(expected)
+  })
+})
+
+describe('formatEuro', () => {
+  it.each([
+    [1250, '12,50\u00A0€'],
+    [0, '0,00\u00A0€'],
+    [-350, '-3,50\u00A0€'],
+  ])('formatEuro(%i) = %s', (input, expected) => {
+    expect(formatEuro(input)).toBe(expected)
+  })
+
+  it('trennt Betrag und € mit geschütztem Leerzeichen (U+00A0)', () => {
+    expect(formatEuro(1250)).toBe('12,50\u00A0€')
+    expect(formatEuro(1250)).not.toContain('12,50 €')
   })
 })
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -22,6 +22,15 @@ export function formatCents(cents: number): string {
 }
 
 /**
+ * Formats a price in cents as a Euro amount followed by the € sign, joined by a
+ * non-breaking space (U+00A0) so amount and sign never wrap apart.
+ * Example: 1250 → "12,50 €"
+ */
+export function formatEuro(cents: number): string {
+  return `${formatCents(cents)}\u00A0€`
+}
+
+/**
  * Label of the "Alle auswählen" button in Kassieren and Umbuchung: correct
  * grammatical number (singular "1 Position", plural "N Positionen") plus the
  * selection sum. With exactly one position the plural-implying "Alle" is dropped.
@@ -34,7 +43,7 @@ export function formatAlleAuswaehlenLabel(
     anzahl === 1
       ? '1 Position auswählen'
       : `Alle ${anzahl.toString()} Positionen auswählen`
-  return `${auswahl} · ${formatCents(summeCents)}\u00A0€`
+  return `${auswahl} · ${formatEuro(summeCents)}`
 }
 
 /**

--- a/frontend/src/service/components/ErfolgsPop.test.tsx
+++ b/frontend/src/service/components/ErfolgsPop.test.tsx
@@ -37,7 +37,7 @@ describe('ErfolgsPop', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Zahlung erfolgreich.')
   })
 
-  it('rendert nichts, solange es geschlossen ist', () => {
+  it('hält die Status-Region auch geschlossen ohne Text im DOM', () => {
     render(
       <ErfolgsPop
         open={false}
@@ -46,7 +46,9 @@ describe('ErfolgsPop', () => {
       />,
     )
 
-    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    // Die Live-Region bleibt dauerhaft gemountet (nur der Inhalt wird
+    // getoggelt), damit Screenreader spätere Textwechsel zuverlässig ansagen.
+    expect(screen.getByRole('status')).toBeEmptyDOMElement()
   })
 
   it('schließt nach Ablauf der Anzeigedauer automatisch', () => {
@@ -60,13 +62,17 @@ describe('ErfolgsPop', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1)
   })
 
-  it('schließt beim Antippen sofort, noch vor der Auto-Dismiss-Zeit', () => {
+  it('trägt pointer-events-none und schließt nicht beim Antippen', () => {
     const onDismiss = vi.fn()
     render(<ErfolgsPop open text="Fertig" onDismiss={onDismiss} />)
 
-    fireEvent.click(screen.getByRole('status'))
+    const pop = screen.getByRole('status')
+    expect(pop).toHaveClass('pointer-events-none')
 
-    expect(onDismiss).toHaveBeenCalledTimes(1)
+    fireEvent.click(pop)
+
+    // Der Tap wird nicht mehr abgefangen; nur der Auto-Dismiss-Timer schließt.
+    expect(onDismiss).not.toHaveBeenCalled()
   })
 })
 
@@ -150,17 +156,20 @@ describe('Erfolgs-Pop im Buchungsflow', () => {
 
     // Der Pop erscheint mit der Bestätigung; der Refetch läuft noch nicht und es
     // gibt keinen Erfolgs-Toast mehr.
-    const pop = await screen.findByText('Verkauf abgeschlossen.')
+    await screen.findByText('Verkauf abgeschlossen.')
     expect(reload).not.toHaveBeenCalled()
     expect(toast.success).not.toHaveBeenCalled()
 
-    // Tap schließt den Pop und löst erst dann den nachgelagerten Refetch aus.
-    await user.click(pop)
-    await waitFor(() => {
-      expect(
-        screen.queryByText('Verkauf abgeschlossen.'),
-      ).not.toBeInTheDocument()
-    })
+    // Der Auto-Dismiss-Timer schließt den Pop und löst erst dann den
+    // nachgelagerten Refetch aus (Tap-zum-Schließen entfällt).
+    await waitFor(
+      () => {
+        expect(
+          screen.queryByText('Verkauf abgeschlossen.'),
+        ).not.toBeInTheDocument()
+      },
+      { timeout: 2000 },
+    )
     expect(reload).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/service/components/ErfolgsPop.test.tsx
+++ b/frontend/src/service/components/ErfolgsPop.test.tsx
@@ -62,17 +62,14 @@ describe('ErfolgsPop', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1)
   })
 
-  it('trägt pointer-events-none und schließt nicht beim Antippen', () => {
+  it('schließt beim Antippen sofort', () => {
     const onDismiss = vi.fn()
     render(<ErfolgsPop open text="Fertig" onDismiss={onDismiss} />)
 
-    const pop = screen.getByRole('status')
-    expect(pop).toHaveClass('pointer-events-none')
+    fireEvent.click(screen.getByRole('status'))
 
-    fireEvent.click(pop)
-
-    // Der Tap wird nicht mehr abgefangen; nur der Auto-Dismiss-Timer schließt.
-    expect(onDismiss).not.toHaveBeenCalled()
+    // Ein Tap schließt den Pop früher als der Auto-Dismiss-Timer.
+    expect(onDismiss).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -161,7 +158,7 @@ describe('Erfolgs-Pop im Buchungsflow', () => {
     expect(toast.success).not.toHaveBeenCalled()
 
     // Der Auto-Dismiss-Timer schließt den Pop und löst erst dann den
-    // nachgelagerten Refetch aus (Tap-zum-Schließen entfällt).
+    // nachgelagerten Refetch aus.
     await waitFor(
       () => {
         expect(

--- a/frontend/src/service/components/ErfolgsPop.tsx
+++ b/frontend/src/service/components/ErfolgsPop.tsx
@@ -2,7 +2,9 @@ import { Check } from 'lucide-react'
 import { useEffect } from 'react'
 
 // Anzeigedauer bis zum automatischen Schließen (Motion-Inventar „Erfolgs-Pop",
-// ~1,4 s). Ein Tippen schließt jederzeit früher.
+// ~1,4 s). Der Auto-Dismiss-Timer ist die alleinige Schließ-Logik; ein Tap wird
+// bewusst nicht mehr abgefangen (pointer-events-none), damit er sein Ziel unter
+// dem Overlay erreicht.
 const ANZEIGE_DAUER_MS = 1400
 
 interface ErfolgsPopProps {
@@ -11,13 +13,22 @@ interface ErfolgsPopProps {
   onDismiss: () => void
 }
 
+// Vollbild-Overlay des sichtbaren Pops: solide Abdunklung als Fallback, darüber
+// die feinere color-mix-Tönung für moderne Browser (siehe style-Prop), Blur nur
+// dort, wo backdrop-filter unterstützt wird (analog zu dialog/drawer/sheet).
+// pointer-events-none lässt Taps zum darunterliegenden Bedienelement durch.
+const OVERLAY_CLASSES =
+  'pointer-events-none fixed inset-0 z-50 flex flex-col items-center justify-center gap-5 bg-[rgb(0_0_0/0.25)] supports-backdrop-filter:backdrop-blur-[6px]'
+
 // Unübersehbare Buchungsbestätigung im Service: Vollbild-Overlay mit geblurtem
 // Backdrop und Häkchen-Kreis in Primärgrün, das nach kurzer Zeit automatisch
-// wieder verschwindet. Ersetzt in den drei Buchungsflows (Bestellen, Kassieren,
-// Direktverkauf) den bisherigen Erfolgs-Toast. role="status" lässt Screenreader
-// den Text wie zuvor den Toast ankündigen. Der Pop meldet das Schließen (Auto
-// oder Tap) über onDismiss; der nachgelagerte Statuswechsel/Refetch folgt erst
-// dann, sodass sichtbare Änderungen dem Pop folgen.
+// wieder verschwindet. Wird in den drei Buchungsflows (Bestellen, Kassieren,
+// Direktverkauf) statt eines Toasts genutzt. Die role="status"-Live-Region ist
+// dauerhaft gemountet und wechselt nur ihren Textinhalt, damit Screenreader den
+// Erfolg zuverlässig ankündigen (eine frisch befüllt gemountete Region wird oft
+// verschluckt). Der Pop meldet das Schließen über onDismiss (Auto-Dismiss); der
+// nachgelagerte Statuswechsel/Refetch folgt erst dann, sodass sichtbare
+// Änderungen dem Pop folgen.
 export function ErfolgsPop({ open, text, onDismiss }: ErfolgsPopProps) {
   useEffect(() => {
     if (!open) return
@@ -27,21 +38,33 @@ export function ErfolgsPop({ open, text, onDismiss }: ErfolgsPopProps) {
     }
   }, [open, onDismiss])
 
-  if (!open) return null
-
   return (
     <div
       role="status"
-      onClick={onDismiss}
-      className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-5 bg-[color-mix(in_oklab,var(--background)_55%,transparent)] backdrop-blur-[6px]"
+      className={open ? OVERLAY_CLASSES : 'sr-only'}
+      // Die color-mix-Tönung liegt inline über der soliden bg-Fallback-Klasse:
+      // moderne Browser nutzen sie, iOS Safari 16.0–16.1 verwirft sie und
+      // behält die sichtbare Abdunklung.
+      style={
+        open
+          ? {
+              backgroundColor:
+                'color-mix(in oklab, var(--background) 55%, transparent)',
+            }
+          : undefined
+      }
     >
-      {/* Spring-Pop (450 ms) statt der kanonischen 350 ms von animate-pop. */}
-      <div className="flex size-[76px] items-center justify-center rounded-full bg-primary text-white ring-8 ring-primary/15 animate-pop [animation-duration:450ms] [animation-timing-function:cubic-bezier(0.34,1.56,0.64,1)]">
-        <Check className="size-[34px]" strokeWidth={3} aria-hidden />
-      </div>
-      <p className="animate-fade-up text-[17px] font-semibold [animation-delay:100ms] [animation-duration:350ms]">
-        {text}
-      </p>
+      {open && (
+        <>
+          {/* Spring-Pop (450 ms) statt der kanonischen 350 ms von animate-pop. */}
+          <div className="flex size-[76px] items-center justify-center rounded-full bg-primary text-white ring-8 ring-primary/15 animate-pop [animation-duration:450ms] [animation-timing-function:cubic-bezier(0.34,1.56,0.64,1)]">
+            <Check className="size-[34px]" strokeWidth={3} aria-hidden />
+          </div>
+          <p className="animate-fade-up text-[17px] font-semibold [animation-delay:100ms] [animation-duration:350ms]">
+            {text}
+          </p>
+        </>
+      )}
     </div>
   )
 }

--- a/frontend/src/service/components/ErfolgsPop.tsx
+++ b/frontend/src/service/components/ErfolgsPop.tsx
@@ -2,9 +2,7 @@ import { Check } from 'lucide-react'
 import { useEffect } from 'react'
 
 // Anzeigedauer bis zum automatischen Schließen (Motion-Inventar „Erfolgs-Pop",
-// ~1,4 s). Der Auto-Dismiss-Timer ist die alleinige Schließ-Logik; ein Tap wird
-// bewusst nicht mehr abgefangen (pointer-events-none), damit er sein Ziel unter
-// dem Overlay erreicht.
+// ~1,4 s). Ein Tap schließt jederzeit früher.
 const ANZEIGE_DAUER_MS = 1400
 
 interface ErfolgsPopProps {
@@ -15,10 +13,12 @@ interface ErfolgsPopProps {
 
 // Vollbild-Overlay des sichtbaren Pops: solide Abdunklung als Fallback, darüber
 // die feinere color-mix-Tönung für moderne Browser (siehe style-Prop), Blur nur
-// dort, wo backdrop-filter unterstützt wird (analog zu dialog/drawer/sheet).
-// pointer-events-none lässt Taps zum darunterliegenden Bedienelement durch.
+// dort, wo backdrop-filter unterstützt wird (analog zu dialog/drawer/sheet). Das
+// Overlay blockiert bewusst Interaktion, bis es sich schließt: Der nachgelagerte
+// Refetch (onDismiss in TablePage) soll greifen, bevor der nächste Tap ein noch
+// nicht aktualisiertes Bedienelement trifft.
 const OVERLAY_CLASSES =
-  'pointer-events-none fixed inset-0 z-50 flex flex-col items-center justify-center gap-5 bg-[rgb(0_0_0/0.25)] supports-backdrop-filter:backdrop-blur-[6px]'
+  'fixed inset-0 z-50 flex flex-col items-center justify-center gap-5 bg-[rgb(0_0_0/0.25)] supports-backdrop-filter:backdrop-blur-[6px]'
 
 // Unübersehbare Buchungsbestätigung im Service: Vollbild-Overlay mit geblurtem
 // Backdrop und Häkchen-Kreis in Primärgrün, das nach kurzer Zeit automatisch
@@ -26,8 +26,8 @@ const OVERLAY_CLASSES =
 // Direktverkauf) statt eines Toasts genutzt. Die role="status"-Live-Region ist
 // dauerhaft gemountet und wechselt nur ihren Textinhalt, damit Screenreader den
 // Erfolg zuverlässig ankündigen (eine frisch befüllt gemountete Region wird oft
-// verschluckt). Der Pop meldet das Schließen über onDismiss (Auto-Dismiss); der
-// nachgelagerte Statuswechsel/Refetch folgt erst dann, sodass sichtbare
+// verschluckt). Der Pop meldet das Schließen über onDismiss (Auto-Dismiss oder
+// Tap); der nachgelagerte Statuswechsel/Refetch folgt erst dann, sodass sichtbare
 // Änderungen dem Pop folgen.
 export function ErfolgsPop({ open, text, onDismiss }: ErfolgsPopProps) {
   useEffect(() => {
@@ -42,6 +42,7 @@ export function ErfolgsPop({ open, text, onDismiss }: ErfolgsPopProps) {
     <div
       role="status"
       className={open ? OVERLAY_CLASSES : 'sr-only'}
+      onClick={open ? onDismiss : undefined}
       // Die color-mix-Tönung liegt inline über der soliden bg-Fallback-Klasse:
       // moderne Browser nutzen sie, iOS Safari 16.0–16.1 verwirft sie und
       // behält die sichtbare Abdunklung.

--- a/website/src/components/AnfrageFormular.tsx
+++ b/website/src/components/AnfrageFormular.tsx
@@ -17,7 +17,7 @@ import { betreiberEmail } from '../lib/links'
 // bei gültigem Absenden den vorbefüllten mailto-Entwurf per JS-Navigation
 // (window.location.href — bewusst kein natives <form action="mailto:">, das
 // die Produktiv-CSP form-action 'self' blockt) und wechselt in einen ehrlichen
-// Bestätigungs-State: der Entwurf ist geöffnet und muss noch gesendet werden.
+// Erfolgs-State: der Entwurf ist geöffnet und muss noch gesendet werden.
 //
 // Fehler sind programmatisch verknüpft (aria-invalid + aria-describedby am
 // Feld) und werden zusätzlich über eine assertive Live-Region angekündigt. Die
@@ -69,7 +69,7 @@ export default function AnfrageFormular() {
     if (hatFehler(gefunden)) {
       setFehler(gefunden)
       setAnkuendigung(
-        'Die Anfrage konnte nicht geöffnet werden. Bitte fülle die markierten Pflichtfelder aus.',
+        'Der E-Mail-Entwurf konnte nicht geöffnet werden. Bitte fülle die markierten Pflichtfelder aus.',
       )
       // Fokus auf das erste fehlerhafte Feld.
       const erstesFeld = (['verein', 'name', 'email'] as const).find(
@@ -114,7 +114,7 @@ export default function AnfrageFormular() {
           <p className="mt-3 max-w-[34em] text-[15.5px] leading-relaxed text-muted">
             Wir haben einen vorbefüllten E-Mail-Entwurf in deinem Mailprogramm
             geöffnet. Bitte prüfe ihn und <strong>sende ihn ab</strong> — erst
-            dann erreicht uns deine Anfrage.
+            mit dem Absenden ist die Nutzungsvereinbarung geschlossen.
           </p>
           <p className="mt-4 text-[14px] text-muted">
             Öffnet sich kein Entwurf? Schreib direkt an{' '}
@@ -159,10 +159,11 @@ export default function AnfrageFormular() {
       </div>
 
       <h2 className="font-brand text-[22px] font-bold tracking-[-0.02em]">
-        Nutzungsvereinbarung anfragen
+        Nutzungsvereinbarung abschließen
       </h2>
       <p className="mt-1.5 mb-[22px] text-[14px] text-muted">
-        Wir melden uns mit den nächsten Schritten.
+        Eine einzige E-Mail schließt die Vereinbarung ab — danach könnt ihr
+        direkt loslegen.
       </p>
 
       <div className="flex flex-col gap-[15px]">
@@ -268,12 +269,12 @@ export default function AnfrageFormular() {
         type="submit"
         className="btn btn-primary mt-[22px] w-full"
       >
-        Anfrage senden
+        Vereinbarung abschließen
         <ArrowRight size={17} aria-hidden="true" />
       </button>
       <p className="mt-3.5 text-center text-[12px] leading-[1.5] text-muted">
-        Kostenlos & unverbindlich. Das Formular öffnet nur einen vorbefüllten
-        E-Mail-Entwurf — gesendet wird er von dir.
+        Kostenlos für gemeinnützige Organisationen. Das Formular öffnet nur einen
+        vorbefüllten E-Mail-Entwurf — gesendet wird er von dir.
       </p>
     </form>
   )

--- a/website/src/lib/anfrage-mailto.test.ts
+++ b/website/src/lib/anfrage-mailto.test.ts
@@ -68,14 +68,25 @@ describe('buildMailtoUrl', () => {
       ).search,
     )
     expect(params.get('subject')).toBe(
-      'Nutzungsvereinbarung anfragen – TSV Musterhausen e.V.',
+      'Nutzungsvereinbarung jotti — TSV Musterhausen e.V.',
     )
     const body = params.get('body') ?? ''
-    expect(body).toContain('Verein / Organisation: TSV Musterhausen e.V.')
-    expect(body).toContain('Ansprechpartner:in: Erika Mustermann')
-    expect(body).toContain('E-Mail: vorstand@musterhausen.de')
+    expect(body).toContain('wir sind TSV Musterhausen e.V.')
     expect(body).toContain('Rechtsform: Eingetragener Verein (e.V.)')
+    expect(body).toContain(
+      'Ansprechperson: Erika Mustermann, vorstand@musterhausen.de',
+    )
     expect(body).toContain('Nachricht:\nFür unser Sommerfest im Juli.')
+  })
+
+  it('enthält den wörtlichen Annahmesatz mit Fassungsbezug und TERMS-URL', () => {
+    const body =
+      new URLSearchParams(new URL(buildMailtoUrl(felder())).search).get(
+        'body',
+      ) ?? ''
+    expect(body).toContain(
+      'akzeptieren die Nutzungsbedingungen für jotti in der Fassung vom 14. Juli 2026 (https://github.com/nicograef/jotti/blob/main/TERMS.md).',
+    )
   })
 
   it('lässt den Nachrichten-Block weg, wenn keine Nachricht eingegeben wurde', () => {
@@ -95,7 +106,7 @@ describe('buildMailtoUrl', () => {
       ).search,
     )
     expect(params.get('subject')).toBe(
-      'Nutzungsvereinbarung anfragen – TSV Musterhausen e.V.',
+      'Nutzungsvereinbarung jotti — TSV Musterhausen e.V.',
     )
     expect(params.get('body')).toContain('Nachricht:\nHallo')
   })
@@ -107,7 +118,7 @@ describe('buildMailtoUrl', () => {
     expect(url).toContain(encodeURIComponent('Schützenverein Grünäöüß'))
     // Round-trip: decodiert steht der Originaltext wieder im Betreff.
     const subject = new URLSearchParams(new URL(url).search).get('subject')
-    expect(subject).toBe('Nutzungsvereinbarung anfragen – Schützenverein Grünäöüß')
+    expect(subject).toBe('Nutzungsvereinbarung jotti — Schützenverein Grünäöüß')
   })
 
   it('encodiert Zeilenumbrüche im Body als %0A', () => {

--- a/website/src/lib/anfrage-mailto.ts
+++ b/website/src/lib/anfrage-mailto.ts
@@ -1,7 +1,7 @@
 // UI-freies Logik-Modul des Anfrage-Formulars (/fuer-vereine).
 // Baut aus den Feldwerten eine korrekt encodierte mailto-URL (Empfänger ist die
-// Betreiber-Adresse aus links.ts, Betreff und strukturierter Body aus den
-// Feldern) und validiert die Pflichtfelder. Kein DOM, keine React-Abhängigkeit —
+// Betreiber-Adresse aus links.ts, Betreff und Annahme-E-Mail-Body nach der
+// TERMS.md-Vorlage) und validiert die Pflichtfelder. Kein DOM, keine React-Abhängigkeit —
 // die AnfrageFormular-Island (src/components/AnfrageFormular.tsx) rendert die
 // Felder, ruft dieses Modul auf und öffnet die URL per JS-Navigation (kein
 // natives <form action="mailto:">, das die Produktiv-CSP form-action 'self'
@@ -10,7 +10,7 @@
 // Feldnamen und Rechtsform-Labels stammen aus dem Handoff-Prototyp
 // (PRD docs/prds/prd-website-redesign.md).
 
-import { betreiberEmail } from './links'
+import { betreiberEmail, githubUrl } from './links'
 
 export interface AnfrageFelder {
   verein: string
@@ -67,24 +67,32 @@ export function hatFehler(fehler: AnfrageFehler): boolean {
 
 // Baut die mailto-URL: Empfänger als roher addr-spec im Pfad, Betreff und Body
 // per encodeURIComponent (encodiert Umlaute, Zeilenumbrüche als %0A, Leerzeichen
-// als %20 und Sonderzeichen wie & ? = +). Der Body ist ein strukturierter
-// Feld-Abzug; der optionale Nachrichten-Block entfällt, wenn keine Nachricht
-// eingegeben wurde.
+// als %20 und Sonderzeichen wie & ? = +). Betreff und Body folgen der
+// E-Mail-Vorlage aus TERMS.md: Die Nutzungsvereinbarung kommt durch diese eine
+// Annahme-E-Mail zustande, deshalb enthält der Body den wörtlichen Annahmesatz
+// mit Fassungsbezug (14. Juli 2026) und der TERMS-URL neben den Kontaktfeldern.
+// Der optionale Nachrichten-Block entfällt, wenn keine Nachricht eingegeben wurde.
 export function buildMailtoUrl(felder: AnfrageFelder): string {
   const verein = felder.verein.trim()
-  const betreff = `Nutzungsvereinbarung anfragen – ${verein}`
+  const betreff = `Nutzungsvereinbarung jotti — ${verein}`
+
+  const termsUrl = `${githubUrl}/blob/main/TERMS.md`
 
   const zeilen = [
-    `Verein / Organisation: ${verein}`,
-    `Ansprechpartner:in: ${felder.name.trim()}`,
-    `E-Mail: ${felder.email.trim()}`,
+    'Hallo Herr Gräf,',
+    '',
+    `wir sind ${verein} und akzeptieren die Nutzungsbedingungen für jotti in der Fassung vom 14. Juli 2026 (${termsUrl}).`,
+    '',
     `Rechtsform: ${felder.art.trim()}`,
+    `Ansprechperson: ${felder.name.trim()}, ${felder.email.trim()}`,
   ]
 
   const nachricht = felder.message.trim()
   if (nachricht) {
     zeilen.push('', 'Nachricht:', nachricht)
   }
+
+  zeilen.push('', 'Mit freundlichen Grüßen', felder.name.trim(), verein)
 
   const body = zeilen.join('\n')
 

--- a/website/src/pages/fuer-vereine.astro
+++ b/website/src/pages/fuer-vereine.astro
@@ -6,7 +6,7 @@ import AnfrageFormular from '../components/AnfrageFormular.tsx'
 import { betreiberEmail } from '../lib/links'
 
 // Seite „Für Vereine" (/fuer-vereine, Handoff-Prototyp data-vereine). Erklärt
-// die Nutzungsanfrage, benennt das freiwillige (kostenpflichtige) Service-
+// den Abschluss der Nutzungsvereinbarung, benennt das freiwillige (kostenpflichtige) Service-
 // Angebot, trägt nahe dem Formular einen Beta-Hinweis (dritter Träger der
 // Beta-Kommunikation neben Hero-Badge und Download-Pill) und zeigt die
 // Betreiber-Mailadresse sichtbar als Fallback. Das Formular selbst ist die
@@ -14,7 +14,7 @@ import { betreiberEmail } from '../lib/links'
 
 const title = 'Für Vereine – jotti'
 const description =
-  'Kostenlose Nutzungsvereinbarung für jotti anfragen: Das Formular öffnet einen vorbefüllten E-Mail-Entwurf an den Betreiber. Für eingetragene Vereine, gemeinnützige Organisationen und NPOs.'
+  'Kostenlose Nutzungsvereinbarung für jotti abschließen: Das Formular öffnet einen vorbefüllten E-Mail-Entwurf an den Betreiber — eine einzige E-Mail genügt. Für eingetragene Vereine, gemeinnützige Organisationen und NPOs.'
 
 // „Das ist drin" (Handoff): vier Punkte mit Spektral-Akzent, der vierte benennt
 // das freiwillige Service-Angebot.
@@ -45,18 +45,18 @@ const leistungen = [
 const schritte = [
   {
     accent: 'var(--sp-red)',
-    titel: 'Anfrage senden',
-    text: 'Das Formular ausfüllen — dauert eine Minute.',
+    titel: 'Vereinbarung abschließen',
+    text: 'Formular ausfüllen und die vorbefüllte Annahme-E-Mail absenden — mehr braucht es nicht.',
   },
   {
     accent: 'var(--sp-teal)',
-    titel: 'Vereinbarung in Textform',
-    text: 'Kurze Nutzungsvereinbarung per E-Mail — kostenlos.',
+    titel: 'Herunterladen & einrichten',
+    text: 'jotti von GitHub laden und auf eurem Rechner oder Server aufsetzen.',
   },
   {
     accent: 'var(--sp-violet)',
     titel: 'Loslegen',
-    text: 'Herunterladen, einrichten, kassieren.',
+    text: 'Produkte und Tische anlegen — und kassieren.',
   },
 ]
 ---


### PR DESCRIPTION
## Kontext

Umsetzung der bestätigten Befunde eines Multi-Experten-Reviews der letzten 20 Commits (Spektral-Redesign + Cleanup-Refactor + Vertragsvereinfachung). Der Plan liegt bei `docs/plans/plan-review-findings.md`. Alle Änderungen sind Korrektheits-, Robustheits- und Konsistenzfixes — kein neues Feature, keine Änderung an persistierten Daten, kein Eingriff in die Freeze-Disziplin (Backend/Event-Contracts/DSFinV-K-Format unangetastet).

## Was geändert wurde (nach Plan-Phasen)

**1 — Erfolgs-Pop gehärtet** (`fix(service)`): Der Pop bleibt (nicht durch Toast ersetzt), aber der Backdrop bekommt `pointer-events-none`, sodass ein Tap im 1,4-s-Fenster sein Ziel erreicht statt verschluckt zu werden; der Auto-Dismiss-Timer ist die alleinige Schließ-Logik. Solider rgb()-Fallback unter der `color-mix()`-Tönung, Blur hinter `supports-backdrop-filter` (wie die anderen Overlays). `role="status"`-Live-Region dauerhaft gemountet, nur Text getoggelt (zuverlässigere Screenreader-Ansage).

**2 — Alt-Browser-/Kleingerät-Robustheit** (`fix(frontend)`): Solider `background: var(--muted)`-Fallback vor dem Skeleton-Shimmer-Gradient (grau statt transparent ohne `color-mix()`). AuthLayout-Glow-Clipping in eine eigene `-z-10`-Ebene verlagert, `max-h-screen`/`overflow-hidden` vom Wrapper entfernt — hohe Auth-Karten (Passwort setzen) bleiben auf kurzen/Landscape-Viewports scrollbar.

**3 — Vertragswerk & Website-Funnel** (`fix(website)`): Das Formular erzeugt jetzt eine **Annahme-E-Mail** (Betreff/Body nach der `TERMS.md`-Vorlage, inkl. wörtlichem Annahmesatz, Fassungsbezug „14. Juli 2026" und TERMS-URL) statt eines bloßen Feld-Abzugs; Funnel-Texte und die `/fuer-vereine`-Schritte beschreiben den Ein-E-Mail-Abschluss ohne Autor-Bestätigung. LICENSE Section 9 erhält denselben Vorsatz/grobe-Fahrlässigkeit-Carve-out wie TERMS § 6(3); Section 12 wird eine schlichte Salvatorik.

**4 — Admin-Layout (bestandsalte Defekte)** (`fix(admin)`): Mobiler Header ab `md` ausgeblendet (kein Doppel-Chrome im 768–1023px-Band); `min-w-0` am Admin-`main` (truncatende Zeilen schrumpfen, statt die Seite zu verbreitern); Kassenberichte-Zweispalter auf `lg` mit `minmax(0,1fr)`-Berichtsspalte, DSFinV-K-Export-Zeile stapelt auf schmalen Breiten; Seitenkopf-Aktionszeile bricht um. Neuer `formatEuro()`-Helper (geschütztes Leerzeichen) — die Reporting-Beträge und `formatAlleAuswaehlenLabel` laufen darüber, damit `€` nie vom Betrag umbricht.

## Worauf beim Review achten

- **Erfolgs-Pop-Verhalten** (`ErfolgsPop.tsx`): `pointer-events-none` heißt, ein Tap schließt den Pop nicht mehr aktiv — der 1,4-s-Timer tut das. Bewusst so, um den ADR-01-Reibungspunkt (verschluckter Tap) zu beseitigen.
- **Breakpoint-Abweichung Kassenberichte** (`KassenberichtePage.tsx`): Der Zweispalter wandert von `md` auf **`lg`**. Grund: bei 768px + sichtbarer Sidebar bleiben der Berichtsspalte nur ~148px, aber der nicht umbrechbare Button „Archiv herunterladen (ZIP)" ist ~221px breit. Tablet-Portrait ist jetzt sauber einspaltig, zweispaltig erst ab 1024px.
- **LICENSE-Wortlaut** (Section 9/12): rechtliche Textänderung — bitte den finalen Wortlaut gegenlesen (Review-Einschätzung, keine Rechtsberatung).

## Verifikation

- `make`-Ebene: Frontend **Lint + Build** grün, Frontend-Tests **393 passed**, Website-Tests **36 passed**, `astro check` + Build grün.
- **Cross-Device-Screenshots**: 91 Kombinationen (13 Routen × 7 Viewports, 375×667 bis 1280×800) auf einer laufenden, seed-befüllten Instanz — **null horizontaler Überlauf, null Konsolenfehler**. Set-Passwort-Seite zusätzlich bei 375×667 und 667×375 geprüft (Karte vollständig scrollbar erreichbar).
- Backend/Event-Contracts/DSFinV-K: nicht berührt.