### PR TITLE
docs: PRD and implementation plan for product/variant sales statistics (R-05)

### DIFF
--- a/docs/plans/plan-produkt-varianten-statistik.md
+++ b/docs/plans/plan-produkt-varianten-statistik.md
@@ -10,7 +10,7 @@ und Variante — je Zeile zwei getrennte Zahlen: **ausgegebene Menge** (Bestellu
 Warenrücknahme/Storno). Gegliedert in Kategorie-Abschnitte (Essen → Getränke →
 Sonstiges), pro Variante aufgeschlüsselt und auf Produktebene mit Zwischensumme
 gruppiert, Ein-Varianten-Produkte zu einer Zeile zusammengefasst, je Kategorie
-nach Menge aufsteigend sortiert. Angezeigt sowohl in der Tagesabrechnung
+nach Menge absteigend sortiert. Angezeigt sowohl in der Tagesabrechnung
 (`get-abrechnung`) als auch im Live-Dashboard (`get-live-reporting`). Setzt die
 Roadmap-Anforderung **R-05** um.
 
@@ -76,8 +76,8 @@ Dauerhafte Entscheidungen, die für alle Phasen gelten:
   `computeUmsatzProSteuersatz` in `query.go`) baut aus den flachen
   `ProduktStatistikZeile`-Werten die Produkt-Hierarchie, berechnet Zwischensummen
   und sortiert: Kategorien fest Essen → Getränke → Sonstiges; Produkte je Kategorie
-  nach `AusgegebeneMenge` aufsteigend; Varianten je Produkt nach `AusgegebeneMenge`
-  aufsteigend; `ProduktName`/`VarianteName` als stabiler Tiebreaker. Backend liefert
+  nach `AusgegebeneMenge` absteigend; Varianten je Produkt nach `AusgegebeneMenge`
+  absteigend; `ProduktName`/`VarianteName` als stabiler Tiebreaker. Backend liefert
   die Liste fertig sortiert. Isoliert unit-testbar (flache Eingabe → gruppierte,
   sortierte Ausgabe).
 - **JSON-Contract** (HTTP-Response-DTO in
@@ -141,16 +141,14 @@ Dauerhafte Entscheidungen, die für alle Phasen gelten:
   bewusst nicht ineinander umrechenbar; erklärender Hinweis im Report.
 - **Direktverkauf** zählt in beide Zahlen.
 - **Kategorie-Abschnitte** Essen → Getränke → Sonstiges; keine Kategorie-Summenzeile.
-- **Sortierung nach ausgegebener Menge aufsteigend** je Kategorie.
+- **Sortierung nach ausgegebener Menge absteigend** je Kategorie.
 - **Ein-Varianten-Produkte** als eine Zeile (Beschriftung `produktName varianteName`).
 - **Kein neues Event, keine Migration, kein Stammdaten-Join.**
 - Gruppierung/Sortierung im **Backend** (Single Source of Truth für Aufbereitung).
 
 ## Open questions / Risks
 
-- **Sortierrichtung**: „aufsteigend" ist wie festgelegt umgesetzt (kleinste Menge
-  zuerst). Falls Top-Seller oben gewünscht, ist es eine reine Umkehr der
-  Vergleichsfunktion — kein Struktureingriff.
+- **Sortierrichtung**: absteigend nach Menge (Meistverkaufte oben) — festgelegt.
 - **Konsistenz-Invariante**: Σ aller Produkt-`UmsatzCents` muss dem kassierten
   Gesamtumsatz (= Σ `UmsatzProSteuersatz`-Brutto) entsprechen — dieselbe
   Positions-Basis. Einziger realer Bruchweg: die `WHERE type IN (…)`-Menge der
@@ -191,7 +189,7 @@ Varianten-Zeilen mit ausgegebener Menge und Umsatz (Vorzeichen laut Event-Mappin
 oben). Eine dedizierte Repo-Methode `GetProduktStatistik` mappt die Rows in
 `[]ProduktStatistikZeile`. Die reine Funktion `gruppiereProduktStatistik` in der
 Anwendungsschicht gruppiert diese zu Kategorie-Abschnitten und Produkten mit
-Zwischensummen und sortiert sie (Kategorie-Reihenfolge fest, Menge aufsteigend,
+Zwischensummen und sortiert sie (Kategorie-Reihenfolge fest, Menge absteigend,
 Name-Tiebreaker); `Query.GetReporting` weist das Ergebnis
 `data.ProduktStatistik` zu. Es wird als `produktStatistik`-Feld der
 `get-abrechnung`-Response serialisiert, im Frontend per Zod validiert und in
@@ -212,11 +210,11 @@ Teil des Z-Bons.
   eine geldneutrale Korrektur mindert nur die Menge, nicht den Umsatz.
 - [ ] Die Ausgabe ist in Kategorie-Abschnitte (Essen → Getränke → Sonstiges)
   gegliedert; je Produkt gibt es eine Zwischensumme über seine Varianten; Produkte
-  und Varianten sind nach ausgegebener Menge aufsteigend sortiert (Name-Tiebreaker).
+  und Varianten sind nach ausgegebener Menge absteigend sortiert (Name-Tiebreaker).
 - [ ] `gruppiereProduktStatistik` ist als reine Funktion isoliert unit-getestet
   (`query_test.go`, Muster `computeUmsatzProSteuersatz`): flache
   `ProduktStatistikZeile`-Eingabe → korrekte Kategorie-Reihenfolge, Produkt-Gruppen,
-  Zwischensummen, aufsteigende Mengensortierung und stabiler Tiebreaker.
+  Zwischensummen, absteigende Mengensortierung und stabiler Tiebreaker.
 - [ ] Σ aller Produkt-`umsatzCents` entspricht der Summe der
   `umsatzProSteuersatz`-Bruttowerte derselben Kassensitzung. Diese Invariante wird
   im **Repo-Integrationstest** (`repo_test.go`, echtes Postgres, dieselben Events

--- a/docs/plans/plan-produkt-varianten-statistik.md
+++ b/docs/plans/plan-produkt-varianten-statistik.md
@@ -31,6 +31,12 @@ Dauerhafte Entscheidungen, die für alle Phasen gelten:
   liefert (`GROUP BY kategorie, varianteId, produktName, varianteName`). Kein neuer
   `kj_extract_*`-DB-Helper (die Vorzeichen-Logik steht inline in der Query). Nach
   Query-Änderung: `make sqlc`.
+  - Casts wie in den bestehenden Reporting-Queries: `(position->>'varianteId')::int`,
+    `(position->>'menge')::int`, `(position->>'einzelpreisCents')::int` sowie
+    `COALESCE(SUM(... CASE ...), 0)::int` für beide Summenspalten, damit sqlc
+    Go-`int` erzeugt (passend zu den `int`-Domänenfeldern). `kategorie`,
+    `produktName`, `varianteName` bleiben `text` — **kein** Enum-Cast (die Query
+    trägt keinen `Steuersatz`, anders als `GetUmsatzPositionszeilen`).
 - **Event-Mapping** (in der SQL-Query als `CASE`):
   - *Ausgegebene Menge* = Σ `menge`: `bestellung-aufgenommen:v1` (+),
     `bestellung-korrigiert:v1` (−), `direktverkauf-getaetigt:v1` (+).
@@ -40,20 +46,40 @@ Dauerhafte Entscheidungen, die für alle Phasen gelten:
   - `bestellung-umgebucht:v1` wird **nicht** gezählt (Positionen bereits bei der
     Bestellung erfasst).
 - **Domänen-Modelle** (`backend/domain/reporting/reporting.go`, keine `json`-Tags):
+  - `ProduktStatistikZeile` — **flacher Zeilentyp** (Repo-Ausgabe, Eingabe der
+    Gruppierung): `Kategorie string`, `ProduktName string`, `VarianteID int`,
+    `VarianteName string`, `AusgegebeneMenge int`, `UmsatzCents int`. Genau die
+    Spalten der SQL-Query.
   - `VarianteStatistik` — `VarianteID int`, `VarianteName string`,
     `AusgegebeneMenge int`, `UmsatzCents int`.
   - `ProduktStatistik` — `Kategorie string`, `ProduktName string`,
     `AusgegebeneMenge int` (Zwischensumme), `UmsatzCents int` (Zwischensumme),
     `Varianten []VarianteStatistik`.
   - Neues Feld `ProduktStatistik []ProduktStatistik` auf `ReportingData` **und**
-    `LiveReportingData`.
-- **Gruppierung/Sortierung**: eine reine Funktion in der Anwendungsschicht
-  (`backend/api/reporting/application/`, analog `computeUmsatzProSteuersatz` in
-  `query.go`) baut aus den flachen Varianten-Zeilen die Produkt-Hierarchie,
-  berechnet Zwischensummen und sortiert: Kategorien fest Essen → Getränke →
-  Sonstiges; Produkte je Kategorie nach `AusgegebeneMenge` aufsteigend; Varianten
-  je Produkt nach `AusgegebeneMenge` aufsteigend; `ProduktName`/`VarianteName` als
-  stabiler Tiebreaker. Backend liefert die Liste fertig sortiert.
+    `LiveReportingData` (die *gruppierte* Form; die flachen Zeilen erscheinen nie
+    in der Response).
+- **Repo → Gruppierung → Response (Plumbing, ausdrücklich festgelegt):** die
+  `computeUmsatzProSteuersatz`-In-place-Analogie gilt hier **nicht**, weil Ein- und
+  Ausgabe unterschiedliche Formen haben (flache Zeilen → verschachtelte
+  Produkte). Deshalb:
+  1. Eine dedizierte Repo-Methode `GetProduktStatistik(ctx, kassensitzungNr)
+     ([]reporting.ProduktStatistikZeile, error)` auf dem `reportingRepo`-Interface
+     liefert die flachen Zeilen (SQL-Rows → `ProduktStatistikZeile`).
+  2. Die Anwendungsschicht ruft sie in `Query.GetReporting` **und**
+     `Query.GetLiveReporting` auf und weist
+     `data.ProduktStatistik = gruppiereProduktStatistik(zeilen)` zu — analog dazu,
+     wie `GetLiveReporting` bereits mehrere Repos orchestriert. Kein transientes
+     Feld auf der Domäne/Response; ein zusätzlicher On-Demand-Query-Roundtrip ist
+     für einen Admin-Report vernachlässigbar.
+- **Gruppierung/Sortierung**: eine reine Funktion `gruppiereProduktStatistik`
+  in der Anwendungsschicht (`backend/api/reporting/application/`, neben
+  `computeUmsatzProSteuersatz` in `query.go`) baut aus den flachen
+  `ProduktStatistikZeile`-Werten die Produkt-Hierarchie, berechnet Zwischensummen
+  und sortiert: Kategorien fest Essen → Getränke → Sonstiges; Produkte je Kategorie
+  nach `AusgegebeneMenge` aufsteigend; Varianten je Produkt nach `AusgegebeneMenge`
+  aufsteigend; `ProduktName`/`VarianteName` als stabiler Tiebreaker. Backend liefert
+  die Liste fertig sortiert. Isoliert unit-testbar (flache Eingabe → gruppierte,
+  sortierte Ausgabe).
 - **JSON-Contract** (HTTP-Response-DTO in
   `backend/api/reporting/http/query_handler.go` und Live-Pendant): Feld
   `produktStatistik` = Array von `{ kategorie, produktName, ausgegebeneMenge,
@@ -74,7 +100,8 @@ Dauerhafte Entscheidungen, die für alle Phasen gelten:
   Zeilen) ist die direkte Vorlage.
 - `backend/repository/reporting_repo/repo.go — Repository.GetReporting()` /
   `Repository.GetLiveReporting()` — feuern die Reporting-Queries parallel per
-  `errgroup` und mappen Rows → Domäne. Hier wird die neue Query eingereiht.
+  `errgroup` und mappen Rows → Domäne. Vorlage für die neue dedizierte Methode
+  `Repository.GetProduktStatistik()`, die SQL-Rows → `[]ProduktStatistikZeile` mappt.
 - `backend/domain/reporting/reporting.go` — Read-Model-Typen (`ReportingData`,
   `LiveReportingData`, `UmsatzServicekraft`, `StornierungPosition`); Vorlage für
   die neuen Typen und den neuen Feld-Anbau.
@@ -126,7 +153,9 @@ Dauerhafte Entscheidungen, die für alle Phasen gelten:
   Vergleichsfunktion — kein Struktureingriff.
 - **Konsistenz-Invariante**: Σ aller Produkt-`UmsatzCents` muss dem kassierten
   Gesamtumsatz (= Σ `UmsatzProSteuersatz`-Brutto) entsprechen — dieselbe
-  Positions-Basis. Wird per Test abgesichert (Phase 1).
+  Positions-Basis. Einziger realer Bruchweg: die `WHERE type IN (…)`-Menge der
+  neuen Query driftet von `GetUmsatzPositionszeilen` ab. Abgesichert im
+  Repo-Integrationstest (Phase 1), nicht im Anwendungs-Unit-Test.
 
 ---
 
@@ -141,7 +170,9 @@ Dauerhafte Entscheidungen, die für alle Phasen gelten:
 - `backend/domain/reporting/reporting.go` — Read-Model-Typen; neue Typen +
   Feld-Anbau an `ReportingData`.
 - `backend/repository/reporting_repo/repo.go — Repository.GetReporting()` —
-  `errgroup`, in den die neue Query eingereiht wird; Row→Domäne-Mapping.
+  Row→Domäne-Mapping-Muster; die neue Query kommt als **dedizierte Methode**
+  `Repository.GetProduktStatistik()` hinzu (nicht in die `GetReporting`-`errgroup`
+  eingereiht), aufgerufen von der Anwendungsschicht.
 - `backend/api/reporting/application/query.go — Query.GetReporting()`,
   `computeUmsatzProSteuersatz()` — Aufruf- und Muster-Vorlage für die neue reine
   Gruppierungs-/Sortierfunktion.
@@ -157,17 +188,18 @@ Dauerhafte Entscheidungen, die für alle Phasen gelten:
 Ein durchgehender vertikaler Schnitt für die Tagesabrechnung: eine neue
 sqlc-Query aggregiert die eingefrorenen Positionen einer Kassensitzung zu flachen
 Varianten-Zeilen mit ausgegebener Menge und Umsatz (Vorzeichen laut Event-Mapping
-oben). Das Repository reiht die Query in die bestehende `GetReporting`-`errgroup`
-ein und mappt die Rows in flache Varianten-Statistik-Werte. Eine reine Funktion in
-der Anwendungsschicht gruppiert diese zu Kategorie-Abschnitten und Produkten mit
+oben). Eine dedizierte Repo-Methode `GetProduktStatistik` mappt die Rows in
+`[]ProduktStatistikZeile`. Die reine Funktion `gruppiereProduktStatistik` in der
+Anwendungsschicht gruppiert diese zu Kategorie-Abschnitten und Produkten mit
 Zwischensummen und sortiert sie (Kategorie-Reihenfolge fest, Menge aufsteigend,
-Name-Tiebreaker). Das Ergebnis hängt als `ProduktStatistik []ProduktStatistik` an
-`ReportingData`, wird als `produktStatistik`-Feld der `get-abrechnung`-Response
-serialisiert, im Frontend per Zod validiert und in `ReportingResults.tsx` als neuer
-Abschnitt „Verkäufe pro Produkt" angezeigt: Kategorie-Überschriften, Produktzeile
-mit Zwischensumme und Variantenzeilen darunter, Ein-Varianten-Produkte als eine
-Zeile, Spalten „Ausgegeben" und „Umsatz" (`formatEuro`), erklärender Ein-Satz-
-Hinweis, leerer Zustand, druckfreundlich als Teil des Z-Bons.
+Name-Tiebreaker); `Query.GetReporting` weist das Ergebnis
+`data.ProduktStatistik` zu. Es wird als `produktStatistik`-Feld der
+`get-abrechnung`-Response serialisiert, im Frontend per Zod validiert und in
+`ReportingResults.tsx` als neuer Abschnitt „Verkäufe pro Produkt" angezeigt:
+Kategorie-Überschriften, Produktzeile mit Zwischensumme und Variantenzeilen
+darunter, Ein-Varianten-Produkte als eine Zeile, Spalten „Ausgegeben" und „Umsatz"
+(`formatEuro`), erklärender Ein-Satz-Hinweis, leerer Zustand, druckfreundlich als
+Teil des Z-Bons.
 
 ### Acceptance criteria
 
@@ -181,9 +213,16 @@ Hinweis, leerer Zustand, druckfreundlich als Teil des Z-Bons.
 - [ ] Die Ausgabe ist in Kategorie-Abschnitte (Essen → Getränke → Sonstiges)
   gegliedert; je Produkt gibt es eine Zwischensumme über seine Varianten; Produkte
   und Varianten sind nach ausgegebener Menge aufsteigend sortiert (Name-Tiebreaker).
+- [ ] `gruppiereProduktStatistik` ist als reine Funktion isoliert unit-getestet
+  (`query_test.go`, Muster `computeUmsatzProSteuersatz`): flache
+  `ProduktStatistikZeile`-Eingabe → korrekte Kategorie-Reihenfolge, Produkt-Gruppen,
+  Zwischensummen, aufsteigende Mengensortierung und stabiler Tiebreaker.
 - [ ] Σ aller Produkt-`umsatzCents` entspricht der Summe der
-  `umsatzProSteuersatz`-Bruttowerte derselben Kassensitzung (Konsistenz-Test grün,
-  Muster `query_export_konsistenz_test.go`).
+  `umsatzProSteuersatz`-Bruttowerte derselben Kassensitzung. Diese Invariante wird
+  im **Repo-Integrationstest** (`repo_test.go`, echtes Postgres, dieselben Events
+  speisen `GetProduktStatistik` und `GetUmsatzPositionszeilen`) geprüft — dort, wo
+  ein Drift der `WHERE type IN (…)`-Mengen real auffällt; ein
+  Anwendungs-Unit-Test mit handgebauten Eingaben kann diesen SQL-Drift nicht fangen.
 - [ ] `admin/get-abrechnung` liefert das Feld `produktStatistik` mit
   verschachtelten `varianten`; das Frontend validiert es per Zod ohne Fehler.
 - [ ] `ReportingResults.tsx` zeigt den Abschnitt „Verkäufe pro Produkt" mit
@@ -201,8 +240,9 @@ Hinweis, leerer Zustand, druckfreundlich als Teil des Z-Bons.
 
 ### Context
 
-- `backend/repository/reporting_repo/repo.go — Repository.GetLiveReporting()` —
-  zweite `errgroup`, in die dieselbe Query eingereiht wird.
+- `backend/repository/reporting_repo/repo.go — Repository.GetProduktStatistik()` —
+  in Phase 1 erstellt; wird im Live-Pfad von `Query.GetLiveReporting` unverändert
+  mitbenutzt.
 - `backend/api/reporting/application/query.go — Query.GetLiveReporting()` — ruft
   die in Phase 1 erstellte Gruppierungs-/Sortierfunktion für die Live-Daten auf.
 - `backend/domain/reporting/reporting.go — LiveReportingData` — Feld-Anbau
@@ -215,10 +255,11 @@ Hinweis, leerer Zustand, druckfreundlich als Teil des Z-Bons.
 
 ### What to build
 
-Der in Phase 1 gebaute Backend-Kern (Query, Domäne-Typen, Gruppierungs-/
-Sortierfunktion) wird in den Live-Pfad eingehängt: `GetLiveReporting` im Repository
-feuert die Query zusätzlich, die Anwendungsschicht gruppiert identisch, das Feld
-`ProduktStatistik` hängt an `LiveReportingData` und wird in der
+Der in Phase 1 gebaute Backend-Kern (Query, `GetProduktStatistik`-Repo-Methode,
+Domäne-Typen, `gruppiereProduktStatistik`) wird in den Live-Pfad eingehängt:
+`Query.GetLiveReporting` ruft dieselbe Repo-Methode und dieselbe
+Gruppierungsfunktion auf und weist `data.ProduktStatistik` zu (keine Duplikat-
+Logik); das Feld hängt an `LiveReportingData` und wird in der
 `get-live-reporting`-Response als `produktStatistik` serialisiert. Im Frontend wird
 dieselbe Anzeige-Komponente aus Phase 1 in `LiveReportingSection.tsx` eingebunden,
 sodass die Statistik der offenen Kassensitzung in Echtzeit erscheint.

--- a/docs/plans/plan-produkt-varianten-statistik.md
+++ b/docs/plans/plan-produkt-varianten-statistik.md
@@ -1,0 +1,272 @@
+# Plan: Produkt- und Varianten-Statistik im Report
+
+> Source PRD: `docs/prds/prd-produkt-varianten-statistik.md`
+
+## Goal
+
+Der Report zeigt pro Kassensitzung eine Aufschlüsselung der Verkäufe pro Produkt
+und Variante — je Zeile zwei getrennte Zahlen: **ausgegebene Menge** (Bestellung
+− Korrektur + Direktverkauf) und **Umsatz** (Kassiert + Direktverkauf −
+Warenrücknahme/Storno). Gegliedert in Kategorie-Abschnitte (Essen → Getränke →
+Sonstiges), pro Variante aufgeschlüsselt und auf Produktebene mit Zwischensumme
+gruppiert, Ein-Varianten-Produkte zu einer Zeile zusammengefasst, je Kategorie
+nach Menge aufsteigend sortiert. Angezeigt sowohl in der Tagesabrechnung
+(`get-abrechnung`) als auch im Live-Dashboard (`get-live-reporting`). Setzt die
+Roadmap-Anforderung **R-05** um.
+
+## Architectural decisions
+
+Dauerhafte Entscheidungen, die für alle Phasen gelten:
+
+- **Endpunkte**: keine neuen. Die bestehenden `admin/get-abrechnung` und
+  `admin/get-live-reporting` tragen ein neues Response-Feld `produktStatistik`.
+- **Datenquelle**: reine additive Leseauswertung über `kassenjournal`, gefiltert
+  nach `kassensitzung_nr`. Kein neues Event, keine Schema-Migration, kein Join auf
+  Stammdaten (Reporting-ACL bleibt gewahrt). Positionsdaten kommen aus den
+  eingefrorenen Fat-Events.
+- **SQL**: eine neue sqlc-Query `GetProduktStatistik` in
+  `backend/sqlc/queries/reporting.sql`, die `data->'positionen'` per
+  `jsonb_array_elements` entfaltet und **flache Zeilen pro Variante**
+  `(kategorie, varianteId, produktName, varianteName, ausgegebeneMenge, umsatzCents)`
+  liefert (`GROUP BY kategorie, varianteId, produktName, varianteName`). Kein neuer
+  `kj_extract_*`-DB-Helper (die Vorzeichen-Logik steht inline in der Query). Nach
+  Query-Änderung: `make sqlc`.
+- **Event-Mapping** (in der SQL-Query als `CASE`):
+  - *Ausgegebene Menge* = Σ `menge`: `bestellung-aufgenommen:v1` (+),
+    `bestellung-korrigiert:v1` (−), `direktverkauf-getaetigt:v1` (+).
+  - *Umsatz* = Σ `einzelpreisCents × menge`: `zahlung-kassiert:v1` (+),
+    `direktverkauf-getaetigt:v1` (+), `stornierung-erteilt:v1` (−),
+    `direktverkauf-storniert:v1` (−).
+  - `bestellung-umgebucht:v1` wird **nicht** gezählt (Positionen bereits bei der
+    Bestellung erfasst).
+- **Domänen-Modelle** (`backend/domain/reporting/reporting.go`, keine `json`-Tags):
+  - `VarianteStatistik` — `VarianteID int`, `VarianteName string`,
+    `AusgegebeneMenge int`, `UmsatzCents int`.
+  - `ProduktStatistik` — `Kategorie string`, `ProduktName string`,
+    `AusgegebeneMenge int` (Zwischensumme), `UmsatzCents int` (Zwischensumme),
+    `Varianten []VarianteStatistik`.
+  - Neues Feld `ProduktStatistik []ProduktStatistik` auf `ReportingData` **und**
+    `LiveReportingData`.
+- **Gruppierung/Sortierung**: eine reine Funktion in der Anwendungsschicht
+  (`backend/api/reporting/application/`, analog `computeUmsatzProSteuersatz` in
+  `query.go`) baut aus den flachen Varianten-Zeilen die Produkt-Hierarchie,
+  berechnet Zwischensummen und sortiert: Kategorien fest Essen → Getränke →
+  Sonstiges; Produkte je Kategorie nach `AusgegebeneMenge` aufsteigend; Varianten
+  je Produkt nach `AusgegebeneMenge` aufsteigend; `ProduktName`/`VarianteName` als
+  stabiler Tiebreaker. Backend liefert die Liste fertig sortiert.
+- **JSON-Contract** (HTTP-Response-DTO in
+  `backend/api/reporting/http/query_handler.go` und Live-Pendant): Feld
+  `produktStatistik` = Array von `{ kategorie, produktName, ausgegebeneMenge,
+  umsatzCents, varianten: [{ varianteId, varianteName, ausgegebeneMenge,
+  umsatzCents }] }`.
+- **Frontend**: neue Zod-Schemas `VarianteStatistikSchema` /
+  `ProduktStatistikSchema` in `frontend/src/admin/reporting/types.ts`, eingehängt
+  in `ReportingDataSchema` und `LiveReportingDataSchema`. Anzeige als neue
+  Komponente, eingebunden in `ReportingResults.tsx` (Abrechnung) und
+  `LiveReportingSection.tsx` (Live). Ein-Varianten-Produkte werden in der
+  Darstellung zu einer Zeile zusammengefasst (reine Präsentation; Datenmodell
+  bleibt Produkt + eine Varianten-Zeile).
+
+## Inventory
+
+- `backend/sqlc/queries/reporting.sql` — bestehende Reporting-Queries; Muster
+  `GetUmsatzPositionszeilen` (entfaltet `data->'positionen'`, liefert unaggregierte
+  Zeilen) ist die direkte Vorlage.
+- `backend/repository/reporting_repo/repo.go — Repository.GetReporting()` /
+  `Repository.GetLiveReporting()` — feuern die Reporting-Queries parallel per
+  `errgroup` und mappen Rows → Domäne. Hier wird die neue Query eingereiht.
+- `backend/domain/reporting/reporting.go` — Read-Model-Typen (`ReportingData`,
+  `LiveReportingData`, `UmsatzServicekraft`, `StornierungPosition`); Vorlage für
+  die neuen Typen und den neuen Feld-Anbau.
+- `backend/api/reporting/application/query.go — Query.GetReporting()` /
+  `Query.GetLiveReporting()` und `computeUmsatzProSteuersatz()` — Vorlage für die
+  reine Gruppierungs-/Sortierfunktion und deren Aufruf.
+- `backend/api/reporting/http/query_handler.go — toReportingResponse()`,
+  `reportingResponse`, `umsatzSteuersatzResponse`, `stornierungPosition` — DTO- und
+  Mapper-Muster; Live-Pendant im selben File (`liveSummaryResponse` ff.).
+- `backend/domain/kasse/bestellung.go — Position`, `PositionEventData`,
+  `Position.Bezeichnung()` — Positions-Felder (`VarianteID`, `ProduktName`,
+  `VarianteName`, `Kategorie`, `EinzelpreisCents`, `Menge`) und die
+  Produkt-plus-Variante-Beschriftung.
+- `backend/domain/kasse/event_json_contract_test.go` — eingefrorene JSON-Keys der
+  Positionen (`varianteId`, `produktName`, `varianteName`, `kategorie`,
+  `einzelpreisCents`, `menge`); Referenz, nicht zu ändern.
+- `frontend/src/admin/reporting/types.ts` — Zod-Schemas
+  (`ReportingDataSchema`, `LiveReportingDataSchema`, `UmsatzSteuersatzSchema`,
+  `StornierungPositionSchema`); Vorlage und Einhängepunkt.
+- `frontend/src/admin/reporting/ReportingResults.tsx — ReportingResults()` — Body
+  der Abrechnung (Kennzahlen, „Umsatz nach Steuersatz", Servicekraft-/Storno-Listen);
+  Einhängepunkt für den neuen Abschnitt.
+- `frontend/src/admin/reporting/LiveReportingSection.tsx` — Live-Dashboard-Body;
+  zweiter Einhängepunkt.
+- `frontend/src/admin/reporting/ReportingBackend.ts` — `getReporting()` /
+  `getLiveReporting()`; unverändert im Aufruf, validieren die erweiterten Schemas.
+- `frontend/src/admin/reporting/utils.ts`, `@/lib/utils — formatEuro` — Cent-Format.
+- Tests als Prior Art: `backend/repository/reporting_repo/repo_test.go`,
+  `backend/api/reporting/application/query_test.go`,
+  `backend/api/reporting/application/query_export_konsistenz_test.go`,
+  `frontend/src/admin/reporting/ReportingResults.test.tsx`,
+  `frontend/src/admin/reporting/LiveReportingSection.test.tsx`.
+
+## Resolved decisions
+
+- **Zwei getrennte Grundlagen** für Menge (Produktion) und Umsatz (Einnahmen) —
+  bewusst nicht ineinander umrechenbar; erklärender Hinweis im Report.
+- **Direktverkauf** zählt in beide Zahlen.
+- **Kategorie-Abschnitte** Essen → Getränke → Sonstiges; keine Kategorie-Summenzeile.
+- **Sortierung nach ausgegebener Menge aufsteigend** je Kategorie.
+- **Ein-Varianten-Produkte** als eine Zeile (Beschriftung `produktName varianteName`).
+- **Kein neues Event, keine Migration, kein Stammdaten-Join.**
+- Gruppierung/Sortierung im **Backend** (Single Source of Truth für Aufbereitung).
+
+## Open questions / Risks
+
+- **Sortierrichtung**: „aufsteigend" ist wie festgelegt umgesetzt (kleinste Menge
+  zuerst). Falls Top-Seller oben gewünscht, ist es eine reine Umkehr der
+  Vergleichsfunktion — kein Struktureingriff.
+- **Konsistenz-Invariante**: Σ aller Produkt-`UmsatzCents` muss dem kassierten
+  Gesamtumsatz (= Σ `UmsatzProSteuersatz`-Brutto) entsprechen — dieselbe
+  Positions-Basis. Wird per Test abgesichert (Phase 1).
+
+---
+
+## Phase 1: Produkt-/Varianten-Statistik in der Tagesabrechnung
+
+**User stories**: 1, 2, 3, 4, 6
+
+### Context
+
+- `backend/sqlc/queries/reporting.sql` — `GetUmsatzPositionszeilen` als
+  Query-Vorlage (Entfaltung von `data->'positionen'`).
+- `backend/domain/reporting/reporting.go` — Read-Model-Typen; neue Typen +
+  Feld-Anbau an `ReportingData`.
+- `backend/repository/reporting_repo/repo.go — Repository.GetReporting()` —
+  `errgroup`, in den die neue Query eingereiht wird; Row→Domäne-Mapping.
+- `backend/api/reporting/application/query.go — Query.GetReporting()`,
+  `computeUmsatzProSteuersatz()` — Aufruf- und Muster-Vorlage für die neue reine
+  Gruppierungs-/Sortierfunktion.
+- `backend/api/reporting/http/query_handler.go — toReportingResponse()`,
+  `reportingResponse` — DTO + Mapper.
+- `frontend/src/admin/reporting/types.ts — ReportingDataSchema` — Zod-Einhängepunkt.
+- `frontend/src/admin/reporting/ReportingResults.tsx — ReportingResults()` —
+  Anzeige-Einhängepunkt.
+- `frontend/src/admin/reporting/ReportingResults.test.tsx` — Test-Vorlage.
+
+### What to build
+
+Ein durchgehender vertikaler Schnitt für die Tagesabrechnung: eine neue
+sqlc-Query aggregiert die eingefrorenen Positionen einer Kassensitzung zu flachen
+Varianten-Zeilen mit ausgegebener Menge und Umsatz (Vorzeichen laut Event-Mapping
+oben). Das Repository reiht die Query in die bestehende `GetReporting`-`errgroup`
+ein und mappt die Rows in flache Varianten-Statistik-Werte. Eine reine Funktion in
+der Anwendungsschicht gruppiert diese zu Kategorie-Abschnitten und Produkten mit
+Zwischensummen und sortiert sie (Kategorie-Reihenfolge fest, Menge aufsteigend,
+Name-Tiebreaker). Das Ergebnis hängt als `ProduktStatistik []ProduktStatistik` an
+`ReportingData`, wird als `produktStatistik`-Feld der `get-abrechnung`-Response
+serialisiert, im Frontend per Zod validiert und in `ReportingResults.tsx` als neuer
+Abschnitt „Verkäufe pro Produkt" angezeigt: Kategorie-Überschriften, Produktzeile
+mit Zwischensumme und Variantenzeilen darunter, Ein-Varianten-Produkte als eine
+Zeile, Spalten „Ausgegeben" und „Umsatz" (`formatEuro`), erklärender Ein-Satz-
+Hinweis, leerer Zustand, druckfreundlich als Teil des Z-Bons.
+
+### Acceptance criteria
+
+- [ ] Für eine Kassensitzung mit Bestellungen, Korrekturen, Zahlungen,
+  Warenrücknahmen, Direktverkäufen und Direktverkauf-Stornos liefert die Auswertung
+  je Variante die korrekte ausgegebene Menge (Bestellung − Korrektur +
+  Direktverkauf) und den korrekten Umsatz (Kassiert + Direktverkauf − Storno);
+  Umbuchungen verändern beide Zahlen nicht.
+- [ ] Warenrücknahme/Direktverkauf-Storno mindern nur den Umsatz, nicht die Menge;
+  eine geldneutrale Korrektur mindert nur die Menge, nicht den Umsatz.
+- [ ] Die Ausgabe ist in Kategorie-Abschnitte (Essen → Getränke → Sonstiges)
+  gegliedert; je Produkt gibt es eine Zwischensumme über seine Varianten; Produkte
+  und Varianten sind nach ausgegebener Menge aufsteigend sortiert (Name-Tiebreaker).
+- [ ] Σ aller Produkt-`umsatzCents` entspricht der Summe der
+  `umsatzProSteuersatz`-Bruttowerte derselben Kassensitzung (Konsistenz-Test grün,
+  Muster `query_export_konsistenz_test.go`).
+- [ ] `admin/get-abrechnung` liefert das Feld `produktStatistik` mit
+  verschachtelten `varianten`; das Frontend validiert es per Zod ohne Fehler.
+- [ ] `ReportingResults.tsx` zeigt den Abschnitt „Verkäufe pro Produkt" mit
+  Kategorie-Überschriften, Zwischensummen, den Spalten „Ausgegeben"/„Umsatz", dem
+  erklärenden Hinweis und einem leeren Zustand bei einer Sitzung ohne Verkäufe;
+  Ein-Varianten-Produkte erscheinen als eine Zeile.
+- [ ] `make sqlc`, `make lint` und die betroffenen Backend- und Frontend-Tests
+  laufen grün; `sqlc/dbgen/` wurde nicht von Hand editiert.
+
+---
+
+## Phase 2: Produkt-/Varianten-Statistik im Live-Dashboard
+
+**User stories**: 5, 6
+
+### Context
+
+- `backend/repository/reporting_repo/repo.go — Repository.GetLiveReporting()` —
+  zweite `errgroup`, in die dieselbe Query eingereiht wird.
+- `backend/api/reporting/application/query.go — Query.GetLiveReporting()` — ruft
+  die in Phase 1 erstellte Gruppierungs-/Sortierfunktion für die Live-Daten auf.
+- `backend/domain/reporting/reporting.go — LiveReportingData` — Feld-Anbau
+  (Typen aus Phase 1 wiederverwendet).
+- `backend/api/reporting/http/query_handler.go` — Live-Response-DTO (Pendant zu
+  `toReportingResponse`) um `produktStatistik` erweitern.
+- `frontend/src/admin/reporting/types.ts — LiveReportingDataSchema` — Zod-Einhängepunkt.
+- `frontend/src/admin/reporting/LiveReportingSection.tsx` — Anzeige-Einhängepunkt.
+- `frontend/src/admin/reporting/LiveReportingSection.test.tsx` — Test-Vorlage.
+
+### What to build
+
+Der in Phase 1 gebaute Backend-Kern (Query, Domäne-Typen, Gruppierungs-/
+Sortierfunktion) wird in den Live-Pfad eingehängt: `GetLiveReporting` im Repository
+feuert die Query zusätzlich, die Anwendungsschicht gruppiert identisch, das Feld
+`ProduktStatistik` hängt an `LiveReportingData` und wird in der
+`get-live-reporting`-Response als `produktStatistik` serialisiert. Im Frontend wird
+dieselbe Anzeige-Komponente aus Phase 1 in `LiveReportingSection.tsx` eingebunden,
+sodass die Statistik der offenen Kassensitzung in Echtzeit erscheint.
+
+### Acceptance criteria
+
+- [ ] `admin/get-live-reporting` liefert für die offene Kassensitzung das Feld
+  `produktStatistik` mit identischer Struktur und identischen Zahlen-Regeln wie die
+  Abrechnung (dieselbe Gruppierungs-/Sortierfunktion, keine Duplikat-Logik).
+- [ ] Das Live-Dashboard zeigt den Abschnitt „Verkäufe pro Produkt" mit denselben
+  Kategorie-Abschnitten, Zwischensummen und Spalten wie die Abrechnung; ein leerer
+  Zustand erscheint, solange noch keine Verkäufe vorliegen.
+- [ ] In einer offenen Sitzung mit noch unbezahlten Bestellungen erscheint die
+  ausgegebene Menge > 0 bei Umsatz 0 (bestellt/rausgegeben, aber noch nicht
+  kassiert) — konsistent mit den Kennzahl-Regeln.
+- [ ] `make lint` und die betroffenen Backend-/Frontend-Tests laufen grün.
+
+---
+
+## Phase 3: Dokumentation nachziehen
+
+**User stories**: — (Doku-Pflege gemäß AGENTS.md)
+
+### Context
+
+- `docs/anforderungen.md` — Roadmap-Tabelle (R-05) und Reporting-Funktionsumfang
+  (R-01 ff.).
+- `docs/handbuch.md` — §7.2 Admin-Ansichten (Reporting), Read-Model-Übersicht und
+  Endpunkt-Tabelle (`get-abrechnung`/`get-live-reporting`).
+- `docs/language.md` — Read-Model-Begriffe (`Summary`, `Breakdowns`,
+  `UmsatzServicekraft` …).
+
+### What to build
+
+Die Doku wird an das umgesetzte Feature angepasst: R-05 wandert in
+`docs/anforderungen.md` aus der Roadmap in den Reporting-Funktionsumfang; die neuen
+Read-Model-Typen (`ProduktStatistik`, `VarianteStatistik`) und das erweiterte
+Response-Feld `produktStatistik` werden in der Read-Model-Übersicht und der
+Endpunkt-Beschreibung von `docs/handbuch.md` §7.2 sowie in der Begriffsliste von
+`docs/language.md` ergänzt.
+
+### Acceptance criteria
+
+- [ ] R-05 steht nicht mehr in der Roadmap, sondern als umgesetzte Anforderung im
+  Reporting-Funktionsumfang von `docs/anforderungen.md`.
+- [ ] `docs/handbuch.md` §7.2 nennt `produktStatistik` als Bestandteil der
+  `get-abrechnung`- und `get-live-reporting`-Antwort und führt die neuen
+  Read-Model-Typen in der Übersicht.
+- [ ] `docs/language.md` enthält Einträge für `ProduktStatistik` und
+  `VarianteStatistik`.
+- [ ] Keine toten Verweise; Begriffe konsistent mit den im Code verwendeten Namen.

--- a/docs/prds/prd-produkt-varianten-statistik.md
+++ b/docs/prds/prd-produkt-varianten-statistik.md
@@ -48,8 +48,8 @@ Abschnitt macht das transparent, damit niemand aus Umsatz ÷ Menge einen
 Stückpreis ableitet.
 
 Sortierung: innerhalb jeder Kategorie werden die Produkte **nach ausgegebener
-Menge aufsteigend** gelistet (Produktname als stabiler Tiebreaker); Varianten
-innerhalb eines Produkts ebenso nach ausgegebener Menge aufsteigend. Eine
+Menge absteigend** gelistet (Produktname als stabiler Tiebreaker); Varianten
+innerhalb eines Produkts ebenso nach ausgegebener Menge absteigend. Eine
 Kassensitzung ohne Verkäufe zeigt einen leeren Zustand; ein Kategorie-Abschnitt
 ohne Verkäufe entfällt.
 
@@ -102,8 +102,8 @@ ohne Verkäufe entfällt.
   Kategoriewechsel eines Produkts innerhalb einer Sitzung würde als getrennte
   Gruppen erscheinen — vernachlässigbarer Randfall.)
 - **Sortierung:** innerhalb jedes Kategorie-Abschnitts Produkte nach
-  `AusgegebeneMenge` **aufsteigend** (`ProduktName` als Tiebreaker); Varianten je
-  Produkt ebenso nach `AusgegebeneMenge` aufsteigend.
+  `AusgegebeneMenge` **absteigend** (`ProduktName` als Tiebreaker); Varianten je
+  Produkt ebenso nach `AusgegebeneMenge` absteigend.
 - **Ein-Varianten-Produkte** werden in der Anzeige zu einer einzigen Zeile
   zusammengefasst; Beschriftung dann `produktName` + `varianteName` (analog
   `Position.Bezeichnung()`). Das Datenmodell bleibt unverändert (Produkt mit einer
@@ -164,8 +164,8 @@ geldneutral vs. kassenwirksam:
 - **Anwendungsschicht (`api/reporting/application`):** eine reine Funktion baut
   aus den flachen Varianten-Zeilen die Produkt-Hierarchie, berechnet die
   Zwischensummen und sortiert: Kategorien in fester Reihenfolge (Essen → Getränke
-  → Sonstiges), Produkte je Kategorie nach `AusgegebeneMenge` aufsteigend,
-  Varianten je Produkt nach `AusgegebeneMenge` aufsteigend (`ProduktName` bzw.
+  → Sonstiges), Produkte je Kategorie nach `AusgegebeneMenge` absteigend,
+  Varianten je Produkt nach `AusgegebeneMenge` absteigend (`ProduktName` bzw.
   `VarianteName` als stabiler Tiebreaker). Die Liste ist damit bereits fertig
   sortiert; das Frontend rendert nur. Deep Module, isoliert testbar über flache
   Eingabe → gruppierte, sortierte Ausgabe.
@@ -213,7 +213,7 @@ nicht die interne Zerlegung.
   `api/reporting/application/query_test.go` (analog `computeUmsatzProSteuersatz`).
   Flache Varianten-Zeilen → korrekte Kategorie-Abschnitte in fester Reihenfolge
   (Essen → Getränke → Sonstiges), korrekte Produkt-Gruppen, korrekte
-  Zwischensummen, Sortierung nach Menge aufsteigend, stabile Tiebreaker.
+  Zwischensummen, Sortierung nach Menge absteigend, stabile Tiebreaker.
 - **Konsistenz mit den Gesamtzahlen:** Prior Art
   `api/reporting/application/query_export_konsistenz_test.go`. Die Summe aller
   Produkt-`UmsatzCents` muss mit dem bestehenden kassierten Gesamtumsatz (bzw. der
@@ -248,9 +248,8 @@ nicht die interne Zerlegung.
 - Setzt die Roadmap-Anforderung **R-05 (Produktumsatz-Reporting, Nice)** um.
 - **Direktverkauf zählt in beide Zahlen** (er gibt aus *und* nimmt ein) — als
   konsequente Anwendung des „rausgegeben/eingenommen"-Prinzips bestätigt.
-- **Sortierung nach Menge aufsteigend** (kleinste Menge zuerst) je Kategorie —
-  wie festgelegt. Falls stattdessen die Top-Seller oben stehen sollen, wäre es
-  absteigend; eine reine Sortier-Umkehr, jederzeit änderbar.
+- **Sortierung nach Menge absteigend** (größte Menge zuerst, Meistverkaufte oben)
+  je Kategorie — wie festgelegt.
 - Die bewusste Trennung der Grundlagen ist ein Feature, kein Bug: eine
   zurückgenommene Portion bleibt „ausgegeben", mindert aber den Umsatz. Der
   erklärende Hinweis im Report verhindert Fehlinterpretationen.

--- a/docs/prds/prd-produkt-varianten-statistik.md
+++ b/docs/prds/prd-produkt-varianten-statistik.md
@@ -1,0 +1,224 @@
+# PRD: Produkt- und Varianten-Statistik im Report
+
+## Problem Statement
+
+Der Report zeigt heute Gesamt-Kennzahlen einer Kassensitzung: kassierter Umsatz,
+Umsatz pro Servicekraft, Umsatz pro Steuersatz, Stornierungen. Was jedoch fehlt,
+ist die einfachste operative Frage eines Kassenwarts nach dem Fest:
+
+> „Wieviele Pommes mit Ketchup haben wir rausgegeben? Wieviele Tagesessen?
+> Wieviel Umsatz haben wir mit welcher Bratwurst gemacht?"
+
+Ohne diese Aufschlüsselung lässt sich weder der Einkauf fürs nächste Fest planen
+(„von welcher Ware brauchen wir wieviel") noch erkennen, welches Produkt sich
+finanziell lohnt. Die Daten liegen vollständig im Kassenjournal — jede Bestell-,
+Zahlungs- und Storno-Position trägt Produktname, Variantenname, Einzelpreis und
+Menge — sie werden nur nirgends pro Produkt/Variante zusammengefasst.
+
+Das entspricht der offenen Roadmap-Anforderung **R-05 (Produktumsatz-Reporting,
+Prio: Nice)**.
+
+## Solution
+
+Der Report bekommt einen neuen Abschnitt **„Verkäufe pro Produkt"**, sowohl in
+der Tagesabrechnung einer (i. d. R. abgeschlossenen) Kassensitzung als auch im
+Live-Dashboard der offenen Kassensitzung. Beide zeigen die Statistik jeweils
+**pro Kassensitzung** — passend zum restlichen Report, ohne neuen Filter.
+
+Die Liste ist **pro Variante aufgeschlüsselt und auf Produktebene gruppiert**:
+jedes Produkt bildet eine Gruppe mit einer Zwischensumme, darunter stehen seine
+Varianten. Jede Zeile (Variante wie Produkt-Zwischensumme) trägt zwei bewusst
+getrennte, klar benannte Zahlen:
+
+- **Ausgegebene Menge** — wieviele Portionen zubereitet bzw. rausgegeben wurden.
+  Basis: aufgenommene Bestellungen minus geldneutrale Korrekturen, inklusive
+  Direktverkäufe. Beantwortet „wieviele Pommes/Tagesessen gingen über die Theke".
+- **Umsatz** — die tatsächlich erzielten Einnahmen. Basis: kassierte Zahlungen
+  und Direktverkäufe minus Warenrücknahmen und Direktverkauf-Stornos.
+  Beantwortet „wieviel Geld haben wir mit diesem Produkt eingenommen".
+
+Die beiden Zahlen ruhen bewusst auf unterschiedlichen Grundlagen (Produktion vs.
+Einnahmen) und sind nicht ineinander umrechenbar — eine zurückgenommene Portion
+zählt als ausgegeben, mindert aber den Umsatz. Ein kurzer erklärender Hinweis im
+Abschnitt macht das transparent, damit niemand aus Umsatz ÷ Menge einen
+Stückpreis ableitet.
+
+Sortierung als Ranking: Produkte nach Umsatz-Zwischensumme absteigend, Varianten
+innerhalb eines Produkts nach Umsatz absteigend (Namens-Tiebreaker). Eine
+Kassensitzung ohne Verkäufe zeigt einen leeren Zustand.
+
+## User Stories
+
+1. Als **Admin/Kassenwart** möchte ich pro Produkt und Variante die ausgegebene
+   Menge sehen, damit ich Einkauf und Produktion für das nächste Fest planen kann.
+2. Als **Admin/Kassenwart** möchte ich pro Produkt und Variante den erzielten
+   Umsatz sehen, damit ich erkenne, welche Produkte sich finanziell lohnen.
+3. Als **Admin/Kassenwart** möchte ich die Varianten unter ihrem Produkt gruppiert
+   und mit Produkt-Zwischensumme sehen, damit ich schnell das große Bild und
+   zugleich die Detailtiefe habe.
+4. Als **Admin/Kassenwart** möchte ich die Statistik bereits während des
+   laufenden Fests im Live-Dashboard sehen, damit ich kurzfristig nachsteuern kann
+   (z. B. Ware nachordern, wenn ein Produkt schnell weggeht).
+5. Als **Admin/Kassenwart** möchte ich die Statistik je Kassensitzung erhalten,
+   passend zum übrigen Report, damit sich Zahlen einer Sitzung eindeutig zuordnen
+   lassen.
+
+## Implementation Decisions
+
+### Datenquelle und Architektur
+
+- **Reine additive Leseauswertung** über das `kassenjournal`, gefiltert nach
+  `kassensitzung_nr` — kein neues Event, kein Schema-Bestand-Eingriff, keine
+  Umdeutung bestehender Daten. Das Feature liest ausschließlich eingefrorene
+  Event-Positionen und folgt exakt dem bestehenden Muster der
+  Umsatz-pro-Steuersatz-Auswertung (`kj_extract_umsatz_pro_steuersatz` /
+  `GetUmsatzPositionszeilen`).
+- **Keine Cross-Context-Kopplung.** Das Reporting liest weiterhin nur das
+  Kassenjournal, nicht die Stammdaten (ACL). Es gibt daher keinen Join auf die
+  aktuellen Produkt-/Varianten-Stammdaten.
+
+### Gruppierung
+
+- **Variantenschlüssel:** `varianteId` (stabil, global eindeutige Identity-PK).
+  Anzeigename ist der **eingefrorene** `varianteName` aus dem Event.
+- **Produktschlüssel:** `produktName` (eingefroren im Event). Die Position trägt
+  keine `produktId`, nur `varianteId` plus die Fat-Event-Namen; innerhalb einer
+  Kassensitzung ist der Produktname stabil und eindeutig (aktiver Name ist unique).
+  Eine Produkt-ID-basierte Gruppierung ist bewusst nicht vorgesehen (siehe
+  Out of Scope).
+
+### Die zwei Kennzahlen (Event-Mapping)
+
+Die Aufteilung spiegelt exakt die bestehende Domänen-Unterscheidung
+geldneutral vs. kassenwirksam:
+
+**Ausgegebene Menge** = Summe der Positions-`menge` über:
+
+| Event                        | Vorzeichen | Begründung                                        |
+| ---------------------------- | ---------- | ------------------------------------------------- |
+| `bestellung-aufgenommen:v1`  | `+`        | bestellt → wird zubereitet/rausgegeben            |
+| `bestellung-korrigiert:v1`   | `−`        | geldneutrale Korrektur unbezahlter Positionen: doch nicht rausgegeben |
+| `direktverkauf-getaetigt:v1` | `+`        | Direktverkauf gibt die Ware sofort aus            |
+
+**Umsatz** = Summe von `einzelpreisCents × menge` über:
+
+| Event                         | Vorzeichen | Begründung                                    |
+| ----------------------------- | ---------- | --------------------------------------------- |
+| `zahlung-kassiert:v1`         | `+`        | kassierte Einnahme                            |
+| `direktverkauf-getaetigt:v1`  | `+`        | kassierte Einnahme                            |
+| `stornierung-erteilt:v1`      | `−`        | kassenwirksame Warenrücknahme (negativer Umsatz) |
+| `direktverkauf-storniert:v1`  | `−`        | kassenwirksame Rückgabe (negativer Umsatz)    |
+
+- **`bestellung-umgebucht:v1` wird in keiner Zahl gezählt** — die Positionen
+  wurden bereits bei der Bestellaufnahme erfasst; das Umbuchen zwischen Tischen
+  ändert produkt-/varianten-seitig nichts (sonst Doppelzählung).
+- **Warenrücknahme/Direktverkauf-Storno mindern nur den Umsatz, nicht die Menge:**
+  die Ware wurde ausgegeben und danach zurückgenommen — die Produktionszahl bleibt.
+- **`bestellung-korrigiert:v1` mindert nur die Menge, nicht den Umsatz:**
+  geldneutral, betrifft nur noch nicht rausgegebene/bezahlte Ware.
+
+### Backend-Module
+
+- **Domäne (`domain/reporting`):** zwei neue Read-Model-Typen ohne `json`-Tags,
+  analog zu `UmsatzServicekraft`/`StornierungPosition`:
+  - `VarianteStatistik` — `VarianteID`, `VarianteName`, `AusgegebeneMenge`,
+    `UmsatzCents`.
+  - `ProduktStatistik` — `ProduktName`, `AusgegebeneMenge` (Zwischensumme),
+    `UmsatzCents` (Zwischensumme), `Varianten []VarianteStatistik`.
+  - Neues Feld `ProduktStatistik []ProduktStatistik` auf `ReportingData` **und**
+    `LiveReportingData`.
+- **Query (`sqlc/queries/reporting.sql`):** eine neue Query
+  `GetProduktStatistik(@kassensitzung_nr)`, die `data->'positionen'` per
+  `jsonb_array_elements` entfaltet und **flache Zeilen pro Variante**
+  `(varianteId, produktName, varianteName, ausgegebeneMenge, umsatzCents)` mit den
+  obigen Vorzeichen liefert (`GROUP BY varianteId, produktName, varianteName`).
+  Anschließend `make sqlc`. Die Aggregation der beiden Vorzeichen-Regeln bleibt in
+  der Query; die Produkt-Gruppierung, Zwischensummen und Sortierung erledigt die
+  Anwendungsschicht (wie `computeUmsatzProSteuersatz`).
+- **Repository (`repository/reporting_repo`):** die neue Query in die bestehenden
+  `errgroup`-Blöcke von `GetReporting` und `GetLiveReporting` einreihen; Zeilen →
+  flache `VarianteStatistik`-Liste mappen.
+- **Anwendungsschicht (`api/reporting/application`):** eine reine Funktion baut
+  aus den flachen Varianten-Zeilen die Produkt-Hierarchie, berechnet die
+  Zwischensummen und sortiert (Produkte nach `UmsatzCents` absteigend, Varianten
+  je Produkt nach `UmsatzCents` absteigend, Name als stabiler Tiebreaker). Deep
+  Module, isoliert testbar über flache Eingabe → gruppierte Ausgabe.
+- **HTTP (`api/reporting/http`):** neue `json`-getaggte Response-DTOs
+  (`produktStatistik` mit verschachtelten `varianten`) plus `to*`-Mapper. Keine
+  neuen Endpunkte — die bestehenden `admin/get-abrechnung` und
+  `admin/get-live-reporting` tragen das neue Feld.
+
+### Frontend-Module
+
+- **Zod-Schemas (`admin/reporting/types.ts`):** Spiegel der neuen DTOs
+  (`ProduktStatistikSchema` mit `varianten`), eingehängt in `ReportingDataSchema`
+  und `LiveReportingDataSchema`.
+- **Backend-Klasse:** unverändert im Aufruf; validiert das erweiterte Schema.
+- **Anzeige:** neuer Abschnitt „Verkäufe pro Produkt" in `ReportingResults.tsx`
+  (Tagesabrechnung, Teil des druckoptimierten Z-Bons) und in
+  `LiveReportingSection.tsx` (Live-Dashboard). Produktzeile mit Zwischensumme,
+  darunter die Variantenzeilen; zwei Spalten **„Ausgegeben"** (Menge) und
+  **„Umsatz"** (€, über `formatEuro`), plus der erklärende Ein-Satz-Hinweis zu den
+  beiden Grundlagen. Leerer Zustand bei einer Sitzung ohne Verkäufe.
+
+### Dokumentation
+
+- Nach Umsetzung **R-05 aus der Roadmap** in `docs/anforderungen.md` in den
+  Reporting-Funktionsumfang verschieben; die neuen Read-Model-Typen in der
+  Read-Model-Übersicht von `docs/handbuch.md` und `docs/language.md` ergänzen.
+
+## Testing Decisions
+
+Getestet wird externes Verhalten (welche Zahlen kommen bei welchen Events heraus),
+nicht die interne Zerlegung.
+
+- **Aggregations-/Vorzeichen-Verhalten (Repository, Integrationstest gegen echtes
+  Postgres):** Prior Art `repository/reporting_repo/repo_test.go`. Ein Szenario mit
+  Bestellungen, Korrekturen, Zahlungen, Warenrücknahmen, Direktverkäufen und
+  Direktverkauf-Stornos über mehrere Produkte/Varianten prüft: korrekte
+  ausgegebene Menge (Bestellung − Korrektur + Direktverkauf), korrekter Umsatz
+  (Kassiert + Direktverkauf − Storno), Umbuchungen zählen nicht, und die Trennung
+  (Warenrücknahme mindert nur Umsatz, Korrektur nur Menge).
+- **Gruppierung und Sortierung (Anwendungsschicht, Unit-Test):** Prior Art
+  `api/reporting/application/query_test.go` (analog `computeUmsatzProSteuersatz`).
+  Flache Varianten-Zeilen → korrekte Produkt-Gruppen, korrekte Zwischensummen,
+  Ranking-Reihenfolge, stabile Tiebreaker.
+- **Konsistenz mit den Gesamtzahlen:** Prior Art
+  `api/reporting/application/query_export_konsistenz_test.go`. Die Summe aller
+  Produkt-`UmsatzCents` muss mit dem bestehenden kassierten Gesamtumsatz (bzw. der
+  Summe der `UmsatzProSteuersatz`-Brutto­werte) übereinstimmen — dieselbe
+  Positions-Basis.
+- **Frontend-Darstellung:** Prior Art `ReportingResults.test.tsx` /
+  `LiveReportingSection.test.tsx`. Aus einer Fixture werden Produkte, Varianten,
+  Zwischensummen und der leere Zustand gerendert; das Schema wird validiert.
+
+## Out of Scope
+
+- **Auswertung über mehrere Kassensitzungen** (Saison-/Jahressumme). Ausschließlich
+  pro Kassensitzung, wie der übrige Report.
+- **Produkt-Rollup über die Stammdaten (`produktId`).** Gruppiert wird über den
+  eingefrorenen `produktName`; ein Join auf die aktuellen Stammdaten würde die
+  Reporting-ACL verletzen.
+- **Aggregation auf Kategorie-Ebene** (essen/getraenk/sonstiges).
+- **Zeitliche Aufschlüsselung** (Stunden-/Tageszeit-Verlauf), Trends, Diagramme.
+- **Separate „kassierte Menge"-Spalte.** Es gibt genau die zwei vereinbarten
+  Zahlen (ausgegebene Menge, Umsatz).
+- **Umsatz pro Produkt je Servicekraft** oder andere Kreuzauswertungen.
+- **Export-Änderungen.** Der DSFinV-K-Export bleibt unberührt; dies ist eine reine
+  Bildschirm-/Report-Auswertung.
+- **Filtern/Suchen/CSV-Download** innerhalb der Produktliste.
+
+## Further Notes
+
+- Setzt die Roadmap-Anforderung **R-05 (Produktumsatz-Reporting, Nice)** um.
+- **Direktverkauf zählt in beide Zahlen** (er gibt aus *und* nimmt ein) — das ist
+  die konsequente Anwendung des „rausgegeben/eingenommen"-Prinzips. Bitte beim
+  Review bestätigen; falls die ausgegebene Menge nur Tisch-Bestellungen umfassen
+  soll, entfällt `direktverkauf-getaetigt:v1` aus der Mengen-Spalte.
+- Die bewusste Trennung der Grundlagen ist ein Feature, kein Bug: eine
+  zurückgenommene Portion bleibt „ausgegeben", mindert aber den Umsatz. Der
+  erklärende Hinweis im Report verhindert Fehlinterpretationen.
+- Produkt-Konservatismus: Das Feature bleibt bewusst flach (zwei Zahlen, eine
+  Ranking-Liste, pro Sitzung). Keine Konfigurierbarkeit, keine Diagramme, keine
+  Vorratsfelder — jede Erweiterung müsste sich am realen Bedarf ehrenamtlicher
+  Teams neu rechtfertigen.

--- a/docs/prds/prd-produkt-varianten-statistik.md
+++ b/docs/prds/prd-produkt-varianten-statistik.md
@@ -25,10 +25,14 @@ der Tagesabrechnung einer (i. d. R. abgeschlossenen) Kassensitzung als auch im
 Live-Dashboard der offenen Kassensitzung. Beide zeigen die Statistik jeweils
 **pro Kassensitzung** — passend zum restlichen Report, ohne neuen Filter.
 
-Die Liste ist **pro Variante aufgeschlüsselt und auf Produktebene gruppiert**:
-jedes Produkt bildet eine Gruppe mit einer Zwischensumme, darunter stehen seine
-Varianten. Jede Zeile (Variante wie Produkt-Zwischensumme) trägt zwei bewusst
-getrennte, klar benannte Zahlen:
+Die Liste ist **nach Kategorie in getrennte Abschnitte gegliedert** (Essen,
+Getränke, Sonstiges — in dieser Reihenfolge) und innerhalb jedes Abschnitts
+**pro Variante aufgeschlüsselt und auf Produktebene gruppiert**: jedes Produkt
+bildet eine Gruppe mit einer Zwischensumme, darunter stehen seine Varianten.
+**Produkte mit nur einer Variante werden zu einer einzigen Zeile
+zusammengefasst** (z. B. „Tagesessen" statt „Tagesessen → Tagesessen"; „Cola
+0,5 l" statt Produkt- plus identischer Variantenzeile). Jede Zeile (Variante wie
+Produkt-Zwischensumme) trägt zwei bewusst getrennte, klar benannte Zahlen:
 
 - **Ausgegebene Menge** — wieviele Portionen zubereitet bzw. rausgegeben wurden.
   Basis: aufgenommene Bestellungen minus geldneutrale Korrekturen, inklusive
@@ -43,9 +47,11 @@ zählt als ausgegeben, mindert aber den Umsatz. Ein kurzer erklärender Hinweis 
 Abschnitt macht das transparent, damit niemand aus Umsatz ÷ Menge einen
 Stückpreis ableitet.
 
-Sortierung als Ranking: Produkte nach Umsatz-Zwischensumme absteigend, Varianten
-innerhalb eines Produkts nach Umsatz absteigend (Namens-Tiebreaker). Eine
-Kassensitzung ohne Verkäufe zeigt einen leeren Zustand.
+Sortierung: innerhalb jeder Kategorie werden die Produkte **nach ausgegebener
+Menge aufsteigend** gelistet (Produktname als stabiler Tiebreaker); Varianten
+innerhalb eines Produkts ebenso nach ausgegebener Menge aufsteigend. Eine
+Kassensitzung ohne Verkäufe zeigt einen leeren Zustand; ein Kategorie-Abschnitt
+ohne Verkäufe entfällt.
 
 ## User Stories
 
@@ -56,10 +62,13 @@ Kassensitzung ohne Verkäufe zeigt einen leeren Zustand.
 3. Als **Admin/Kassenwart** möchte ich die Varianten unter ihrem Produkt gruppiert
    und mit Produkt-Zwischensumme sehen, damit ich schnell das große Bild und
    zugleich die Detailtiefe habe.
-4. Als **Admin/Kassenwart** möchte ich die Statistik bereits während des
+4. Als **Admin/Kassenwart** möchte ich die Produkte nach Kategorie (Essen,
+   Getränke, Sonstiges) getrennt aufgelistet sehen, damit ich verwandte Ware
+   zusammen im Blick habe und Essen und Getränke nicht vermischt werden.
+5. Als **Admin/Kassenwart** möchte ich die Statistik bereits während des
    laufenden Fests im Live-Dashboard sehen, damit ich kurzfristig nachsteuern kann
    (z. B. Ware nachordern, wenn ein Produkt schnell weggeht).
-5. Als **Admin/Kassenwart** möchte ich die Statistik je Kassensitzung erhalten,
+6. Als **Admin/Kassenwart** möchte ich die Statistik je Kassensitzung erhalten,
    passend zum übrigen Report, damit sich Zahlen einer Sitzung eindeutig zuordnen
    lassen.
 
@@ -77,7 +86,7 @@ Kassensitzung ohne Verkäufe zeigt einen leeren Zustand.
   Kassenjournal, nicht die Stammdaten (ACL). Es gibt daher keinen Join auf die
   aktuellen Produkt-/Varianten-Stammdaten.
 
-### Gruppierung
+### Gruppierung und Sortierung
 
 - **Variantenschlüssel:** `varianteId` (stabil, global eindeutige Identity-PK).
   Anzeigename ist der **eingefrorene** `varianteName` aus dem Event.
@@ -86,6 +95,19 @@ Kassensitzung ohne Verkäufe zeigt einen leeren Zustand.
   Kassensitzung ist der Produktname stabil und eindeutig (aktiver Name ist unique).
   Eine Produkt-ID-basierte Gruppierung ist bewusst nicht vorgesehen (siehe
   Out of Scope).
+- **Kategorie-Abschnitte:** die Position trägt ein eingefrorenes `kategorie`-Feld
+  (`essen`/`getraenk`/`sonstiges`). Produkte werden nach Kategorie in getrennte
+  Abschnitte gegliedert, feste Reihenfolge Essen → Getränke → Sonstiges. (Ein
+  Produkt liegt je Kassensitzung in genau einer Kategorie; ein theoretischer
+  Kategoriewechsel eines Produkts innerhalb einer Sitzung würde als getrennte
+  Gruppen erscheinen — vernachlässigbarer Randfall.)
+- **Sortierung:** innerhalb jedes Kategorie-Abschnitts Produkte nach
+  `AusgegebeneMenge` **aufsteigend** (`ProduktName` als Tiebreaker); Varianten je
+  Produkt ebenso nach `AusgegebeneMenge` aufsteigend.
+- **Ein-Varianten-Produkte** werden in der Anzeige zu einer einzigen Zeile
+  zusammengefasst; Beschriftung dann `produktName` + `varianteName` (analog
+  `Position.Bezeichnung()`). Das Datenmodell bleibt unverändert (Produkt mit einer
+  Varianten-Zeile); nur die Darstellung fasst zusammen.
 
 ### Die zwei Kennzahlen (Event-Mapping)
 
@@ -123,26 +145,30 @@ geldneutral vs. kassenwirksam:
   analog zu `UmsatzServicekraft`/`StornierungPosition`:
   - `VarianteStatistik` — `VarianteID`, `VarianteName`, `AusgegebeneMenge`,
     `UmsatzCents`.
-  - `ProduktStatistik` — `ProduktName`, `AusgegebeneMenge` (Zwischensumme),
-    `UmsatzCents` (Zwischensumme), `Varianten []VarianteStatistik`.
+  - `ProduktStatistik` — `Kategorie`, `ProduktName`, `AusgegebeneMenge`
+    (Zwischensumme), `UmsatzCents` (Zwischensumme), `Varianten []VarianteStatistik`.
   - Neues Feld `ProduktStatistik []ProduktStatistik` auf `ReportingData` **und**
     `LiveReportingData`.
 - **Query (`sqlc/queries/reporting.sql`):** eine neue Query
   `GetProduktStatistik(@kassensitzung_nr)`, die `data->'positionen'` per
   `jsonb_array_elements` entfaltet und **flache Zeilen pro Variante**
-  `(varianteId, produktName, varianteName, ausgegebeneMenge, umsatzCents)` mit den
-  obigen Vorzeichen liefert (`GROUP BY varianteId, produktName, varianteName`).
-  Anschließend `make sqlc`. Die Aggregation der beiden Vorzeichen-Regeln bleibt in
-  der Query; die Produkt-Gruppierung, Zwischensummen und Sortierung erledigt die
+  `(kategorie, varianteId, produktName, varianteName, ausgegebeneMenge, umsatzCents)`
+  mit den obigen Vorzeichen liefert
+  (`GROUP BY kategorie, varianteId, produktName, varianteName`). Anschließend
+  `make sqlc`. Die Aggregation der beiden Vorzeichen-Regeln bleibt in der Query;
+  die Kategorie-/Produkt-Gruppierung, Zwischensummen und Sortierung erledigt die
   Anwendungsschicht (wie `computeUmsatzProSteuersatz`).
 - **Repository (`repository/reporting_repo`):** die neue Query in die bestehenden
   `errgroup`-Blöcke von `GetReporting` und `GetLiveReporting` einreihen; Zeilen →
-  flache `VarianteStatistik`-Liste mappen.
+  flache Varianten-Zeilen mappen.
 - **Anwendungsschicht (`api/reporting/application`):** eine reine Funktion baut
   aus den flachen Varianten-Zeilen die Produkt-Hierarchie, berechnet die
-  Zwischensummen und sortiert (Produkte nach `UmsatzCents` absteigend, Varianten
-  je Produkt nach `UmsatzCents` absteigend, Name als stabiler Tiebreaker). Deep
-  Module, isoliert testbar über flache Eingabe → gruppierte Ausgabe.
+  Zwischensummen und sortiert: Kategorien in fester Reihenfolge (Essen → Getränke
+  → Sonstiges), Produkte je Kategorie nach `AusgegebeneMenge` aufsteigend,
+  Varianten je Produkt nach `AusgegebeneMenge` aufsteigend (`ProduktName` bzw.
+  `VarianteName` als stabiler Tiebreaker). Die Liste ist damit bereits fertig
+  sortiert; das Frontend rendert nur. Deep Module, isoliert testbar über flache
+  Eingabe → gruppierte, sortierte Ausgabe.
 - **HTTP (`api/reporting/http`):** neue `json`-getaggte Response-DTOs
   (`produktStatistik` mit verschachtelten `varianten`) plus `to*`-Mapper. Keine
   neuen Endpunkte — die bestehenden `admin/get-abrechnung` und
@@ -151,15 +177,19 @@ geldneutral vs. kassenwirksam:
 ### Frontend-Module
 
 - **Zod-Schemas (`admin/reporting/types.ts`):** Spiegel der neuen DTOs
-  (`ProduktStatistikSchema` mit `varianten`), eingehängt in `ReportingDataSchema`
-  und `LiveReportingDataSchema`.
+  (`ProduktStatistikSchema` mit `kategorie` und `varianten`), eingehängt in
+  `ReportingDataSchema` und `LiveReportingDataSchema`.
 - **Backend-Klasse:** unverändert im Aufruf; validiert das erweiterte Schema.
 - **Anzeige:** neuer Abschnitt „Verkäufe pro Produkt" in `ReportingResults.tsx`
   (Tagesabrechnung, Teil des druckoptimierten Z-Bons) und in
-  `LiveReportingSection.tsx` (Live-Dashboard). Produktzeile mit Zwischensumme,
-  darunter die Variantenzeilen; zwei Spalten **„Ausgegeben"** (Menge) und
-  **„Umsatz"** (€, über `formatEuro`), plus der erklärende Ein-Satz-Hinweis zu den
-  beiden Grundlagen. Leerer Zustand bei einer Sitzung ohne Verkäufe.
+  `LiveReportingSection.tsx` (Live-Dashboard). Gegliedert in Kategorie-Abschnitte
+  (Essen, Getränke, Sonstiges) mit Abschnittsüberschrift; je Produkt eine
+  Produktzeile mit Zwischensumme und darunter die Variantenzeilen, **außer bei
+  einer einzigen Variante — dann eine zusammengefasste Zeile**. Zwei Spalten
+  **„Ausgegeben"** (Menge) und **„Umsatz"** (€, über `formatEuro`), plus der
+  erklärende Ein-Satz-Hinweis zu den beiden Grundlagen. Leerer Zustand bei einer
+  Sitzung ohne Verkäufe; leere Kategorie-Abschnitte werden weggelassen. Die
+  Reihenfolge kommt fertig vom Backend — das Frontend sortiert nicht um.
 
 ### Dokumentation
 
@@ -181,16 +211,19 @@ nicht die interne Zerlegung.
   (Warenrücknahme mindert nur Umsatz, Korrektur nur Menge).
 - **Gruppierung und Sortierung (Anwendungsschicht, Unit-Test):** Prior Art
   `api/reporting/application/query_test.go` (analog `computeUmsatzProSteuersatz`).
-  Flache Varianten-Zeilen → korrekte Produkt-Gruppen, korrekte Zwischensummen,
-  Ranking-Reihenfolge, stabile Tiebreaker.
+  Flache Varianten-Zeilen → korrekte Kategorie-Abschnitte in fester Reihenfolge
+  (Essen → Getränke → Sonstiges), korrekte Produkt-Gruppen, korrekte
+  Zwischensummen, Sortierung nach Menge aufsteigend, stabile Tiebreaker.
 - **Konsistenz mit den Gesamtzahlen:** Prior Art
   `api/reporting/application/query_export_konsistenz_test.go`. Die Summe aller
   Produkt-`UmsatzCents` muss mit dem bestehenden kassierten Gesamtumsatz (bzw. der
   Summe der `UmsatzProSteuersatz`-Brutto­werte) übereinstimmen — dieselbe
   Positions-Basis.
 - **Frontend-Darstellung:** Prior Art `ReportingResults.test.tsx` /
-  `LiveReportingSection.test.tsx`. Aus einer Fixture werden Produkte, Varianten,
-  Zwischensummen und der leere Zustand gerendert; das Schema wird validiert.
+  `LiveReportingSection.test.tsx`. Aus einer Fixture werden Kategorie-Abschnitte,
+  Produkte, Varianten, Zwischensummen, die Ein-Zeilen-Zusammenfassung bei
+  Ein-Varianten-Produkten und der leere Zustand gerendert; das Schema wird
+  validiert.
 
 ## Out of Scope
 
@@ -199,7 +232,9 @@ nicht die interne Zerlegung.
 - **Produkt-Rollup über die Stammdaten (`produktId`).** Gruppiert wird über den
   eingefrorenen `produktName`; ein Join auf die aktuellen Stammdaten würde die
   Reporting-ACL verletzen.
-- **Aggregation auf Kategorie-Ebene** (essen/getraenk/sonstiges).
+- **Kategorie-Zwischensummen.** Die Kategorien Essen/Getränke/Sonstiges dienen nur
+  der Gliederung in Abschnitte (siehe Solution), nicht als eigene aggregierte
+  Summenzeile pro Kategorie.
 - **Zeitliche Aufschlüsselung** (Stunden-/Tageszeit-Verlauf), Trends, Diagramme.
 - **Separate „kassierte Menge"-Spalte.** Es gibt genau die zwei vereinbarten
   Zahlen (ausgegebene Menge, Umsatz).
@@ -211,10 +246,11 @@ nicht die interne Zerlegung.
 ## Further Notes
 
 - Setzt die Roadmap-Anforderung **R-05 (Produktumsatz-Reporting, Nice)** um.
-- **Direktverkauf zählt in beide Zahlen** (er gibt aus *und* nimmt ein) — das ist
-  die konsequente Anwendung des „rausgegeben/eingenommen"-Prinzips. Bitte beim
-  Review bestätigen; falls die ausgegebene Menge nur Tisch-Bestellungen umfassen
-  soll, entfällt `direktverkauf-getaetigt:v1` aus der Mengen-Spalte.
+- **Direktverkauf zählt in beide Zahlen** (er gibt aus *und* nimmt ein) — als
+  konsequente Anwendung des „rausgegeben/eingenommen"-Prinzips bestätigt.
+- **Sortierung nach Menge aufsteigend** (kleinste Menge zuerst) je Kategorie —
+  wie festgelegt. Falls stattdessen die Top-Seller oben stehen sollen, wäre es
+  absteigend; eine reine Sortier-Umkehr, jederzeit änderbar.
 - Die bewusste Trennung der Grundlagen ist ein Feature, kein Bug: eine
   zurückgenommene Portion bleibt „ausgegeben", mindert aber den Umsatz. Der
   erklärende Hinweis im Report verhindert Fehlinterpretationen.


### PR DESCRIPTION
## Worum es geht

Spezifikation für **R-05 (Produktumsatz-Reporting)**: eine Aufschlüsselung der Verkäufe pro Produkt und Variante im Report — „Wieviele Pommes mit Ketchup wurden ausgegeben? Wieviel Umsatz pro Produkt?". Dieser PR enthält **nur Dokumentation** (PRD + Implementierungsplan), noch keinen Code.

## Inhalt

- `docs/prds/prd-produkt-varianten-statistik.md` — PRD nach strukturierter Klärung.
- `docs/plans/plan-produkt-varianten-statistik.md` — phasenweiser Tracer-Bullet-Plan (Abrechnung → Live-Dashboard → Doku), nach adversarialem Review überarbeitet.

## Kernentscheidungen

- **Zwei getrennte, klar benannte Kennzahlen** je Zeile, die exakt auf jottis geldneutral/kassenwirksam-Unterscheidung abbilden:
  - **Ausgegebene Menge** = Bestellung − Korrektur + Direktverkauf (was rausgegeben/produziert wurde).
  - **Umsatz** = Kassiert + Direktverkauf − Warenrücknahme/Storno (tatsächliche Einnahmen).
- **Gliederung** in Kategorie-Abschnitte (Essen → Getränke → Sonstiges), pro Variante aufgeschlüsselt und auf Produktebene mit Zwischensumme gruppiert; Ein-Varianten-Produkte als eine Zeile; je Kategorie nach Menge aufsteigend.
- Angezeigt in **Tagesabrechnung** und **Live-Dashboard**, jeweils pro Kassensitzung.
- **Additive Leseauswertung** über das Kassenjournal: kein neues Event, keine Migration, kein Stammdaten-Join (Reporting-ACL bleibt gewahrt).

## Review-Historie

Der Plan wurde von einem unabhängigen Reviewer geprüft. Ein blockierender Befund (fehlender flacher Zeilentyp + ungültige `computeUmsatzProSteuersatz`-Analogie) sowie zwei Verbesserungen (Konsistenz-Invariante gehört in den Repo-Integrationstest; SQL-Cast-Details) sind eingearbeitet.

## Nächster Schritt

Umsetzung nach dem Plan (Phase 1 zuerst) — separat.