### PR TITLE
feat(reporting): add produkt/varianten sales statistics to abrechnung and live dashboard

### DIFF
--- a/backend/api/reporting/application/query.go
+++ b/backend/api/reporting/application/query.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nicograef/jotti/backend/db"
 	"github.com/nicograef/jotti/backend/domain/kasse"
+	"github.com/nicograef/jotti/backend/domain/produkt"
 	"github.com/nicograef/jotti/backend/domain/reporting"
 	"github.com/nicograef/jotti/backend/domain/steuer"
 	"github.com/nicograef/jotti/backend/domain/tisch"
@@ -18,6 +19,7 @@ type reportingRepo interface {
 	GetReporting(ctx context.Context, kassensitzungNr int) (reporting.ReportingData, error)
 	GetEigeneUebersicht(ctx context.Context, userID int, kassensitzungNr int) (reporting.EigeneUebersicht, error)
 	GetLiveReporting(ctx context.Context, kassensitzungNr int) (reporting.LiveReportingData, error)
+	GetProduktStatistik(ctx context.Context, kassensitzungNr int) ([]reporting.ProduktStatistikZeile, error)
 }
 
 type kassensitzungenRepo interface {
@@ -52,6 +54,13 @@ func (q Query) GetReporting(ctx context.Context, kassensitzungNr int) (reporting
 
 	data.UmsatzProSteuersatz = computeUmsatzProSteuersatz(data.UmsatzProSteuersatz)
 	data.Breakdowns.StornierungenProServicekraft = aggregateStornierungenProServicekraft(data.Stornierungen)
+
+	zeilen, err := q.ReportingRepo.GetProduktStatistik(ctx, kassensitzungNr)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get produkt statistik")
+		return reporting.ReportingData{}, ErrDatabase
+	}
+	data.ProduktStatistik = gruppiereProduktStatistik(zeilen)
 
 	log.Info().Msg("Retrieved reporting")
 	return data, nil
@@ -144,6 +153,87 @@ func computeUmsatzProSteuersatz(bruttoZeilen []reporting.UmsatzSteuersatz) []rep
 	return out
 }
 
+// kategorieRang legt die feste Reihenfolge der Kategorie-Abschnitte fest:
+// Essen → Getränke → Sonstiges. Unbekannte Kategorien (theoretischer Randfall)
+// sortieren dahinter und werden untereinander alphabetisch geordnet.
+func kategorieRang(kategorie string) int {
+	switch kategorie {
+	case string(produkt.EssenKategorie):
+		return 0
+	case string(produkt.GetraenkKategorie):
+		return 1
+	case string(produkt.SonstigesKategorie):
+		return 2
+	default:
+		return 3
+	}
+}
+
+// gruppiereProduktStatistik baut aus den flachen Varianten-Zeilen die
+// Produkt-Hierarchie für den Report: je Produkt eine Gruppe mit Zwischensumme
+// über ihre Varianten, in Kategorie-Abschnitte gegliedert. Sortierung:
+// Kategorien fest (Essen → Getränke → Sonstiges), Produkte je Kategorie und
+// Varianten je Produkt nach ausgegebener Menge absteigend, Name als stabiler
+// Tiebreaker. Reine Funktion — das Backend liefert die Liste fertig sortiert,
+// die Ein-Varianten-Zusammenfassung bleibt reine Präsentation im Frontend.
+func gruppiereProduktStatistik(zeilen []reporting.ProduktStatistikZeile) []reporting.ProduktStatistik {
+	// Produkte per (Kategorie, ProduktName) sammeln; ein Produkt liegt je Sitzung
+	// in genau einer Kategorie, der Produktname ist innerhalb der Sitzung eindeutig.
+	type produktKey struct {
+		kategorie   string
+		produktName string
+	}
+	indexByKey := make(map[produktKey]int, len(zeilen))
+	produkte := []reporting.ProduktStatistik{}
+	for _, z := range zeilen {
+		key := produktKey{kategorie: z.Kategorie, produktName: z.ProduktName}
+		idx, ok := indexByKey[key]
+		if !ok {
+			idx = len(produkte)
+			indexByKey[key] = idx
+			produkte = append(produkte, reporting.ProduktStatistik{
+				Kategorie:   z.Kategorie,
+				ProduktName: z.ProduktName,
+				Varianten:   []reporting.VarianteStatistik{},
+			})
+		}
+		produkte[idx].Varianten = append(produkte[idx].Varianten, reporting.VarianteStatistik{
+			VarianteID:       z.VarianteID,
+			VarianteName:     z.VarianteName,
+			AusgegebeneMenge: z.AusgegebeneMenge,
+			UmsatzCents:      z.UmsatzCents,
+		})
+		produkte[idx].AusgegebeneMenge += z.AusgegebeneMenge
+		produkte[idx].UmsatzCents += z.UmsatzCents
+	}
+
+	for i := range produkte {
+		varianten := produkte[i].Varianten
+		sort.SliceStable(varianten, func(a, b int) bool {
+			if varianten[a].AusgegebeneMenge != varianten[b].AusgegebeneMenge {
+				return varianten[a].AusgegebeneMenge > varianten[b].AusgegebeneMenge
+			}
+			return varianten[a].VarianteName < varianten[b].VarianteName
+		})
+	}
+
+	sort.SliceStable(produkte, func(a, b int) bool {
+		rangA, rangB := kategorieRang(produkte[a].Kategorie), kategorieRang(produkte[b].Kategorie)
+		if rangA != rangB {
+			return rangA < rangB
+		}
+		if produkte[a].Kategorie != produkte[b].Kategorie {
+			return produkte[a].Kategorie < produkte[b].Kategorie
+		}
+		if produkte[a].AusgegebeneMenge != produkte[b].AusgegebeneMenge {
+			return produkte[a].AusgegebeneMenge > produkte[b].AusgegebeneMenge
+		}
+		return produkte[a].ProduktName < produkte[b].ProduktName
+	})
+
+	return produkte
+}
+
 func (q Query) GetAbgeschlosseneKassensitzungen(ctx context.Context) ([]reporting.AbgeschlosseneSitzung, error) {
 	log := zerolog.Ctx(ctx)
 
@@ -215,6 +305,13 @@ func (q Query) GetLiveReporting(ctx context.Context) (*reporting.LiveReportingDa
 
 	data.Servicekraefte = mergeServicekraefteLive(data.Breakdowns.UmsatzProServicekraft, sessions, nameByTischID)
 	data.Breakdowns.StornierungenProServicekraft = aggregateStornierungenProServicekraft(data.Stornierungen)
+
+	zeilen, err := q.ReportingRepo.GetProduktStatistik(ctx, ks.ZNr)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get produkt statistik for live reporting")
+		return nil, ErrDatabase
+	}
+	data.ProduktStatistik = gruppiereProduktStatistik(zeilen)
 
 	log.Info().Msg("Retrieved live reporting")
 	return &data, nil

--- a/backend/api/reporting/application/query_test.go
+++ b/backend/api/reporting/application/query_test.go
@@ -18,6 +18,7 @@ type mockReportingRepo struct {
 	data             reporting.ReportingData
 	liveData         reporting.LiveReportingData
 	eigeneUebersicht reporting.EigeneUebersicht
+	produktStatistik []reporting.ProduktStatistikZeile
 	err              error
 }
 
@@ -31,6 +32,10 @@ func (m mockReportingRepo) GetEigeneUebersicht(_ context.Context, _ int, _ int) 
 
 func (m mockReportingRepo) GetLiveReporting(_ context.Context, _ int) (reporting.LiveReportingData, error) {
 	return m.liveData, m.err
+}
+
+func (m mockReportingRepo) GetProduktStatistik(_ context.Context, _ int) ([]reporting.ProduktStatistikZeile, error) {
+	return m.produktStatistik, m.err
 }
 
 type mockTischSessionRepo struct {
@@ -236,6 +241,115 @@ func assertStornoAggregat(t *testing.T, agg []reporting.StornierungServicekraft,
 	}
 	if summeCents != summary.GesamtStornierungenCents {
 		t.Errorf("Summe StornierungenCents %d != Summary %d", summeCents, summary.GesamtStornierungenCents)
+	}
+}
+
+func TestGruppiereProduktStatistik_GruppiertSortiertUndSummiert(t *testing.T) {
+	// Bewusst unsortierte, kategorieübergreifende Eingabe: Sonstiges vor Essen,
+	// Varianten und Produkte in wechselnder Mengen-Reihenfolge.
+	zeilen := []reporting.ProduktStatistikZeile{
+		{Kategorie: "sonstiges", ProduktName: "Los", VarianteID: 90, VarianteName: "Los", AusgegebeneMenge: 4, UmsatzCents: 400},
+		{Kategorie: "getraenk", ProduktName: "Cola", VarianteID: 20, VarianteName: "0,5 l", AusgegebeneMenge: 3, UmsatzCents: 900},
+		{Kategorie: "getraenk", ProduktName: "Cola", VarianteID: 21, VarianteName: "0,3 l", AusgegebeneMenge: 10, UmsatzCents: 2000},
+		{Kategorie: "essen", ProduktName: "Pommes", VarianteID: 10, VarianteName: "groß", AusgegebeneMenge: 5, UmsatzCents: 1500},
+		{Kategorie: "essen", ProduktName: "Pommes", VarianteID: 11, VarianteName: "klein", AusgegebeneMenge: 5, UmsatzCents: 1000},
+		{Kategorie: "essen", ProduktName: "Wurst", VarianteID: 12, VarianteName: "Wurst", AusgegebeneMenge: 8, UmsatzCents: 2400},
+	}
+
+	produkte := gruppiereProduktStatistik(zeilen)
+
+	// Kategorie-Reihenfolge fest Essen → Getränke → Sonstiges; innerhalb Essen
+	// Wurst (8) vor Pommes (10 gesamt)? Nein: Pommes hat 5+5=10 > Wurst 8.
+	if len(produkte) != 4 {
+		t.Fatalf("expected 4 produkte, got %d: %+v", len(produkte), produkte)
+	}
+
+	// Essen zuerst; Pommes (Menge 10) vor Wurst (Menge 8).
+	if produkte[0].Kategorie != "essen" || produkte[0].ProduktName != "Pommes" {
+		t.Fatalf("expected Pommes first in Essen, got %+v", produkte[0])
+	}
+	if produkte[0].AusgegebeneMenge != 10 || produkte[0].UmsatzCents != 2500 {
+		t.Errorf("expected Pommes subtotal menge 10 / umsatz 2500, got %d / %d", produkte[0].AusgegebeneMenge, produkte[0].UmsatzCents)
+	}
+	// Varianten je Produkt nach Menge absteigend, Name als Tiebreaker bei
+	// Gleichstand (groß vor klein: beide 5).
+	if len(produkte[0].Varianten) != 2 || produkte[0].Varianten[0].VarianteName != "groß" || produkte[0].Varianten[1].VarianteName != "klein" {
+		t.Errorf("expected Pommes-Varianten groß, klein (Name-Tiebreaker), got %+v", produkte[0].Varianten)
+	}
+
+	if produkte[1].Kategorie != "essen" || produkte[1].ProduktName != "Wurst" {
+		t.Errorf("expected Wurst second in Essen, got %+v", produkte[1])
+	}
+
+	// Getränke nach Essen; Cola-Varianten 0,3 l (10) vor 0,5 l (3).
+	if produkte[2].Kategorie != "getraenk" || produkte[2].ProduktName != "Cola" {
+		t.Fatalf("expected Cola in Getränke, got %+v", produkte[2])
+	}
+	if produkte[2].AusgegebeneMenge != 13 || produkte[2].UmsatzCents != 2900 {
+		t.Errorf("expected Cola subtotal menge 13 / umsatz 2900, got %d / %d", produkte[2].AusgegebeneMenge, produkte[2].UmsatzCents)
+	}
+	if produkte[2].Varianten[0].VarianteName != "0,3 l" || produkte[2].Varianten[1].VarianteName != "0,5 l" {
+		t.Errorf("expected Cola-Varianten 0,3 l vor 0,5 l (Menge absteigend), got %+v", produkte[2].Varianten)
+	}
+
+	// Sonstiges zuletzt; Ein-Varianten-Produkt behält genau eine Variante.
+	if produkte[3].Kategorie != "sonstiges" || produkte[3].ProduktName != "Los" || len(produkte[3].Varianten) != 1 {
+		t.Errorf("expected Los as single-variant Sonstiges product, got %+v", produkte[3])
+	}
+}
+
+func TestGruppiereProduktStatistik_LeereEingabe(t *testing.T) {
+	produkte := gruppiereProduktStatistik(nil)
+	if produkte == nil {
+		t.Fatal("expected non-nil empty slice for empty input")
+	}
+	if len(produkte) != 0 {
+		t.Errorf("expected empty result, got %+v", produkte)
+	}
+}
+
+func TestGetReporting_ReichtProduktStatistikDurch(t *testing.T) {
+	zeilen := []reporting.ProduktStatistikZeile{
+		{Kategorie: "essen", ProduktName: "Pommes", VarianteID: 10, VarianteName: "groß", AusgegebeneMenge: 5, UmsatzCents: 1500},
+	}
+	q := Query{
+		ReportingRepo:       mockReportingRepo{produktStatistik: zeilen},
+		KassensitzungenRepo: mockKasseRepo{kassensitzungNr: testKassensitzungNr},
+	}
+
+	result, err := q.GetReporting(context.Background(), testKassensitzungNr)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(result.ProduktStatistik) != 1 || result.ProduktStatistik[0].ProduktName != "Pommes" {
+		t.Fatalf("expected ProduktStatistik with Pommes, got %+v", result.ProduktStatistik)
+	}
+	if result.ProduktStatistik[0].AusgegebeneMenge != 5 || result.ProduktStatistik[0].UmsatzCents != 1500 {
+		t.Errorf("expected Pommes subtotal 5 / 1500, got %+v", result.ProduktStatistik[0])
+	}
+}
+
+func TestGetLiveReporting_ReichtProduktStatistikDurch(t *testing.T) {
+	ks := &kasse.Kassensitzung{ZNr: testKassensitzungNr, Status: kasse.KassensitzungOffen}
+	zeilen := []reporting.ProduktStatistikZeile{
+		{Kategorie: "getraenk", ProduktName: "Cola", VarianteID: 20, VarianteName: "0,5 l", AusgegebeneMenge: 3, UmsatzCents: 900},
+	}
+	q := Query{
+		ReportingRepo:       mockReportingRepo{produktStatistik: zeilen},
+		KassensitzungenRepo: mockKasseRepo{kassensitzung: ks},
+		TischSessionRepo:    mockTischSessionRepo{},
+		TischRepo:           mockTischRepo{},
+	}
+
+	result, err := q.GetLiveReporting(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.ProduktStatistik) != 1 || result.ProduktStatistik[0].ProduktName != "Cola" {
+		t.Fatalf("expected ProduktStatistik with Cola, got %+v", result.ProduktStatistik)
 	}
 }
 

--- a/backend/api/reporting/http/query_handler.go
+++ b/backend/api/reporting/http/query_handler.go
@@ -39,6 +39,7 @@ type reportingResponse struct {
 	Breakdowns          breakdownsResponse         `json:"breakdowns"`
 	UmsatzProSteuersatz []umsatzSteuersatzResponse `json:"umsatzProSteuersatz"`
 	Stornierungen       []stornierungDetail        `json:"stornierungen"`
+	ProduktStatistik    []produktStatistikResponse `json:"produktStatistik"`
 }
 
 func (h *QueryHandler) GetReportingHandler() http.HandlerFunc {
@@ -101,6 +102,23 @@ type umsatzSteuersatzResponse struct {
 	BruttoCents int    `json:"bruttoCents"`
 	NettoCents  int    `json:"nettoCents"`
 	SteuerCents int    `json:"steuerCents"`
+}
+
+// varianteStatistikResponse und produktStatistikResponse tragen die gruppierte
+// Verkaufsstatistik der Response; die flachen Repo-Zeilen erscheinen nie hier.
+type varianteStatistikResponse struct {
+	VarianteID       int    `json:"varianteId"`
+	VarianteName     string `json:"varianteName"`
+	AusgegebeneMenge int    `json:"ausgegebeneMenge"`
+	UmsatzCents      int    `json:"umsatzCents"`
+}
+
+type produktStatistikResponse struct {
+	Kategorie        string                      `json:"kategorie"`
+	ProduktName      string                      `json:"produktName"`
+	AusgegebeneMenge int                         `json:"ausgegebeneMenge"`
+	UmsatzCents      int                         `json:"umsatzCents"`
+	Varianten        []varianteStatistikResponse `json:"varianten"`
 }
 
 type stornierungPosition struct {
@@ -217,6 +235,33 @@ func toStornierungDetails(details []reporting.StornierungDetail) []stornierungDe
 	return out
 }
 
+func toProduktStatistik(p reporting.ProduktStatistik) produktStatistikResponse {
+	varianten := make([]varianteStatistikResponse, len(p.Varianten))
+	for i, v := range p.Varianten {
+		varianten[i] = varianteStatistikResponse{
+			VarianteID:       v.VarianteID,
+			VarianteName:     v.VarianteName,
+			AusgegebeneMenge: v.AusgegebeneMenge,
+			UmsatzCents:      v.UmsatzCents,
+		}
+	}
+	return produktStatistikResponse{
+		Kategorie:        p.Kategorie,
+		ProduktName:      p.ProduktName,
+		AusgegebeneMenge: p.AusgegebeneMenge,
+		UmsatzCents:      p.UmsatzCents,
+		Varianten:        varianten,
+	}
+}
+
+func toProduktStatistikList(werte []reporting.ProduktStatistik) []produktStatistikResponse {
+	out := make([]produktStatistikResponse, len(werte))
+	for i := range werte {
+		out[i] = toProduktStatistik(werte[i])
+	}
+	return out
+}
+
 func toReportingResponse(d reporting.ReportingData) reportingResponse {
 	return reportingResponse{
 		KassensitzungNr: d.KassensitzungNr,
@@ -242,6 +287,7 @@ func toReportingResponse(d reporting.ReportingData) reportingResponse {
 		},
 		UmsatzProSteuersatz: toUmsatzSteuersatzList(d.UmsatzProSteuersatz),
 		Stornierungen:       toStornierungDetails(d.Stornierungen),
+		ProduktStatistik:    toProduktStatistikList(d.ProduktStatistik),
 	}
 }
 
@@ -356,14 +402,15 @@ type liveBreakdownsResponse struct {
 }
 
 type liveReportingResponse struct {
-	KassensitzungNr  int                    `json:"kassensitzungNr"`
-	Bezeichnung      string                 `json:"bezeichnung"`
-	Datum            string                 `json:"datum"` // Kalendertag YYYY-MM-DD
-	OffeneTische     []offenerTischResponse `json:"offeneTische"`
-	OffeneSaldiCents int                    `json:"offeneSaldiCents"`
-	Summary          liveSummaryResponse    `json:"summary"`
-	Breakdowns       liveBreakdownsResponse `json:"breakdowns"`
-	Stornierungen    []stornierungDetail    `json:"stornierungen"`
+	KassensitzungNr  int                        `json:"kassensitzungNr"`
+	Bezeichnung      string                     `json:"bezeichnung"`
+	Datum            string                     `json:"datum"` // Kalendertag YYYY-MM-DD
+	OffeneTische     []offenerTischResponse     `json:"offeneTische"`
+	OffeneSaldiCents int                        `json:"offeneSaldiCents"`
+	Summary          liveSummaryResponse        `json:"summary"`
+	Breakdowns       liveBreakdownsResponse     `json:"breakdowns"`
+	Stornierungen    []stornierungDetail        `json:"stornierungen"`
+	ProduktStatistik []produktStatistikResponse `json:"produktStatistik"`
 }
 
 func toServicekraftLive(s reporting.ServicekraftLive) servicekraftLiveResponse {
@@ -422,7 +469,8 @@ func toLiveReportingResponse(d reporting.LiveReportingData) liveReportingRespons
 			Servicekraefte:               toServicekraefteLive(d.Servicekraefte),
 			StornierungenProServicekraft: toStornierungenProServicekraft(d.Breakdowns.StornierungenProServicekraft),
 		},
-		Stornierungen: toStornierungDetails(d.Stornierungen),
+		Stornierungen:    toStornierungDetails(d.Stornierungen),
+		ProduktStatistik: toProduktStatistikList(d.ProduktStatistik),
 	}
 }
 

--- a/backend/api/reporting/http/query_handler_test.go
+++ b/backend/api/reporting/http/query_handler_test.go
@@ -111,6 +111,14 @@ func TestGetReportingHandler_ValidRequest_ReturnsReportingData(t *testing.T) {
 			{Satz: steuer.RegelSteuersatz, BruttoCents: 1190, NettoCents: 1000, SteuerCents: 190},
 		},
 		Stornierungen: []reporting.StornierungDetail{},
+		ProduktStatistik: []reporting.ProduktStatistik{
+			{
+				Kategorie: "essen", ProduktName: "Pommes", AusgegebeneMenge: 4, UmsatzCents: 900,
+				Varianten: []reporting.VarianteStatistik{
+					{VarianteID: 10, VarianteName: "groß", AusgegebeneMenge: 4, UmsatzCents: 900},
+				},
+			},
+		},
 	}
 	handler := QueryHandler{Query: mockQuery{data: mockData}}
 
@@ -150,9 +158,30 @@ func TestGetReportingHandler_ValidRequest_ReturnsReportingData(t *testing.T) {
 				StornierungenCents  int `json:"stornierungenCents"`
 			} `json:"stornierungenProServicekraft"`
 		} `json:"breakdowns"`
+		ProduktStatistik []struct {
+			Kategorie        string `json:"kategorie"`
+			ProduktName      string `json:"produktName"`
+			AusgegebeneMenge int    `json:"ausgegebeneMenge"`
+			UmsatzCents      int    `json:"umsatzCents"`
+			Varianten        []struct {
+				VarianteID       int    `json:"varianteId"`
+				VarianteName     string `json:"varianteName"`
+				AusgegebeneMenge int    `json:"ausgegebeneMenge"`
+				UmsatzCents      int    `json:"umsatzCents"`
+			} `json:"varianten"`
+		} `json:"produktStatistik"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("expected valid JSON response: %v", err)
+	}
+	if len(resp.ProduktStatistik) != 1 {
+		t.Fatalf("expected 1 produktStatistik row, got %+v", resp.ProduktStatistik)
+	}
+	if p := resp.ProduktStatistik[0]; p.Kategorie != "essen" || p.ProduktName != "Pommes" || p.AusgegebeneMenge != 4 || p.UmsatzCents != 900 {
+		t.Fatalf("unexpected produktStatistik row: %+v", resp.ProduktStatistik[0])
+	}
+	if v := resp.ProduktStatistik[0].Varianten; len(v) != 1 || v[0].VarianteID != 10 || v[0].VarianteName != "groß" {
+		t.Fatalf("unexpected produktStatistik varianten: %+v", resp.ProduktStatistik[0].Varianten)
 	}
 	if len(resp.Breakdowns.StornierungenProServicekraft) != 1 {
 		t.Fatalf("expected 1 stornierungenProServicekraft row, got %+v", resp.Breakdowns.StornierungenProServicekraft)

--- a/backend/domain/reporting/reporting.go
+++ b/backend/domain/reporting/reporting.go
@@ -53,6 +53,40 @@ type StornierungServicekraft struct {
 	StornierungenCents  int
 }
 
+// ProduktStatistikZeile ist eine flache Ausgabezeile der GetProduktStatistik-Query:
+// je Variante die ausgegebene Menge (Produktion) und der Umsatz (Einnahmen) einer
+// Kassensitzung. Eingabe der Gruppierung (gruppiereProduktStatistik); erscheint
+// nie direkt in einer Response.
+type ProduktStatistikZeile struct {
+	Kategorie        string
+	ProduktName      string
+	VarianteID       int
+	VarianteName     string
+	AusgegebeneMenge int
+	UmsatzCents      int
+}
+
+// VarianteStatistik ist die aufbereitete Verkaufs-Kennzahl einer Variante:
+// ausgegebene Menge und Umsatz, bewusst getrennte Grundlagen (nicht ineinander
+// umrechenbar).
+type VarianteStatistik struct {
+	VarianteID       int
+	VarianteName     string
+	AusgegebeneMenge int
+	UmsatzCents      int
+}
+
+// ProduktStatistik gruppiert die Varianten eines Produkts mit Zwischensummen
+// über ausgegebene Menge und Umsatz. Ein-Varianten-Produkte tragen genau eine
+// Variante; die Zusammenfassung zu einer Zeile ist reine Präsentation.
+type ProduktStatistik struct {
+	Kategorie        string
+	ProduktName      string
+	AusgegebeneMenge int
+	UmsatzCents      int
+	Varianten        []VarianteStatistik
+}
+
 type Summary struct {
 	GesamtUmsatzCents        int
 	GesamtBestellungenCents  int
@@ -87,6 +121,10 @@ type ReportingData struct {
 	Breakdowns          Breakdowns
 	UmsatzProSteuersatz []UmsatzSteuersatz
 	Stornierungen       []StornierungDetail
+	// ProduktStatistik ist die fertig gruppierte und sortierte Verkaufsstatistik
+	// je Produkt/Variante (Kategorie-Abschnitte). Von der Anwendungsschicht aus
+	// den flachen ProduktStatistikZeile-Werten gebaut.
+	ProduktStatistik []ProduktStatistik
 }
 
 // AbgeschlosseneSitzung ist ein Eintrag der Kassenberichte-Sitzungsliste: die
@@ -120,6 +158,9 @@ type LiveReportingData struct {
 	// eigenen Arbeit über die Tisch-Sessions, per user_id gemerged.
 	Servicekraefte []ServicekraftLive
 	Stornierungen  []StornierungDetail
+	// ProduktStatistik ist die fertig gruppierte und sortierte Verkaufsstatistik
+	// der offenen Sitzung — identische Form und Regeln wie in der Abrechnung.
+	ProduktStatistik []ProduktStatistik
 }
 
 // ServicekraftLive ist die Live-Sicht auf eine Servicekraft im Admin-Dashboard:

--- a/backend/repository/reporting_repo/repo.go
+++ b/backend/repository/reporting_repo/repo.go
@@ -282,6 +282,31 @@ func toStornierungen(rows []dbgen.GetStornierungenRow) ([]reporting.StornierungD
 	return stornierungen, nil
 }
 
+// GetProduktStatistik liefert die flachen Verkaufszeilen je Variante einer
+// Kassensitzung (ausgegebene Menge und Umsatz); die Gruppierung/Sortierung zu
+// Kategorie-Abschnitten übernimmt die Anwendungsschicht. Bewusst als eigene
+// Methode statt in der GetReporting-errgroup, damit derselbe Code den
+// Abrechnungs- und den Live-Pfad speist.
+func (r Repository) GetProduktStatistik(ctx context.Context, kassensitzungNr int) ([]reporting.ProduktStatistikZeile, error) {
+	rows, err := r.q.GetProduktStatistik(ctx, kassensitzungNr)
+	if err != nil {
+		return nil, err
+	}
+
+	zeilen := make([]reporting.ProduktStatistikZeile, len(rows))
+	for i, row := range rows {
+		zeilen[i] = reporting.ProduktStatistikZeile{
+			Kategorie:        row.Kategorie,
+			ProduktName:      row.ProduktName,
+			VarianteID:       row.VarianteID,
+			VarianteName:     row.VarianteName,
+			AusgegebeneMenge: row.AusgegebeneMenge,
+			UmsatzCents:      row.UmsatzCents,
+		}
+	}
+	return zeilen, nil
+}
+
 func (r Repository) GetEigeneUebersicht(ctx context.Context, userID int, kassensitzungNr int) (reporting.EigeneUebersicht, error) {
 	row, err := r.q.GetEigeneUebersicht(ctx, dbgen.GetEigeneUebersichtParams{
 		UserID:          userID,

--- a/backend/repository/reporting_repo/repo_test.go
+++ b/backend/repository/reporting_repo/repo_test.go
@@ -124,6 +124,160 @@ func korrekturData(betragCents int, kommentar string) map[string]any {
 	}
 }
 
+// produktPosition baut eine Fat-Event-Position mit den für die
+// Produkt-/Varianten-Statistik nötigen eingefrorenen Feldern (varianteId,
+// produktName, varianteName, kategorie, einzelpreisCents, menge).
+func produktPosition(varianteID int, produktName, varianteName, kategorie string, einzelpreisCents, menge int) map[string]any {
+	return map[string]any{
+		"positionId":       "p0000000-0000-0000-0000-000000000001",
+		"varianteId":       varianteID,
+		"produktName":      produktName,
+		"varianteName":     varianteName,
+		"kategorie":        kategorie,
+		"steuersatz":       "regel",
+		"einzelpreisCents": einzelpreisCents,
+		"menge":            menge,
+	}
+}
+
+// TestGetProduktStatistik_MengeUndUmsatzMitVorzeichen prüft die beiden getrennten
+// Zahlen je Variante über alle beteiligten Event-Typen: Bestellung (+Menge),
+// Korrektur (−Menge, geldneutral), Zahlung (+Umsatz), Warenrücknahme (−Umsatz,
+// menge-neutral), Direktverkauf (+Menge/+Umsatz) und Direktverkauf-Storno
+// (−Umsatz). Zugleich die Konsistenz-Invariante: Σ Produkt-Umsatz == Σ Brutto
+// der Umsatz-Positionszeilen derselben Sitzung (kein WHERE-type-Drift).
+func TestGetProduktStatistik_MengeUndUmsatzMitVorzeichen(t *testing.T) {
+	db := dbpkg.OpenTestDatabase()
+	defer func() { _ = db.Close() }()
+	cleanDB(t, db)
+	defer cleanDB(t, db)
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	userID := createUser(t, db, "Anna Müller", "anna", "active")
+	ksNr := createKassensitzung(t, db)
+
+	pommes := func(menge int) map[string]any {
+		return produktPosition(10, "Pommes", "groß", "essen", 300, menge)
+	}
+	cola := func(menge int) map[string]any {
+		return produktPosition(20, "Cola", "0,5 l", "getraenk", 250, menge)
+	}
+
+	// Pommes groß: bestellt 5, korrigiert 1 (geldneutral), kassiert 4, 1 zurückgenommen.
+	insertEvent(t, db, userID, "anna", "bestellung-aufgenommen:v1", "kassensitzung-1/tisch-1", 1, map[string]any{
+		"bestellungId": "b1", "gesamtPreisCents": 1500, "positionen": []map[string]any{pommes(5)},
+	}, ksNr)
+	insertEvent(t, db, userID, "anna", "bestellung-korrigiert:v1", "kassensitzung-1/tisch-1", 2, map[string]any{
+		"korrekturId": "k1", "gesamtCents": 300, "kommentar": "eine zu viel", "positionen": []map[string]any{pommes(1)},
+	}, ksNr)
+	insertEvent(t, db, userID, "anna", "zahlung-kassiert:v1", "kassensitzung-1/tisch-1", 3, map[string]any{
+		"zahlungId": "z1", "gesamtZahlungCents": 1200, "kommentar": "", "positionen": []map[string]any{pommes(4)},
+	}, ksNr)
+	insertEvent(t, db, userID, "anna", "stornierung-erteilt:v1", "kassensitzung-1/tisch-1", 4, map[string]any{
+		"stornierungId": "s1", "zahlungId": "z1", "gesamtStornierungCents": 300, "kommentar": "Warenrücknahme", "positionen": []map[string]any{pommes(1)},
+	}, ksNr)
+
+	// Cola 0,5 l: Direktverkauf 3, davon 1 storniert (Umsatz-mindernd, menge-neutral).
+	insertEvent(t, db, userID, "anna", "direktverkauf-getaetigt:v1", "kassensitzung-1/direktverkauf-d1", 5, map[string]any{
+		"verkaufId": "d1", "gesamtbetragCents": 750, "positionen": []map[string]any{cola(3)},
+	}, ksNr)
+	insertEvent(t, db, userID, "anna", "direktverkauf-storniert:v1", "kassensitzung-1/direktverkauf-d1", 6, map[string]any{
+		"stornierungId": "ds1", "verkaufId": "d1", "gesamtStornierungCents": 250, "kommentar": "Fehlbuchung", "positionen": []map[string]any{cola(1)},
+	}, ksNr)
+
+	zeilen, err := repo.GetProduktStatistik(ctx, ksNr)
+	if err != nil {
+		t.Fatalf("GetProduktStatistik failed: %v", err)
+	}
+
+	byVariante := map[int]reporting.ProduktStatistikZeile{}
+	for _, z := range zeilen {
+		byVariante[z.VarianteID] = z
+	}
+	if len(zeilen) != 2 {
+		t.Fatalf("expected 2 variant rows, got %d: %+v", len(zeilen), zeilen)
+	}
+
+	// Pommes: ausgegebene Menge 5 − 1 = 4; Umsatz 1200 − 300 = 900.
+	pommesZeile := byVariante[10]
+	if pommesZeile.ProduktName != "Pommes" || pommesZeile.VarianteName != "groß" || pommesZeile.Kategorie != "essen" {
+		t.Errorf("unexpected Pommes identity: %+v", pommesZeile)
+	}
+	if pommesZeile.AusgegebeneMenge != 4 {
+		t.Errorf("expected Pommes menge 4 (5 bestellt − 1 korrigiert), got %d", pommesZeile.AusgegebeneMenge)
+	}
+	if pommesZeile.UmsatzCents != 900 {
+		t.Errorf("expected Pommes umsatz 900 (1200 kassiert − 300 Warenrücknahme), got %d", pommesZeile.UmsatzCents)
+	}
+
+	// Cola: Direktverkauf-Storno mindert nur den Umsatz, nicht die Menge.
+	colaZeile := byVariante[20]
+	if colaZeile.AusgegebeneMenge != 3 {
+		t.Errorf("expected Cola menge 3 (Direktverkauf, Storno menge-neutral), got %d", colaZeile.AusgegebeneMenge)
+	}
+	if colaZeile.UmsatzCents != 500 {
+		t.Errorf("expected Cola umsatz 500 (750 Direktverkauf − 250 Storno), got %d", colaZeile.UmsatzCents)
+	}
+
+	// Konsistenz-Invariante: Σ Produkt-Umsatz == Σ Brutto der Umsatz-Positionszeilen
+	// derselben Sitzung — dieselbe WHERE-type-/Vorzeichenbasis, kein Drift.
+	data, err := repo.GetReporting(ctx, ksNr)
+	if err != nil {
+		t.Fatalf("GetReporting failed: %v", err)
+	}
+	summeZeilenBrutto := 0
+	for _, z := range data.UmsatzProSteuersatz {
+		summeZeilenBrutto += z.BruttoCents
+	}
+	summeProduktUmsatz := 0
+	for _, z := range zeilen {
+		summeProduktUmsatz += z.UmsatzCents
+	}
+	if summeProduktUmsatz != summeZeilenBrutto {
+		t.Errorf("Σ Produkt-Umsatz %d != Σ Positionszeilen-Brutto %d (WHERE-type-Drift)", summeProduktUmsatz, summeZeilenBrutto)
+	}
+}
+
+// TestGetProduktStatistik_UmbuchungZaehltNicht stellt sicher, dass
+// bestellung-umgebucht:v1 weder Menge noch Umsatz verändert (die Positionen sind
+// bereits bei der Bestellung erfasst).
+func TestGetProduktStatistik_UmbuchungZaehltNicht(t *testing.T) {
+	db := dbpkg.OpenTestDatabase()
+	defer func() { _ = db.Close() }()
+	cleanDB(t, db)
+	defer cleanDB(t, db)
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	userID := createUser(t, db, "Anna Müller", "anna", "active")
+	ksNr := createKassensitzung(t, db)
+
+	pos := produktPosition(10, "Pommes", "groß", "essen", 300, 2)
+	insertEvent(t, db, userID, "anna", "bestellung-aufgenommen:v1", "kassensitzung-1/tisch-1", 1, map[string]any{
+		"bestellungId": "b1", "gesamtPreisCents": 600, "positionen": []map[string]any{pos},
+	}, ksNr)
+	insertEvent(t, db, userID, "anna", "bestellung-umgebucht:v1", "kassensitzung-1/tisch-3", 2, map[string]any{
+		"umbuchungId": "u1", "quellTischId": 1, "zielTischId": 3, "gesamtCents": 600, "kommentar": "", "positionen": []map[string]any{pos},
+	}, ksNr)
+
+	zeilen, err := repo.GetProduktStatistik(ctx, ksNr)
+	if err != nil {
+		t.Fatalf("GetProduktStatistik failed: %v", err)
+	}
+	if len(zeilen) != 1 {
+		t.Fatalf("expected 1 variant row, got %d: %+v", len(zeilen), zeilen)
+	}
+	if zeilen[0].AusgegebeneMenge != 2 {
+		t.Errorf("expected menge 2 (Umbuchung zählt nicht), got %d", zeilen[0].AusgegebeneMenge)
+	}
+	if zeilen[0].UmsatzCents != 0 {
+		t.Errorf("expected umsatz 0 (nur Bestellung, keine Zahlung), got %d", zeilen[0].UmsatzCents)
+	}
+}
+
 // TestGetReporting_ResolvesKlarnameIncludingSoftDeleted verifies that the live LEFT JOIN
 // resolves the current Klarname for both active and soft-deleted users, while the frozen
 // username stays the maßgebliche identity in the event rows.

--- a/backend/sqlc/dbgen/reporting.sql.go
+++ b/backend/sqlc/dbgen/reporting.sql.go
@@ -159,6 +159,92 @@ func (q *Queries) GetOffeneTischeDetails(ctx context.Context, kassensitzungNr in
 	return items, nil
 }
 
+const getProduktStatistik = `-- name: GetProduktStatistik :many
+SELECT
+    (position->>'kategorie')::text AS kategorie,
+    (position->>'varianteId')::int AS variante_id,
+    (position->>'produktName')::text AS produkt_name,
+    (position->>'varianteName')::text AS variante_name,
+    COALESCE(SUM(
+        (position->>'menge')::int * CASE
+            WHEN kj.type IN ('bestellung-aufgenommen:v1', 'direktverkauf-getaetigt:v1') THEN 1
+            WHEN kj.type = 'bestellung-korrigiert:v1' THEN -1
+            ELSE 0
+        END
+    ), 0)::int AS ausgegebene_menge,
+    COALESCE(SUM(
+        ((position->>'einzelpreisCents')::int * (position->>'menge')::int) * CASE
+            WHEN kj.type IN ('zahlung-kassiert:v1', 'direktverkauf-getaetigt:v1') THEN 1
+            WHEN kj.type IN ('stornierung-erteilt:v1', 'direktverkauf-storniert:v1') THEN -1
+            ELSE 0
+        END
+    ), 0)::int AS umsatz_cents
+FROM kassenjournal kj
+CROSS JOIN LATERAL jsonb_array_elements(kj.data->'positionen') AS position
+WHERE kj.type IN (
+    'bestellung-aufgenommen:v1',
+    'bestellung-korrigiert:v1',
+    'direktverkauf-getaetigt:v1',
+    'zahlung-kassiert:v1',
+    'stornierung-erteilt:v1',
+    'direktverkauf-storniert:v1'
+)
+AND kj.kassensitzung_nr = $1
+GROUP BY kategorie, variante_id, produkt_name, variante_name
+`
+
+type GetProduktStatistikRow struct {
+	Kategorie        string
+	VarianteID       int
+	ProduktName      string
+	VarianteName     string
+	AusgegebeneMenge int
+	UmsatzCents      int
+}
+
+// Tagesabrechnung/Live: Verkäufe je Produkt und Variante einer Kassensitzung,
+// aus den eingefrorenen Fat-Event-Positionen aggregiert (kein Stammdaten-Join).
+// Flache Zeilen je Variante mit zwei bewusst getrennten Zahlen — die
+// Anwendungsschicht gruppiert und sortiert sie zu Kategorie-Abschnitten:
+//
+//	Ausgegebene Menge (Produktion) = Σ menge: bestellung-aufgenommen (+),
+//	  bestellung-korrigiert (−), direktverkauf-getaetigt (+).
+//	Umsatz (Einnahmen) = Σ einzelpreisCents × menge: zahlung-kassiert (+),
+//	  direktverkauf-getaetigt (+), stornierung-erteilt (−), direktverkauf-storniert (−).
+//
+// bestellung-umgebucht zählt nicht (Positionen bereits bei der Bestellung erfasst).
+// Dieselbe Positions-/Vorzeichenbasis wie GetUmsatzPositionszeilen für den
+// Umsatzanteil, damit Σ umsatzCents dem kassierten Gesamtumsatz entspricht.
+func (q *Queries) GetProduktStatistik(ctx context.Context, kassensitzungNr int) ([]GetProduktStatistikRow, error) {
+	rows, err := q.db.QueryContext(ctx, getProduktStatistik, kassensitzungNr)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetProduktStatistikRow{}
+	for rows.Next() {
+		var i GetProduktStatistikRow
+		if err := rows.Scan(
+			&i.Kategorie,
+			&i.VarianteID,
+			&i.ProduktName,
+			&i.VarianteName,
+			&i.AusgegebeneMenge,
+			&i.UmsatzCents,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getReportingStats = `-- name: GetReportingStats :one
 SELECT
     (

--- a/backend/sqlc/queries/reporting.sql
+++ b/backend/sqlc/queries/reporting.sql
@@ -108,6 +108,50 @@ CROSS JOIN LATERAL kj_extract_umsatz_pro_steuersatz(kj.type, kj.data) AS s(steue
 WHERE kj.type IN ('zahlung-kassiert:v1', 'direktverkauf-getaetigt:v1', 'direktverkauf-storniert:v1', 'stornierung-erteilt:v1')
 AND kj.kassensitzung_nr = @kassensitzung_nr;
 
+-- name: GetProduktStatistik :many
+-- Tagesabrechnung/Live: Verkäufe je Produkt und Variante einer Kassensitzung,
+-- aus den eingefrorenen Fat-Event-Positionen aggregiert (kein Stammdaten-Join).
+-- Flache Zeilen je Variante mit zwei bewusst getrennten Zahlen — die
+-- Anwendungsschicht gruppiert und sortiert sie zu Kategorie-Abschnitten:
+--   Ausgegebene Menge (Produktion) = Σ menge: bestellung-aufgenommen (+),
+--     bestellung-korrigiert (−), direktverkauf-getaetigt (+).
+--   Umsatz (Einnahmen) = Σ einzelpreisCents × menge: zahlung-kassiert (+),
+--     direktverkauf-getaetigt (+), stornierung-erteilt (−), direktverkauf-storniert (−).
+-- bestellung-umgebucht zählt nicht (Positionen bereits bei der Bestellung erfasst).
+-- Dieselbe Positions-/Vorzeichenbasis wie GetUmsatzPositionszeilen für den
+-- Umsatzanteil, damit Σ umsatzCents dem kassierten Gesamtumsatz entspricht.
+SELECT
+    (position->>'kategorie')::text AS kategorie,
+    (position->>'varianteId')::int AS variante_id,
+    (position->>'produktName')::text AS produkt_name,
+    (position->>'varianteName')::text AS variante_name,
+    COALESCE(SUM(
+        (position->>'menge')::int * CASE
+            WHEN kj.type IN ('bestellung-aufgenommen:v1', 'direktverkauf-getaetigt:v1') THEN 1
+            WHEN kj.type = 'bestellung-korrigiert:v1' THEN -1
+            ELSE 0
+        END
+    ), 0)::int AS ausgegebene_menge,
+    COALESCE(SUM(
+        ((position->>'einzelpreisCents')::int * (position->>'menge')::int) * CASE
+            WHEN kj.type IN ('zahlung-kassiert:v1', 'direktverkauf-getaetigt:v1') THEN 1
+            WHEN kj.type IN ('stornierung-erteilt:v1', 'direktverkauf-storniert:v1') THEN -1
+            ELSE 0
+        END
+    ), 0)::int AS umsatz_cents
+FROM kassenjournal kj
+CROSS JOIN LATERAL jsonb_array_elements(kj.data->'positionen') AS position
+WHERE kj.type IN (
+    'bestellung-aufgenommen:v1',
+    'bestellung-korrigiert:v1',
+    'direktverkauf-getaetigt:v1',
+    'zahlung-kassiert:v1',
+    'stornierung-erteilt:v1',
+    'direktverkauf-storniert:v1'
+)
+AND kj.kassensitzung_nr = @kassensitzung_nr
+GROUP BY kategorie, variante_id, produkt_name, variante_name;
+
 -- name: GetKassensitzungMetadaten :one
 -- Tagesabrechnung: Sitzungs-Metadaten für den formalen Berichtskopf, reine
 -- Projektion über die vorhandenen Journal-Events. Eröffnungs- und

--- a/docs/anforderungen.md
+++ b/docs/anforderungen.md
@@ -14,9 +14,7 @@ Rollen: `admin` (Stammdaten und Kasse), `serviceleitung` (Kasse inkl. Storno), `
 
 ## Roadmap
 
-| ID   | Titel                    | Beschreibung                                                                  | Bereich     | Prio   |
-| ---- | ------------------------ | ----------------------------------------------------------------------------- | ----------- | ------ |
-| R-05 | Produktumsatz-Reporting  | Mengen, Ranking und Einnahmen pro Produkt und Variante.                       | Reporting   | Nice   |
+Aktuell keine offenen Roadmap-Anforderungen — alle spezifizierten Anforderungen sind umgesetzt (siehe Funktionsumfang).
 
 ## Nicht-Ziele
 
@@ -79,10 +77,11 @@ Zeitraumbezogene Auswertungen beziehen sich je auf eine Kassensitzung (`kassensi
 
 | ID   | Titel                       | Beschreibung                             |
 | ---- | --------------------------- | ---------------------------------------- |
-| R-01 | Tagesabrechnung             | KPIs und Breakdowns je Kassensitzung.    |
-| R-04 | Abrechnung pro Servicekraft | Umsatz pro Servicekraft (Teil von R-01). |
-| R-06 | Eigene Übersicht            | KPI-Sektion auf dem Service-Dashboard.   |
-| R-07 | Live-Dashboard              | Echtzeit-KPIs der offenen Kassensitzung. |
+| R-01 | Tagesabrechnung              | KPIs und Breakdowns je Kassensitzung.                                                                        |
+| R-04 | Abrechnung pro Servicekraft  | Umsatz pro Servicekraft (Teil von R-01).                                                                     |
+| R-05 | Produkt-/Varianten-Statistik | Ausgegebene Menge und Umsatz pro Produkt und Variante je Kassensitzung — in Tagesabrechnung und Live-Dashboard. |
+| R-06 | Eigene Übersicht             | KPI-Sektion auf dem Service-Dashboard.                                                                       |
+| R-07 | Live-Dashboard               | Echtzeit-KPIs der offenen Kassensitzung.                                                                     |
 
 ### Querschnitt (Qualitätsmerkmale)
 

--- a/docs/handbuch.md
+++ b/docs/handbuch.md
@@ -479,12 +479,14 @@ Reporting ist Admin-only und wird on-demand per SQL-Aggregation über `kassenjou
 
 | Endpunkt                         | Scope                                  | Inhalt                                                                              |
 | -------------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------- |
-| `POST /admin/get-live-reporting` | offene Kassensitzung (ohne Parameter)  | KPIs, offene Tische, offene Saldi, Stornierungen                                    |
-| `POST /admin/get-abrechnung`     | bestimmte Kassensitzung (`kassensitzungNr`) | `metadaten` (`eroeffnetAm`, `abgeschlossenAm`, `abgeschlossenVon`, `kassensturzDifferenzCents`), `summary`, `breakdowns` (Umsatz pro Servicekraft), `umsatzProSteuersatz`, `stornierungen` |
+| `POST /admin/get-live-reporting` | offene Kassensitzung (ohne Parameter)  | KPIs, offene Tische, offene Saldi, Stornierungen, `produktStatistik`                 |
+| `POST /admin/get-abrechnung`     | bestimmte Kassensitzung (`kassensitzungNr`) | `metadaten` (`eroeffnetAm`, `abgeschlossenAm`, `abgeschlossenVon`, `kassensturzDifferenzCents`), `summary`, `breakdowns` (Umsatz pro Servicekraft), `umsatzProSteuersatz`, `stornierungen`, `produktStatistik` |
 | `POST /admin/get-abgeschlossene-kassensitzungen` | alle abgeschlossenen Kassensitzungen | Liste `AbgeschlosseneSitzung`: `zNr`, `datum`, `bezeichnung`, `umsatzGesamtCents`, `abgeschlossenAm` (aus `tagesabschluss-erstellt:v1`) — Auswahlliste der Kassenberichte |
 | `POST /admin/get-all-tische`     | alle Tische (Stammdaten)               | Tischliste mit offenem Saldo (`TischMitSaldo`): Tisch-Stammdaten + `saldoCents` aus der `tisch_sessions`-Projektion der offenen Kassensitzung (Saldo-Anzeige, Lösch-/Deaktivier-Schutz, → [§2.2](#22-beziehungen-zwischen-kontexten)) |
 
-Beide `summary`-Sektionen enthalten die Direktverkauf-Kennzahlen `anzahlDirektverkaeufe` und `direktverkaufUmsatzCents` (netto: Verkauf minus Storno). Anforderungs-IDs (R-01–R-05) → [anforderungen.md](anforderungen.md).
+Beide `summary`-Sektionen enthalten die Direktverkauf-Kennzahlen `anzahlDirektverkaeufe` und `direktverkaufUmsatzCents` (netto: Verkauf minus Storno). Anforderungs-IDs (R-01–R-07) → [anforderungen.md](anforderungen.md).
+
+`produktStatistik` (R-05) ist in beiden Antworten identisch: die Verkäufe je Produkt und Variante der Kassensitzung, aus den eingefrorenen Fat-Event-Positionen aggregiert (kein Stammdaten-Join). Read-Model-Typen `ProduktStatistik` (Produkt mit Zwischensumme, Feld `varianten`) und `VarianteStatistik` (`varianteId`, `varianteName`, `ausgegebeneMenge`, `umsatzCents`) — zwei bewusst getrennte Zahlen: ausgegebene Menge (Bestellung − Korrektur + Direktverkauf) und Umsatz (Kassiert + Direktverkauf − Warenrücknahme/Storno). Die Anwendungsschicht gruppiert die flachen SQL-Zeilen zu Kategorie-Abschnitten (Essen → Getränke → Sonstiges) und sortiert je Kategorie nach Menge absteigend; die Umsatzsumme deckt sich mit `umsatzProSteuersatz` (dieselbe Positions-/Vorzeichenbasis).
 
 ### 7.3 Ausgabe-Ansichten
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -349,12 +349,15 @@ Reporting-Daten werden on-demand per SQL-Aggregation aus dem Kassenjournal berec
 
 | Begriff             | Bedeutung                                                                                                  |
 | ------------------- | ---------------------------------------------------------------------------------------------------------- |
-| ReportingData       | Vollständiger Reporting-Datensatz einer Kassensitzung: Summary + Breakdowns + Stornierungen                |
+| ReportingData       | Vollständiger Reporting-Datensatz einer Kassensitzung: Summary + Breakdowns + Stornierungen + ProduktStatistik |
 | Summary             | Aggregierte Kennzahlen einer Kassensitzung (Umsatz, Stornierungen, offene Salden, Anzahlen)                |
 | Breakdowns          | Aufschlüsselung des Umsatzes: `UmsatzProServicekraft []UmsatzServicekraft`                                 |
 | UmsatzServicekraft  | Umsatz einer einzelnen Servicekraft (Zahlungen, Anzahl)                                                    |
 | StornierungDetail   | Einzelne Stornierung im Reporting (Zeitpunkt, Tisch, Benutzer, Betrag, Kommentar, Positionen); `barRueckgabe` markiert die kassenwirksame Warenrücknahme gegenüber der geldneutralen Korrektur |
 | StornierungPosition | Position innerhalb einer StornierungDetail (Produktname, Variantenname, Menge, Einzelpreis)                |
+| ProduktStatistik    | Verkäufe eines Produkts einer Kassensitzung, gruppiert nach Kategorie, mit Zwischensumme über `Varianten []VarianteStatistik` (ausgegebene Menge und Umsatz). Teil von `ReportingData` und `LiveReportingData` (`produktStatistik`) |
+| VarianteStatistik   | Verkaufs-Kennzahl einer Variante: `varianteId`, `varianteName`, `ausgegebeneMenge` (Bestellung − Korrektur + Direktverkauf) und `umsatzCents` (Kassiert + Direktverkauf − Warenrücknahme/Storno) — zwei bewusst getrennte Grundlagen |
+| ProduktStatistikZeile | Flache Repo-Ausgabezeile je Variante (SQL `GetProduktStatistik`), Eingabe der Gruppierung; erscheint nie in einer Response                                 |
 
 ---
 

--- a/docs/plans/offene-punkte.md
+++ b/docs/plans/offene-punkte.md
@@ -78,5 +78,7 @@ Release-Vorbereitung.
   (GoBD-Integritätsnachweis) und F-09 (eBeleg) als v1.1 nachziehen sollten.
   Commit `186aea9` hat K-23, R-02 (CSV-Export), F-08 und F-09 jedoch ohne
   Begründung aus `anforderungen.md` entfernt (weder Roadmap noch
-  Nicht-Ziele; nur R-05 steht noch). Entscheiden, ob sie zurück in die
-  Roadmap kommen oder als Nicht-Ziele dokumentiert werden.
+  Nicht-Ziele). R-05 ist inzwischen umgesetzt und in den Funktionsumfang
+  verschoben; die Roadmap ist damit leer. Entscheiden, ob K-23, R-02, F-08
+  und F-09 zurück in die Roadmap kommen oder als Nicht-Ziele dokumentiert
+  werden.

--- a/docs/plans/plan-produkt-varianten-statistik.md
+++ b/docs/plans/plan-produkt-varianten-statistik.md
@@ -201,33 +201,33 @@ Teil des Z-Bons.
 
 ### Acceptance criteria
 
-- [ ] Für eine Kassensitzung mit Bestellungen, Korrekturen, Zahlungen,
+- [x] Für eine Kassensitzung mit Bestellungen, Korrekturen, Zahlungen,
   Warenrücknahmen, Direktverkäufen und Direktverkauf-Stornos liefert die Auswertung
   je Variante die korrekte ausgegebene Menge (Bestellung − Korrektur +
   Direktverkauf) und den korrekten Umsatz (Kassiert + Direktverkauf − Storno);
   Umbuchungen verändern beide Zahlen nicht.
-- [ ] Warenrücknahme/Direktverkauf-Storno mindern nur den Umsatz, nicht die Menge;
+- [x] Warenrücknahme/Direktverkauf-Storno mindern nur den Umsatz, nicht die Menge;
   eine geldneutrale Korrektur mindert nur die Menge, nicht den Umsatz.
-- [ ] Die Ausgabe ist in Kategorie-Abschnitte (Essen → Getränke → Sonstiges)
+- [x] Die Ausgabe ist in Kategorie-Abschnitte (Essen → Getränke → Sonstiges)
   gegliedert; je Produkt gibt es eine Zwischensumme über seine Varianten; Produkte
   und Varianten sind nach ausgegebener Menge absteigend sortiert (Name-Tiebreaker).
-- [ ] `gruppiereProduktStatistik` ist als reine Funktion isoliert unit-getestet
+- [x] `gruppiereProduktStatistik` ist als reine Funktion isoliert unit-getestet
   (`query_test.go`, Muster `computeUmsatzProSteuersatz`): flache
   `ProduktStatistikZeile`-Eingabe → korrekte Kategorie-Reihenfolge, Produkt-Gruppen,
   Zwischensummen, absteigende Mengensortierung und stabiler Tiebreaker.
-- [ ] Σ aller Produkt-`umsatzCents` entspricht der Summe der
+- [x] Σ aller Produkt-`umsatzCents` entspricht der Summe der
   `umsatzProSteuersatz`-Bruttowerte derselben Kassensitzung. Diese Invariante wird
   im **Repo-Integrationstest** (`repo_test.go`, echtes Postgres, dieselben Events
   speisen `GetProduktStatistik` und `GetUmsatzPositionszeilen`) geprüft — dort, wo
   ein Drift der `WHERE type IN (…)`-Mengen real auffällt; ein
   Anwendungs-Unit-Test mit handgebauten Eingaben kann diesen SQL-Drift nicht fangen.
-- [ ] `admin/get-abrechnung` liefert das Feld `produktStatistik` mit
+- [x] `admin/get-abrechnung` liefert das Feld `produktStatistik` mit
   verschachtelten `varianten`; das Frontend validiert es per Zod ohne Fehler.
-- [ ] `ReportingResults.tsx` zeigt den Abschnitt „Verkäufe pro Produkt" mit
+- [x] `ReportingResults.tsx` zeigt den Abschnitt „Verkäufe pro Produkt" mit
   Kategorie-Überschriften, Zwischensummen, den Spalten „Ausgegeben"/„Umsatz", dem
   erklärenden Hinweis und einem leeren Zustand bei einer Sitzung ohne Verkäufe;
   Ein-Varianten-Produkte erscheinen als eine Zeile.
-- [ ] `make sqlc`, `make lint` und die betroffenen Backend- und Frontend-Tests
+- [x] `make sqlc`, `make lint` und die betroffenen Backend- und Frontend-Tests
   laufen grün; `sqlc/dbgen/` wurde nicht von Hand editiert.
 
 ---
@@ -264,16 +264,16 @@ sodass die Statistik der offenen Kassensitzung in Echtzeit erscheint.
 
 ### Acceptance criteria
 
-- [ ] `admin/get-live-reporting` liefert für die offene Kassensitzung das Feld
+- [x] `admin/get-live-reporting` liefert für die offene Kassensitzung das Feld
   `produktStatistik` mit identischer Struktur und identischen Zahlen-Regeln wie die
   Abrechnung (dieselbe Gruppierungs-/Sortierfunktion, keine Duplikat-Logik).
-- [ ] Das Live-Dashboard zeigt den Abschnitt „Verkäufe pro Produkt" mit denselben
+- [x] Das Live-Dashboard zeigt den Abschnitt „Verkäufe pro Produkt" mit denselben
   Kategorie-Abschnitten, Zwischensummen und Spalten wie die Abrechnung; ein leerer
   Zustand erscheint, solange noch keine Verkäufe vorliegen.
-- [ ] In einer offenen Sitzung mit noch unbezahlten Bestellungen erscheint die
+- [x] In einer offenen Sitzung mit noch unbezahlten Bestellungen erscheint die
   ausgegebene Menge > 0 bei Umsatz 0 (bestellt/rausgegeben, aber noch nicht
   kassiert) — konsistent mit den Kennzahl-Regeln.
-- [ ] `make lint` und die betroffenen Backend-/Frontend-Tests laufen grün.
+- [x] `make lint` und die betroffenen Backend-/Frontend-Tests laufen grün.
 
 ---
 
@@ -301,11 +301,11 @@ Endpunkt-Beschreibung von `docs/handbuch.md` §7.2 sowie in der Begriffsliste vo
 
 ### Acceptance criteria
 
-- [ ] R-05 steht nicht mehr in der Roadmap, sondern als umgesetzte Anforderung im
+- [x] R-05 steht nicht mehr in der Roadmap, sondern als umgesetzte Anforderung im
   Reporting-Funktionsumfang von `docs/anforderungen.md`.
-- [ ] `docs/handbuch.md` §7.2 nennt `produktStatistik` als Bestandteil der
+- [x] `docs/handbuch.md` §7.2 nennt `produktStatistik` als Bestandteil der
   `get-abrechnung`- und `get-live-reporting`-Antwort und führt die neuen
   Read-Model-Typen in der Übersicht.
-- [ ] `docs/language.md` enthält Einträge für `ProduktStatistik` und
+- [x] `docs/language.md` enthält Einträge für `ProduktStatistik` und
   `VarianteStatistik`.
-- [ ] Keine toten Verweise; Begriffe konsistent mit den im Code verwendeten Namen.
+- [x] Keine toten Verweise; Begriffe konsistent mit den im Code verwendeten Namen.

--- a/frontend/src/admin/reporting/AdminDashboardPage.test.tsx
+++ b/frontend/src/admin/reporting/AdminDashboardPage.test.tsx
@@ -84,6 +84,7 @@ function makeLiveData(): LiveReportingData {
     },
     breakdowns: { servicekraefte: [], stornierungenProServicekraft: [] },
     stornierungen: [],
+    produktStatistik: [],
   }
 }
 

--- a/frontend/src/admin/reporting/KassenberichtePage.test.tsx
+++ b/frontend/src/admin/reporting/KassenberichtePage.test.tsx
@@ -67,6 +67,7 @@ function makeReport(zNr: number): ReportingData {
     },
     umsatzProSteuersatz: [],
     stornierungen: [],
+    produktStatistik: [],
   }
 }
 

--- a/frontend/src/admin/reporting/LiveReportingSection.test.tsx
+++ b/frontend/src/admin/reporting/LiveReportingSection.test.tsx
@@ -40,6 +40,7 @@ function liveData(
     },
     breakdowns: { servicekraefte, stornierungenProServicekraft },
     stornierungen,
+    produktStatistik: [],
     ...overrides,
   }
 }
@@ -250,5 +251,55 @@ describe('LiveReportingSection — Übersicht', () => {
     expect(
       screen.getByRole('link', { name: 'Zur Kassensitzungs-Seite' }),
     ).toHaveAttribute('href', '/admin/kasse')
+  })
+})
+
+describe('LiveReportingSection — Verkäufe pro Produkt', () => {
+  it('zeigt die Produkt-/Varianten-Statistik der offenen Sitzung', () => {
+    render(
+      <LiveReportingSection
+        liveData={liveData([], [], [], {
+          produktStatistik: [
+            {
+              kategorie: 'essen',
+              produktName: 'Pommes',
+              // Bestellt/ausgegeben, aber noch nicht kassiert: Menge > 0, Umsatz 0.
+              ausgegebeneMenge: 6,
+              umsatzCents: 0,
+              varianten: [
+                {
+                  varianteId: 10,
+                  varianteName: 'groß',
+                  ausgegebeneMenge: 6,
+                  umsatzCents: 0,
+                },
+              ],
+            },
+          ],
+        })}
+        loading={false}
+        dataUpdatedAt={0}
+        onRefresh={noopRefresh}
+      />,
+    )
+
+    expect(screen.getByText('Verkäufe pro Produkt')).toBeInTheDocument()
+    expect(screen.getByText('Essen')).toBeInTheDocument()
+    expect(screen.getByText('Pommes groß')).toBeInTheDocument()
+  })
+
+  it('zeigt einen leeren Zustand ohne Verkäufe', () => {
+    render(
+      <LiveReportingSection
+        liveData={liveData([])}
+        loading={false}
+        dataUpdatedAt={0}
+        onRefresh={noopRefresh}
+      />,
+    )
+
+    expect(
+      screen.getByText('Keine Verkäufe in dieser Kassensitzung.'),
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/src/admin/reporting/LiveReportingSection.tsx
+++ b/frontend/src/admin/reporting/LiveReportingSection.tsx
@@ -31,6 +31,7 @@ import { StornoAggregat } from './StornoServicekraft'
 import { SummaryCard } from './SummaryCard'
 import type { LiveReportingData } from './types'
 import { formatBediener, formatDatum, formatStand } from './utils'
+import { VerkaufStatistik } from './VerkaufStatistik'
 
 // Nach fünf Einträgen wird die Liste offener Tische gekürzt; „Alle n anzeigen"
 // blendet den Rest ein (Design-Handoff 1a).
@@ -263,6 +264,11 @@ export function LiveReportingSection({
             </div>
           )}
         </div>
+      </div>
+
+      {/* Verkäufe pro Produkt: dieselbe Aufbereitung wie in der Abrechnung */}
+      <div className="rounded-xl border p-5">
+        <VerkaufStatistik produktStatistik={liveData.produktStatistik} />
       </div>
 
       {/* Stornierungen: eingeklappte Zeile, Aufklappen zeigt die Detail-Liste */}

--- a/frontend/src/admin/reporting/ReportingResults.test.tsx
+++ b/frontend/src/admin/reporting/ReportingResults.test.tsx
@@ -64,6 +64,42 @@ const reportingResult: ReportingData = {
       positionen: [],
     },
   ],
+  produktStatistik: [
+    {
+      kategorie: 'essen',
+      produktName: 'Pommes',
+      ausgegebeneMenge: 9,
+      umsatzCents: 2500,
+      varianten: [
+        {
+          varianteId: 10,
+          varianteName: 'groß',
+          ausgegebeneMenge: 5,
+          umsatzCents: 1500,
+        },
+        {
+          varianteId: 11,
+          varianteName: 'klein',
+          ausgegebeneMenge: 4,
+          umsatzCents: 1000,
+        },
+      ],
+    },
+    {
+      kategorie: 'getraenk',
+      produktName: 'Cola',
+      ausgegebeneMenge: 3,
+      umsatzCents: 900,
+      varianten: [
+        {
+          varianteId: 20,
+          varianteName: '0,5 l',
+          ausgegebeneMenge: 3,
+          umsatzCents: 900,
+        },
+      ],
+    },
+  ],
 }
 
 const sitzung: AbgeschlosseneSitzung = {
@@ -134,6 +170,45 @@ describe('ReportingResults', () => {
     expect(screen.getByText('67,89 €')).toBeInTheDocument()
     // Storno-Marker an der Servicekraft-Zeile.
     expect(screen.getByText('1 Storno')).toBeInTheDocument()
+  })
+
+  it('zeigt den Abschnitt „Verkäufe pro Produkt" mit Kategorien, Zwischensumme und Ein-Varianten-Zeile', () => {
+    render(
+      <ReportingResults
+        result={reportingResult}
+        sitzung={sitzung}
+        loading={false}
+      />,
+    )
+
+    expect(screen.getByText('Verkäufe pro Produkt')).toBeInTheDocument()
+    // Kategorie-Überschriften.
+    expect(screen.getByText('Essen')).toBeInTheDocument()
+    expect(screen.getByText('Getränke')).toBeInTheDocument()
+    // Mehr-Varianten-Produkt: Produktzeile plus zwei Variantenzeilen.
+    expect(screen.getByText('Pommes')).toBeInTheDocument()
+    expect(screen.getByText('groß')).toBeInTheDocument()
+    expect(screen.getByText('klein')).toBeInTheDocument()
+    // Ein-Varianten-Produkt zu einer Zeile zusammengefasst (produktName ==
+    // varianteName erscheint genau einmal).
+    expect(screen.getByText('Cola 0,5 l')).toBeInTheDocument()
+    // Spaltenüberschriften und ein Umsatzwert.
+    expect(screen.getByText('Ausgegeben')).toBeInTheDocument()
+    expect(screen.getByText('25,00 €')).toBeInTheDocument()
+  })
+
+  it('zeigt einen leeren Zustand ohne Verkäufe', () => {
+    render(
+      <ReportingResults
+        result={{ ...reportingResult, produktStatistik: [] }}
+        sitzung={sitzung}
+        loading={false}
+      />,
+    )
+
+    expect(
+      screen.getByText('Keine Verkäufe in dieser Kassensitzung.'),
+    ).toBeInTheDocument()
   })
 
   it('druckt beim Klick auf Drucken über window.print', async () => {

--- a/frontend/src/admin/reporting/ReportingResults.tsx
+++ b/frontend/src/admin/reporting/ReportingResults.tsx
@@ -8,6 +8,7 @@ import { StornoItem } from './StornoItem'
 import { StornoMarker } from './StornoServicekraft'
 import type { AbgeschlosseneSitzung, ReportingData } from './types'
 import { formatBediener, formatDatumLang, formatLocalTime } from './utils'
+import { VerkaufStatistik } from './VerkaufStatistik'
 
 // Berichtskopf-Zeile: Datum, Eröffnungs-/Abschlusszeit, abschließender Benutzer
 // und Kassensturz-Differenz — rein aus den vom Backend projizierten Metadaten.
@@ -227,6 +228,8 @@ export function ReportingResults({
           )}
         </div>
       </div>
+
+      <VerkaufStatistik produktStatistik={result.produktStatistik} />
     </div>
   )
 }

--- a/frontend/src/admin/reporting/VerkaufStatistik.tsx
+++ b/frontend/src/admin/reporting/VerkaufStatistik.tsx
@@ -1,0 +1,130 @@
+import { Fragment } from 'react'
+
+import { formatEuro, formatPositionName } from '@/lib/utils'
+
+import type { ProduktStatistik } from './types'
+
+const KATEGORIE_LABEL: Record<string, string> = {
+  essen: 'Essen',
+  getraenk: 'Getränke',
+  sonstiges: 'Sonstiges',
+}
+
+function kategorieLabel(kategorie: string): string {
+  return KATEGORIE_LABEL[kategorie] ?? kategorie
+}
+
+// StatistikZeile ist eine Tabellenzeile des Verkaufsabschnitts: Beschriftung,
+// ausgegebene Menge (ganze Portionen) und Umsatz. `bold` hebt die
+// Produkt-Zwischensumme hervor, `indent` rückt Variantenzeilen darunter ein.
+function StatistikZeile({
+  label,
+  ausgegebeneMenge,
+  umsatzCents,
+  bold = false,
+  indent = false,
+}: {
+  label: string
+  ausgegebeneMenge: number
+  umsatzCents: number
+  bold?: boolean
+  indent?: boolean
+}) {
+  const betonung = bold ? 'font-semibold' : ''
+  return (
+    <div className="grid grid-cols-[1.6fr_1fr_1fr] gap-x-3 border-t px-3 py-2 text-sm">
+      <span
+        className={`${indent ? 'pl-4 text-muted-foreground' : ''} ${betonung}`}
+      >
+        {label}
+      </span>
+      <span className={`text-right tabular-nums ${betonung}`}>
+        {ausgegebeneMenge}
+      </span>
+      <span className={`text-right tabular-nums ${betonung}`}>
+        {formatEuro(umsatzCents)}
+      </span>
+    </div>
+  )
+}
+
+// VerkaufStatistik zeigt die Verkäufe je Produkt und Variante einer
+// Kassensitzung, in Kategorie-Abschnitte (Essen → Getränke → Sonstiges)
+// gegliedert. Zwei bewusst getrennte Zahlen: ausgegebene Menge (Produktion) und
+// Umsatz (Einnahmen) — nicht ineinander umrechenbar. Ein-Varianten-Produkte
+// erscheinen als eine Zeile; sonst Produkt-Zwischensumme mit eingerückten
+// Varianten. Das Backend liefert die Liste fertig gruppiert und sortiert.
+export function VerkaufStatistik({
+  produktStatistik,
+}: {
+  produktStatistik: ProduktStatistik[]
+}) {
+  return (
+    <div>
+      <div className="mb-2 text-sm font-semibold">Verkäufe pro Produkt</div>
+      <p className="mb-2 text-xs text-muted-foreground">
+        „Ausgegeben" zählt zubereitete Portionen (bestellt minus Korrekturen,
+        inklusive Direktverkauf); „Umsatz" zählt die Einnahmen (kassiert und
+        Direktverkauf minus Storno). Die beiden Zahlen ruhen auf
+        unterschiedlichen Grundlagen und sind nicht ineinander umrechenbar.
+      </p>
+      {produktStatistik.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Keine Verkäufe in dieser Kassensitzung.
+        </p>
+      ) : (
+        <div className="overflow-hidden rounded-lg border">
+          <div className="grid grid-cols-[1.6fr_1fr_1fr] gap-x-3 bg-sidebar px-3 py-2 text-xs font-semibold text-muted-foreground">
+            <span>Produkt</span>
+            <span className="text-right">Ausgegeben</span>
+            <span className="text-right">Umsatz</span>
+          </div>
+          {produktStatistik.map((produkt, index) => {
+            const neuerAbschnitt =
+              index === 0 ||
+              produktStatistik[index - 1].kategorie !== produkt.kategorie
+            const einVariante = produkt.varianten.length === 1
+
+            return (
+              <Fragment key={`${produkt.kategorie}-${produkt.produktName}`}>
+                {neuerAbschnitt && (
+                  <div className="border-t bg-muted/40 px-3 py-1.5 text-xs font-semibold">
+                    {kategorieLabel(produkt.kategorie)}
+                  </div>
+                )}
+                {einVariante ? (
+                  <StatistikZeile
+                    label={formatPositionName(
+                      produkt.produktName,
+                      produkt.varianten[0].varianteName,
+                    )}
+                    ausgegebeneMenge={produkt.ausgegebeneMenge}
+                    umsatzCents={produkt.umsatzCents}
+                  />
+                ) : (
+                  <>
+                    <StatistikZeile
+                      label={produkt.produktName}
+                      ausgegebeneMenge={produkt.ausgegebeneMenge}
+                      umsatzCents={produkt.umsatzCents}
+                      bold
+                    />
+                    {produkt.varianten.map((variante) => (
+                      <StatistikZeile
+                        key={variante.varianteId}
+                        label={variante.varianteName}
+                        ausgegebeneMenge={variante.ausgegebeneMenge}
+                        umsatzCents={variante.umsatzCents}
+                        indent
+                      />
+                    ))}
+                  </>
+                )}
+              </Fragment>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/admin/reporting/types.ts
+++ b/frontend/src/admin/reporting/types.ts
@@ -62,6 +62,28 @@ export const UmsatzSteuersatzSchema = z.object({
 })
 export type UmsatzSteuersatz = z.infer<typeof UmsatzSteuersatzSchema>
 
+// VarianteStatistik: Verkaufs-Kennzahl einer Variante — ausgegebene Menge
+// (Produktion) und Umsatz (Einnahmen), bewusst getrennte Grundlagen.
+export const VarianteStatistikSchema = z.object({
+  varianteId: z.number().int(),
+  varianteName: z.string(),
+  ausgegebeneMenge: z.number().int(),
+  umsatzCents: z.number().int(),
+})
+export type VarianteStatistik = z.infer<typeof VarianteStatistikSchema>
+
+// ProduktStatistik: ein Produkt mit Zwischensumme über seine Varianten,
+// eingeordnet in eine Kategorie (essen/getraenk/sonstiges). Vom Backend fertig
+// gruppiert und sortiert geliefert; Ein-Varianten-Produkte tragen eine Variante.
+export const ProduktStatistikSchema = z.object({
+  kategorie: z.string(),
+  produktName: z.string(),
+  ausgegebeneMenge: z.number().int(),
+  umsatzCents: z.number().int(),
+  varianten: z.array(VarianteStatistikSchema),
+})
+export type ProduktStatistik = z.infer<typeof ProduktStatistikSchema>
+
 // AbgeschlosseneSitzung ist ein Eintrag der Kassenberichte-Sitzungsliste: die
 // abgeschlossene Kassensitzung mit Gesamtumsatz und Abschlusszeitpunkt aus dem
 // Tagesabschluss-Event. Status entfällt (alle Einträge sind abgeschlossen).
@@ -126,6 +148,7 @@ export const LiveReportingDataSchema = z.object({
     stornierungenProServicekraft: z.array(StornierungServicekraftSchema),
   }),
   stornierungen: z.array(StornierungDetailSchema),
+  produktStatistik: z.array(ProduktStatistikSchema),
 })
 export type LiveReportingData = z.infer<typeof LiveReportingDataSchema>
 
@@ -139,5 +162,6 @@ export const ReportingDataSchema = z.object({
   }),
   umsatzProSteuersatz: z.array(UmsatzSteuersatzSchema),
   stornierungen: z.array(StornierungDetailSchema),
+  produktStatistik: z.array(ProduktStatistikSchema),
 })
 export type ReportingData = z.infer<typeof ReportingDataSchema>


### PR DESCRIPTION
Implements **R-05**: per-Kassensitzung sales broken down by product and variant, shown in both the Tagesabrechnung (`get-abrechnung`) and the Live-Dashboard (`get-live-reporting`) via a new `produktStatistik` response field.

## What

Each row carries two deliberately separate figures (different bases, not convertible into each other):

- **Ausgegebene Menge** (production): Bestellung − Korrektur + Direktverkauf
- **Umsatz** (revenue): Kassiert + Direktverkauf − Warenrücknahme/Storno

Grouped into category sections (Essen → Getränke → Sonstiges), each product with a subtotal over its variants; single-variant products collapse to one row; sorted by quantity descending (name as stable tiebreaker). `bestellung-umgebucht` is not counted.

## Backend

- New **additive** sqlc query `GetProduktStatistik` unfolds the frozen fat-event positions (`jsonb_array_elements`) into flat variant rows, with the quantity/revenue sign logic inline. No new event, no migration, no Stammdaten join (Reporting-ACL preserved).
- Dedicated repo method `GetProduktStatistik` maps rows → `[]ProduktStatistikZeile`; the pure application-layer function `gruppiereProduktStatistik` groups/sorts them and feeds **both** `GetReporting` and `GetLiveReporting` (no duplicate logic).
- New domain read-model types `ProduktStatistikZeile` / `VarianteStatistik` / `ProduktStatistik` (no json tags); HTTP DTOs + `produktStatistik` field on both responses.
- The Umsatz figure uses the **same** `WHERE type IN (…)`/sign basis as `GetUmsatzPositionszeilen`; a repo integration test guards the invariant `Σ produkt-umsatz == Σ positionszeilen-brutto` so the two can't drift.

## Frontend

- Zod schemas `VarianteStatistikSchema` / `ProduktStatistikSchema` wired into both `ReportingDataSchema` and `LiveReportingDataSchema`.
- Shared `VerkaufStatistik` component (category headings, subtotals, `Ausgegeben`/`Umsatz` columns, explanatory hint, empty state) rendered in both `ReportingResults.tsx` and `LiveReportingSection.tsx`.

## Docs

R-05 moved from the roadmap into the Reporting-Funktionsumfang; `handbuch.md` §7.2 and `language.md` updated.

## Tests / checks

`make check` green (backend unit + frontend lint/test/build); reporting-repo integration tests green (real Postgres), including the consistency invariant and an Umbuchung-doesn't-count case; new grouping unit tests and frontend component tests. The change was additionally run through an adversarial multi-lens review (correctness / plan-adherence / frontend); the two confirmed minor findings (reuse the canonical `formatPositionName` helper; fix a stale R-05 roadmap reference in `offene-punkte.md`) are applied.