### PR TITLE
feat(service): responsive split-screen service layout (ADR 08)

### DIFF
--- a/docs/adrs/08_service-split-screen.md
+++ b/docs/adrs/08_service-split-screen.md
@@ -88,5 +88,16 @@ freeze-konform (nur Frontend).
 - Das Motion-Inventar und die Typografie aus dem Spektral-Redesign (ADR 06)
   gelten in der zweispaltigen Ansicht unverändert weiter; die Layout-Änderung
   führt keine neuen Motion- oder Farb-Entscheidungen ein.
+- **Eingabe-State ist vorgangs-, nicht container-gebunden.** Die extrahierten
+  Abschluss-Komponenten sind dauerhaft gemountet (in der Spalte ohnehin, im Sheet
+  als Kind des Drawers), und Erhalten/Zielbetrag/Kommentar werden je logischem
+  Vorgang zurückgesetzt (Beginn aus dem Leerzustand bzw. nach erfolgreichem
+  Abschluss), nicht beim Schließen des Drawers. Ein bewusster, vereinheitlichter
+  Bruch mit dem alten Handy-Drawer, der Erhalten/Zielbetrag beim Schließen leerte:
+  Ein Schließen ohne Auswahländerung beendet den Vorgang nicht, die Eingaben
+  bleiben also erhalten (Handy und Spalte verhalten sich gleich). Kein
+  Geld-/Nutzlast-Effekt — Erhalten/Zielbetrag steuern nur die sichtbare Rückgeld-/
+  Trinkgeld-Berechnung und gehen nie an das Backend; die Felder sind kontrolliert,
+  Angezeigtes und Berechnetes stimmen immer überein.
 - Eine Rückkehr zum durchgängig einspaltigen Service-Bereich bräuchte ein neues
   ADR.

--- a/docs/adrs/08_service-split-screen.md
+++ b/docs/adrs/08_service-split-screen.md
@@ -1,0 +1,92 @@
+# ADR 08: Zweispaltiges Service-Layout ab `lg` mit responsiver Drawer-Präsentation
+
+- **Status:** akzeptiert (2026-07-15)
+- **Kontext-Dokumente:** `docs/prds/prd-service-split-screen-tablet.md`;
+  `docs/plans/plan-service-split-screen.md`; ADR 03 (Drawer-Layoutvertrag),
+  ADR 07 (Desktop-Schwelle `lg`)
+
+## Kontext
+
+Der Service-Bereich (`/service/*`) war durchgängig mobile-first einspaltig:
+Die Auswahl (Produktliste, offene Positionen, Historie) füllt eine schmale
+Spalte, der jeweilige Abschluss (Warenkorb, Zahlung, Storno, Umbuchung) steckt
+in einem Bottom-Sheet-Drawer, den ein fixierter Dock-Aktionsbutton öffnet.
+Dieses Layout galt auf allen Viewports.
+
+Auf den BYOD-Smartphones der Servicekräfte ist das richtig. Sobald jotti aber
+auf einem stationären Kassengerät läuft (Tablet, Laptop, Surface im Pavillon),
+bleibt die Bildschirmbreite ungenutzt, und jeder Kassiervorgang kostet einen
+zusätzlichen Tipp, um den Warenkorb-Drawer zu öffnen. Ein Verein hat für genau
+dieses Szenario außerhalb von jotti ein zweispaltiges Thekenkassen-Frontend
+gebaut und als deutlich angenehmer erlebt — belegter Bedarf.
+
+Damit stand die implizite Festlegung „der Service-Bereich ist durchgängig
+einspaltig" für große Bildschirme zur Disposition. Zugleich sollte der bindende
+Bottom-Sheet-Layoutvertrag aus ADR 03 (installierte iOS-PWA, nur Handy-Breiten)
+unangetastet bleiben.
+
+## Entscheidung
+
+Der Service-Bereich wird ab der bestehenden Desktop-Schwelle `lg` (1024px,
+ADR 07) responsiv zweispaltig; darunter bleibt alles unverändert.
+
+- **Drei Zusammenstellungs-Flächen erhalten eine dauerhaft sichtbare
+  Abschluss-Spalte:** Direktverkauf-Verkaufen, Tisch-Bestellen, Tisch-Kassieren.
+  Links die Auswahl, rechts der Abschluss-Inhalt (Belegvorschau, Eingaben,
+  primärer Button). Die fixierte Dock-Leiste und ihr Portal-Aktions-Slot sind
+  damit eine reine Handy-Darstellung; die Reiter liegen ab `lg` oben im
+  Inhaltsbereich.
+- **Reine Listen behalten volle Breite:** Historie und Tischauswahl bekommen
+  keine Abschluss-Spalte, sondern behalten ihre vorhandenen Rasterlayouts.
+- **Eine Quelle je Abschluss-Inhalt.** Der heutige Drawer-Body samt Footer jeder
+  Fläche wird als eine darstellungsneutrale Abschluss-Inhaltskomponente
+  extrahiert (Beleg, Eingaben, Betragsberechnung, primärer Button, Submit-/
+  Fehler-/Retry-Verhalten, Idempotenz-Schlüssel-Lebenszyklus). Diese eine
+  Komponente rendert sowohl im Bottom-Sheet-Drawer (schmal) als auch in der
+  festen Spalte (breit); die Varianten unterscheiden sich nur im umschließenden
+  Container. Kein zweites Layout- oder Drawer-System.
+- **Container-Wahl per `useIsMobile()`, nicht per CSS-Sichtbarkeit.** Der
+  JS-Breakpoint entscheidet, welcher Container mountet, damit der
+  Abschluss-Inhalt genau einmal existiert — eine State-Quelle, ein
+  Idempotenz-Schlüssel — und nicht zwei parallel gemountete Bäume doppelten
+  Zustand führen.
+- **Idempotenz-Schlüssel je logischem Vorgang** (Direktverkauf `verkaufId`,
+  Bestellen `bestellungId`): neu, sobald eine Zusammenstellung aus dem
+  Leerzustand beginnt, und erneut nach jedem erfolgreichen Abschluss beim
+  Zurücksetzen; über einen Retry stabil. Tisch-Kassieren trägt bewusst **keinen**
+  Client-Schlüssel (`ZahlungKassierenSchema` hat keinen); die Idempotenz bleibt
+  dort zustandsbasiert, und der `useActionSubmit`-Loading-Guard verhindert den
+  Doppel-Submit wie zuvor.
+- **Korrekturvorgänge als zentrierter Dialog ab `lg`.** Die zeilengebundenen
+  Overlays (Stornieren und Umbuchen aus der Tisch-Historie, Storno aus der
+  Direktverkauf-Historie) bleiben auf dem einen Drawer-Primitive (ADR 03),
+  erhalten aber eine responsive Präsentation: Bottom-Sheet unterhalb `lg`,
+  mittig zentrierter Modal-Dialog ab `lg`. Umgesetzt als responsive Variante im
+  `DrawerContent` — kein Fork der Primitive.
+- **Der ADR-03-Handy-Vertrag gilt unter `lg` wörtlich weiter** (85dvh,
+  Safe-Area, ein Scrollbereich, kein Drag-Handle). Die installierte iOS-PWA läuft
+  nur auf Handy-Breiten und ist von der Dialog-Darstellung nicht betroffen.
+
+Reiner Präsentations-Layer: kein Backend, keine Endpunkte, keine Event-Formate,
+keine Validierung, Idempotenz oder Steuer-/TSE-Logik ändern sich. Damit
+freeze-konform (nur Frontend).
+
+## Konsequenzen
+
+- Auf großen Bildschirmen fährt in keiner Service-Fläche mehr ein Sheet vom
+  unteren Rand herein; die Abschluss-Spalte macht den Warenkorb ohne
+  Zwischenschritt sichtbar.
+- Die sicherheits- und geldrelevanten Kassen-Oberflächen werden umgebaut. Die
+  darstellungsneutrale Extraktion muss verhaltensgleich zum heutigen Drawer sein;
+  die bestehenden Verhaltenstests ziehen auf die extrahierten Komponenten um
+  bzw. laufen unverändert weiter (sie matchen auf Texte und Bedienelemente, nicht
+  auf den Container).
+- Zweispaltige Darstellung und Breakpoint-Verhalten sind manuelle Abnahme
+  (schmal, Querformat-Tablet, Laptop; Hell/Dunkel), analog zur Spektral-Abnahme
+  (ADR 06). Automatisierte Tests prüfen externes Verhalten, nicht welcher
+  Container rendert; keine Snapshot-Tests.
+- Das Motion-Inventar und die Typografie aus dem Spektral-Redesign (ADR 06)
+  gelten in der zweispaltigen Ansicht unverändert weiter; die Layout-Änderung
+  führt keine neuen Motion- oder Farb-Entscheidungen ein.
+- Eine Rückkehr zum durchgängig einspaltigen Service-Bereich bräuchte ein neues
+  ADR.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -21,3 +21,4 @@ Entscheidung, Konsequenzen).
 | 05  | [Spektral-Branding auf der Website](05_spektral-branding-website.md) | akzeptiert |
 | 06  | [Spektral-Branding im App-Frontend](06_spektral-branding-app.md) | akzeptiert |
 | 07  | [Einheitliche Desktop-Schwelle bei lg (1024px)](07_desktop-breakpoint-lg.md) | akzeptiert |
+| 08  | [Zweispaltiges Service-Layout ab lg](08_service-split-screen.md) | akzeptiert |

--- a/docs/plans/plan-service-split-screen.md
+++ b/docs/plans/plan-service-split-screen.md
@@ -240,17 +240,17 @@ in der Spalte. Leerzustand und Idempotenz-Lebenszyklus analog Phase 1.
 
 ### Acceptance criteria
 
-- [ ] Ab 1024px zeigt der Reiter „Bestellen" die Produktliste links und die
+- [x] Ab 1024px zeigt der Reiter „Bestellen" die Produktliste links und die
       entstehende Bestellung rechts dauerhaft nebeneinander; kein Drawer, keine
       fixierte Dock-Leiste auf dieser Breite.
-- [ ] Unterhalb 1024px ist der Reiter „Bestellen" unverändert.
-- [ ] Abschluss-Inhalt aus einer Komponente in beiden Containern; Leerzustand mit
+- [x] Unterhalb 1024px ist der Reiter „Bestellen" unverändert.
+- [x] Abschluss-Inhalt aus einer Komponente in beiden Containern; Leerzustand mit
       Hinweistext plus deaktiviertem Button.
-- [ ] `bestellungId` bleibt über Retry stabil und wechselt bei neuem logischem
+- [x] `bestellungId` bleibt über Retry stabil und wechselt bei neuem logischem
       Vorgang.
-- [ ] Beim Abschluss wird `bestellungAufnehmen` genau einmal mit der erwarteten
+- [x] Beim Abschluss wird `bestellungAufnehmen` genau einmal mit der erwarteten
       Nutzlast aufgerufen; Erfolgs-Pop verhält sich wie zuvor.
-- [ ] Bestehende Bestellen-Verhaltenstests grün; `make check` grün.
+- [x] Bestehende Bestellen-Verhaltenstests grün; `make check` grün.
 
 ---
 
@@ -283,21 +283,21 @@ erfolgreicher Zahlung nur den lokalen Eingabe-State zurück; der
 
 ### Acceptance criteria
 
-- [ ] Ab 1024px zeigt der Reiter „Kassieren" die offenen Positionen links und die
+- [x] Ab 1024px zeigt der Reiter „Kassieren" die offenen Positionen links und die
       Zahlungsübersicht (Erhalten, Zielbetrag/Trinkgeld, Rückgeld, Restbetrag)
       rechts dauerhaft nebeneinander; kein Drawer, keine fixierte Dock-Leiste.
-- [ ] Die Restbetrag-Zeile ist ab `lg` in der Abschluss-Spalte sichtbar (nicht im
+- [x] Die Restbetrag-Zeile ist ab `lg` in der Abschluss-Spalte sichtbar (nicht im
       Dock-Slot).
-- [ ] Unterhalb 1024px ist der Reiter „Kassieren" unverändert, inklusive der
+- [x] Unterhalb 1024px ist der Reiter „Kassieren" unverändert, inklusive der
       Restbetrag-Zeile im Dock-Slot.
-- [ ] Abschluss-Inhalt aus einer Komponente in beiden Containern; Leerzustand mit
+- [x] Abschluss-Inhalt aus einer Komponente in beiden Containern; Leerzustand mit
       Hinweistext plus deaktiviertem Button.
-- [ ] Rückgeld- und Trinkgeld-Berechnung sind in der breiten Ansicht identisch zur
+- [x] Rückgeld- und Trinkgeld-Berechnung sind in der breiten Ansicht identisch zur
       schmalen.
-- [ ] Beim Abschluss wird `zahlungKassieren` genau einmal mit der erwarteten
+- [x] Beim Abschluss wird `zahlungKassieren` genau einmal mit der erwarteten
       Nutzlast (ohne zusätzlichen Schlüssel) aufgerufen; ein Doppelklick löst
       keinen zweiten Aufruf aus.
-- [ ] Bestehende Kassieren-Verhaltenstests grün; `make check` grün.
+- [x] Bestehende Kassieren-Verhaltenstests grün; `make check` grün.
 
 ---
 
@@ -326,14 +326,14 @@ Fachliches Verhalten (Validierung, Idempotenz, Fehler) bleibt unberührt.
 
 ### Acceptance criteria
 
-- [ ] Ab 1024px erscheinen Stornieren und Umbuchen (Tisch) sowie der
+- [x] Ab 1024px erscheinen Stornieren und Umbuchen (Tisch) sowie der
       Direktverkauf-Storno als mittig zentrierter Dialog; unterhalb 1024px
       unverändert als Bottom-Sheet.
-- [ ] Der ADR-03-Handy-Vertrag (85dvh, Safe-Area, ein Scrollbereich, kein
+- [x] Der ADR-03-Handy-Vertrag (85dvh, Safe-Area, ein Scrollbereich, kein
       Drag-Handle) gilt unter `lg` wörtlich weiter; die installierte iOS-PWA
       (nur Handy-Breiten) ist nicht betroffen.
-- [ ] Es bleibt ein Drawer-System (kein Fork der Primitive, kein Parallelsystem).
-- [ ] Auf großen Bildschirmen fährt in keiner Service-Fläche mehr ein Sheet vom
+- [x] Es bleibt ein Drawer-System (kein Fork der Primitive, kein Parallelsystem).
+- [x] Auf großen Bildschirmen fährt in keiner Service-Fläche mehr ein Sheet vom
       unteren Rand herein.
-- [ ] Fachliches Verhalten der Korrekturvorgänge unverändert; bestehende Tests
+- [x] Fachliches Verhalten der Korrekturvorgänge unverändert; bestehende Tests
       grün; `make check` grün.

--- a/docs/plans/plan-service-split-screen.md
+++ b/docs/plans/plan-service-split-screen.md
@@ -194,24 +194,24 @@ Die tragende Scheibe: die responsive Service-Shell **und** die erste Fläche
 
 ### Acceptance criteria
 
-- [ ] Ab 1024px zeigt Direktverkauf-Verkaufen Produkte links und den Warenkorb
+- [x] Ab 1024px zeigt Direktverkauf-Verkaufen Produkte links und den Warenkorb
       (Receipt, Erhalten/Rückgeld, Kommentar, „Verkauf abschließen") rechts
       dauerhaft nebeneinander; kein Bottom-Sheet-Drawer und keine fixierte
-      Dock-Leiste erscheinen auf dieser Breite.
-- [ ] Unterhalb 1024px ist Direktverkauf-Verkaufen unverändert (einspaltig,
+      Dock-Leiste erscheinen auf dieser Breite. _(Sichtabnahme manuell)_
+- [x] Unterhalb 1024px ist Direktverkauf-Verkaufen unverändert (einspaltig,
       fixierte Dock-Leiste, Bottom-Sheet-Drawer).
-- [ ] Der Abschluss-Inhalt stammt aus **einer** Komponente, die in beiden
+- [x] Der Abschluss-Inhalt stammt aus **einer** Komponente, die in beiden
       Containern gerendert wird (kein dupliziertes Markup, keine zweite
       State-Quelle).
-- [ ] Leerzustand der Abschluss-Spalte: Hinweistext plus deaktivierter Button.
-- [ ] `verkaufId` bleibt über einen Retry stabil und wechselt bei einem neuen
+- [x] Leerzustand der Abschluss-Spalte: Hinweistext plus deaktivierter Button.
+- [x] `verkaufId` bleibt über einen Retry stabil und wechselt bei einem neuen
       logischen Vorgang (aus Leerzustand bzw. nach erfolgreichem Abschluss).
-- [ ] Beim Abschluss wird `direktverkaufTaetigen` genau einmal mit der
+- [x] Beim Abschluss wird `direktverkaufTaetigen` genau einmal mit der
       erwarteten Nutzlast aufgerufen; Erfolgs-Pop und Betragsberechnung
       verhalten sich wie zuvor.
-- [ ] Die bestehenden Direktverkauf-Verhaltenstests laufen (ggf. auf die
+- [x] Die bestehenden Direktverkauf-Verhaltenstests laufen (ggf. auf die
       extrahierte Komponente umgezogen) grün; keine Snapshot-Tests.
-- [ ] `docs/adrs/08_service-split-screen.md` existiert, ist in
+- [x] `docs/adrs/08_service-split-screen.md` existiert, ist in
       `docs/adrs/README.md` verlinkt, und `make check` ist grün.
 
 ---

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -1,7 +1,13 @@
 // Bottom-Sheet auf Radix Dialog — bewusst ohne vaul, dessen Scroll-Lock das
 // Layout der installierten iOS-PWA bricht (Praxistest 09.07.2026, vaul#505).
-// Der Layout-Vertrag (85dvh statt vh, Safe-Area-Padding, ein Scrollbereich,
-// kein Drag-Handle) ist bindend: docs/adrs/03_drawer-radix-statt-vaul.md
+// Der Handy-Layout-Vertrag (85dvh statt vh, Safe-Area-Padding, ein Scrollbereich,
+// kein Drag-Handle) ist unter lg bindend: docs/adrs/03_drawer-radix-statt-vaul.md
+//
+// Responsive Präsentation (ADR 08, docs/adrs/08_service-split-screen.md): unter
+// lg unverändert Bottom-Sheet, ab lg mittig zentrierter Modal-Dialog (analog
+// dialog.tsx). Ein Drawer-System, kein Fork — die Umschaltung ist reines CSS
+// über lg:-Overrides in DrawerContent. Die installierte iOS-PWA läuft nur auf
+// Handy-Breiten und bleibt damit ausschließlich im Bottom-Sheet.
 import * as React from 'react'
 import { Dialog as DrawerPrimitive } from 'radix-ui'
 
@@ -84,7 +90,10 @@ function DrawerContent({
           onInteractOutside?.(event)
         }}
         className={cn(
-          'group/drawer-content fixed inset-x-0 bottom-0 z-50 flex max-h-[85dvh] flex-col rounded-t-xl border-t bg-popover pb-[env(safe-area-inset-bottom,0px)] text-sm text-popover-foreground duration-200 data-open:animate-in data-open:fade-in-0 data-open:slide-in-from-bottom-10 data-closed:animate-out data-closed:fade-out-0 data-closed:slide-out-to-bottom-10',
+          // Unter lg: Bottom-Sheet (ADR 03). Ab lg: mittig zentrierter Dialog
+          // (ADR 08) — die lg:-Overrides heben die Bodenverankerung auf, zentrieren
+          // und tauschen die Einfahr-Animation gegen ein Zoom (wie dialog.tsx).
+          'group/drawer-content fixed inset-x-0 bottom-0 z-50 flex max-h-[85dvh] flex-col rounded-t-xl border-t bg-popover pb-[env(safe-area-inset-bottom,0px)] text-sm text-popover-foreground duration-200 data-open:animate-in data-open:fade-in-0 data-open:slide-in-from-bottom-10 data-closed:animate-out data-closed:fade-out-0 data-closed:slide-out-to-bottom-10 lg:inset-x-auto lg:bottom-auto lg:top-1/2 lg:left-1/2 lg:w-full lg:max-w-md lg:-translate-x-1/2 lg:-translate-y-1/2 lg:rounded-xl lg:border lg:pb-0 lg:ring-1 lg:ring-foreground/10 lg:data-open:slide-in-from-bottom-0 lg:data-open:zoom-in-95 lg:data-closed:slide-out-to-bottom-0 lg:data-closed:zoom-out-95',
           className,
         )}
         {...props}

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -93,7 +93,7 @@ function DrawerContent({
           // Unter lg: Bottom-Sheet (ADR 03). Ab lg: mittig zentrierter Dialog
           // (ADR 08) — die lg:-Overrides heben die Bodenverankerung auf, zentrieren
           // und tauschen die Einfahr-Animation gegen ein Zoom (wie dialog.tsx).
-          'group/drawer-content fixed inset-x-0 bottom-0 z-50 flex max-h-[85dvh] flex-col rounded-t-xl border-t bg-popover pb-[env(safe-area-inset-bottom,0px)] text-sm text-popover-foreground duration-200 data-open:animate-in data-open:fade-in-0 data-open:slide-in-from-bottom-10 data-closed:animate-out data-closed:fade-out-0 data-closed:slide-out-to-bottom-10 lg:inset-x-auto lg:bottom-auto lg:top-1/2 lg:left-1/2 lg:w-full lg:max-w-md lg:-translate-x-1/2 lg:-translate-y-1/2 lg:rounded-xl lg:border lg:pb-0 lg:ring-1 lg:ring-foreground/10 lg:data-open:slide-in-from-bottom-0 lg:data-open:zoom-in-95 lg:data-closed:slide-out-to-bottom-0 lg:data-closed:zoom-out-95',
+          'group/drawer-content fixed inset-x-0 bottom-0 z-50 flex max-h-[85dvh] flex-col rounded-t-xl border-t bg-popover pb-[env(safe-area-inset-bottom,0px)] text-sm text-popover-foreground duration-200 data-open:animate-in data-open:fade-in-0 data-open:slide-in-from-bottom-10 data-closed:animate-out data-closed:fade-out-0 data-closed:slide-out-to-bottom-10 lg:inset-x-auto lg:bottom-auto lg:top-1/2 lg:left-1/2 lg:w-full lg:max-w-md lg:-translate-x-1/2 lg:-translate-y-1/2 lg:rounded-xl lg:border-t-0 lg:pb-0 lg:ring-1 lg:ring-foreground/10 lg:duration-100 lg:data-open:slide-in-from-bottom-0 lg:data-open:zoom-in-95 lg:data-closed:slide-out-to-bottom-0 lg:data-closed:zoom-out-95',
           className,
         )}
         {...props}

--- a/frontend/src/service/DirektverkaufPage.tsx
+++ b/frontend/src/service/DirektverkaufPage.tsx
@@ -83,11 +83,21 @@ export function DirektverkaufPage() {
             </TabsContent>
           </ServiceDock>
         ) : (
-          <>
+          // Höhenbegrenzte Flex-Spalte (Viewport minus Header und Content-
+          // Padding aus ServiceLayout); die Reiter-Höhe ergibt sich per Flex,
+          // der Split füllt via h-full den Rest und scrollt in seinen Spalten.
+          <div className="flex h-[calc(100dvh-5.5rem)] flex-col xl:h-[calc(100dvh-6.5rem)]">
             <div className="mb-4 max-w-md">{tabTrigger}</div>
-            <TabsContent value="verkaufen">{verkaufenInhalt}</TabsContent>
-            <TabsContent value="historie">{historieInhalt}</TabsContent>
-          </>
+            <TabsContent value="verkaufen" className="min-h-0 flex-1">
+              {verkaufenInhalt}
+            </TabsContent>
+            <TabsContent
+              value="historie"
+              className="min-h-0 flex-1 overflow-y-auto"
+            >
+              {historieInhalt}
+            </TabsContent>
+          </div>
         )}
       </Tabs>
       <ErfolgsPop

--- a/frontend/src/service/DirektverkaufPage.tsx
+++ b/frontend/src/service/DirektverkaufPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { BackendSingleton } from '@/lib/Backend'
 
 import { Direktverkauf } from './components/direktverkauf/Direktverkauf'
@@ -15,10 +16,11 @@ const direktverkaufBackend = new DirektverkaufBackend(BackendSingleton)
 
 // Unterer Freiraum der Tab-Inhalte in Dock-Höhe (Aktionsbutton plus TabsList
 // plus Innenabstände), damit die letzte Zeile über dem fixierten ServiceDock
-// endet und antippbar bleibt.
+// endet und antippbar bleibt. Nur im Handy-Layout (unter lg) relevant.
 const dockFreiraum = 'pb-[calc(9rem+env(safe-area-inset-bottom,0px))]'
 
 export function DirektverkaufPage() {
+  const isMobile = useIsMobile()
   const { produkte, isPending } = useAktiveProdukte()
   const {
     historie,
@@ -38,40 +40,55 @@ export function DirektverkaufPage() {
     void reloadHistorie()
   }, [reloadHistorie])
 
+  const tabTrigger = (
+    <TabsList className="h-10 w-full">
+      <TabsTrigger value="verkaufen" className="flex-1">
+        Verkaufen
+      </TabsTrigger>
+      <TabsTrigger value="historie" className="flex-1">
+        Historie
+      </TabsTrigger>
+    </TabsList>
+  )
+
+  const verkaufenInhalt = (
+    <Direktverkauf
+      backend={direktverkaufBackend}
+      products={produkte}
+      productsLoading={isPending}
+      onErfolg={zeigeErfolg}
+    />
+  )
+  const historieInhalt = (
+    <DirektverkaufHistorie
+      historie={historie}
+      historieLoading={historieLoading}
+      backend={direktverkaufBackend}
+      onStorniert={() => {
+        void reloadHistorie()
+      }}
+    />
+  )
+
   return (
     <>
       <Tabs defaultValue="verkaufen">
-        <ServiceDock
-          leiste={
-            <TabsList className="h-10 w-full">
-              <TabsTrigger value="verkaufen" className="flex-1">
-                Verkaufen
-              </TabsTrigger>
-              <TabsTrigger value="historie" className="flex-1">
-                Historie
-              </TabsTrigger>
-            </TabsList>
-          }
-        >
-          <TabsContent value="verkaufen" className={dockFreiraum}>
-            <Direktverkauf
-              backend={direktverkaufBackend}
-              products={produkte}
-              productsLoading={isPending}
-              onErfolg={zeigeErfolg}
-            />
-          </TabsContent>
-          <TabsContent value="historie" className={dockFreiraum}>
-            <DirektverkaufHistorie
-              historie={historie}
-              historieLoading={historieLoading}
-              backend={direktverkaufBackend}
-              onStorniert={() => {
-                void reloadHistorie()
-              }}
-            />
-          </TabsContent>
-        </ServiceDock>
+        {isMobile ? (
+          <ServiceDock leiste={tabTrigger}>
+            <TabsContent value="verkaufen" className={dockFreiraum}>
+              {verkaufenInhalt}
+            </TabsContent>
+            <TabsContent value="historie" className={dockFreiraum}>
+              {historieInhalt}
+            </TabsContent>
+          </ServiceDock>
+        ) : (
+          <>
+            <div className="mb-4 max-w-md">{tabTrigger}</div>
+            <TabsContent value="verkaufen">{verkaufenInhalt}</TabsContent>
+            <TabsContent value="historie">{historieInhalt}</TabsContent>
+          </>
+        )}
       </Tabs>
       <ErfolgsPop
         open={erfolg.open}

--- a/frontend/src/service/TablePage.test.tsx
+++ b/frontend/src/service/TablePage.test.tsx
@@ -30,6 +30,13 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
+// Diese Suite prüft Kopfbereich und Fehlerzustand (identisch in beiden
+// Layouts). Auf dem Handy-Pfad trägt nur der Kopf den Tischnamen; ab lg zeigt
+// ihn zusätzlich die Abschluss-Spalte — der Split selbst ist manuelle Abnahme.
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => true,
+}))
+
 vi.mock('@/lib/Backend', () => ({
   BackendSingleton: {},
 }))

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useCountUp } from '@/hooks/use-count-up'
 import { useErstAufbau } from '@/hooks/use-erst-aufbau'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { BackendSingleton } from '@/lib/Backend'
 import { formatCents } from '@/lib/utils'
 
@@ -56,12 +57,12 @@ function StatusBadgeInhalt({
 }
 
 // Unterer Freiraum des Tab-Inhalts in Dock-Höhe, damit die letzte Listenzeile
-// über dem fixierten ServiceDock endet und antippbar bleibt. Das Dock ist der
-// Aktionsbutton (3.5rem) plus TabsList (2.5rem) plus Innenabstände; der Freiraum
-// wächst mit env(safe-area-inset-bottom) mit.
+// über dem fixierten ServiceDock endet und antippbar bleibt. Nur im Handy-Layout
+// (unter lg) relevant; ab lg trägt die Spalte den Button selbst.
 const dockFreiraum = 'pb-[calc(9rem+env(safe-area-inset-bottom,0px))]'
 
 export function TablePage() {
+  const isMobile = useIsMobile()
   const { tischId } = useParams<{ tischId: string }>()
   const {
     state,
@@ -119,106 +120,139 @@ export function TablePage() {
   const tabsLocked = stateLoading || historieLoading
   const anzahlUnbezahlt = state.unbezahltePositionen.length
 
-  return (
-    <>
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="font-heading text-[22px] font-semibold leading-tight">
-            {stateLoading ? 'Tisch ??' : tisch.name}
-          </h1>
-          {!stateLoading && (
-            <div className="mt-1.5 flex flex-wrap items-center gap-2">
-              <TischStatusBadge anzahlUnbezahlt={anzahlUnbezahlt} />
-              <span className="text-sm text-muted-foreground">
-                {state.fuerMichErledigt
-                  ? 'Für dich erledigt'
-                  : 'Für dich noch offen'}
-              </span>
-            </div>
-          )}
+  const kopf = (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <h1 className="font-heading text-[22px] font-semibold leading-tight">
+          {stateLoading ? 'Tisch ??' : tisch.name}
+        </h1>
+        {!stateLoading && (
+          <div className="mt-1.5 flex flex-wrap items-center gap-2">
+            <TischStatusBadge anzahlUnbezahlt={anzahlUnbezahlt} />
+            <span className="text-sm text-muted-foreground">
+              {state.fuerMichErledigt
+                ? 'Für dich erledigt'
+                : 'Für dich noch offen'}
+            </span>
+          </div>
+        )}
+      </div>
+      <div className="text-right">
+        <div className="text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground">
+          Offen
         </div>
-        <div className="text-right">
-          <div className="text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground">
-            Offen
-          </div>
-          <div
-            data-slot="tisch-saldo"
-            className="text-xl font-bold tabular-nums"
-          >
-            {stateLoading ? '?' : <>{formatCents(animierterSaldo)}&nbsp;€</>}
-          </div>
+        <div data-slot="tisch-saldo" className="text-xl font-bold tabular-nums">
+          {stateLoading ? '?' : <>{formatCents(animierterSaldo)}&nbsp;€</>}
         </div>
       </div>
-      <Tabs defaultValue="order" className="mt-4">
-        <ServiceDock
-          leiste={
-            <>
-              {tabsLocked && (
-                <p className="rounded-md border bg-background/90 px-3 py-1 text-center text-xs text-muted-foreground">
-                  Lade Tischdaten. Tabs sind kurzzeitig deaktiviert.
-                </p>
-              )}
-              <TabsList className="h-10 w-full">
-                <TabsTrigger
-                  value="order"
-                  className="flex-1"
-                  disabled={tabsLocked}
-                >
-                  Bestellen
-                </TabsTrigger>
-                <TabsTrigger
-                  value="payment"
-                  className="flex-1"
-                  disabled={tabsLocked}
-                >
-                  Kassieren
-                </TabsTrigger>
-                <TabsTrigger
-                  value="history"
-                  className="flex-1"
-                  disabled={tabsLocked}
-                >
-                  Historie
-                </TabsTrigger>
-              </TabsList>
-            </>
-          }
+    </div>
+  )
+
+  const tabsLockedHinweis = tabsLocked && (
+    <p className="rounded-md border bg-background/90 px-3 py-1 text-center text-xs text-muted-foreground">
+      Lade Tischdaten. Tabs sind kurzzeitig deaktiviert.
+    </p>
+  )
+
+  const tabsList = (
+    <TabsList className="h-10 w-full">
+      <TabsTrigger value="order" className="flex-1" disabled={tabsLocked}>
+        Bestellen
+      </TabsTrigger>
+      <TabsTrigger value="payment" className="flex-1" disabled={tabsLocked}>
+        Kassieren
+      </TabsTrigger>
+      <TabsTrigger value="history" className="flex-1" disabled={tabsLocked}>
+        Historie
+      </TabsTrigger>
+    </TabsList>
+  )
+
+  const bestellenInhalt = !stateLoading && (
+    <Bestellung
+      backend={tischBackend}
+      tisch={tisch}
+      products={produkte}
+      productsLoading={isPending}
+      onErfolg={zeigeErfolg}
+    />
+  )
+  const kassierenInhalt = !stateLoading && (
+    <Zahlung
+      backend={tischBackend}
+      tisch={tisch}
+      positionen={state.unbezahltePositionen}
+      onErfolg={zeigeErfolg}
+    />
+  )
+  const historieInhalt = !stateLoading && (
+    <TischHistorie
+      historie={historie}
+      historieLoading={historieLoading}
+      tisch={tisch}
+      backend={tischBackend}
+      onStornierungErteilt={reload}
+      onBestellungUmgebucht={reload}
+    />
+  )
+
+  return (
+    <>
+      {isMobile ? (
+        <>
+          {kopf}
+          <Tabs defaultValue="order" className="mt-4">
+            <ServiceDock
+              leiste={
+                <>
+                  {tabsLockedHinweis}
+                  {tabsList}
+                </>
+              }
+            >
+              <TabsContent value="order" className={dockFreiraum}>
+                {bestellenInhalt}
+              </TabsContent>
+              <TabsContent value="payment" className={dockFreiraum}>
+                {kassierenInhalt}
+              </TabsContent>
+              <TabsContent value="history" className={dockFreiraum}>
+                {historieInhalt}
+              </TabsContent>
+            </ServiceDock>
+          </Tabs>
+        </>
+      ) : (
+        // Höhenbegrenzte Flex-Spalte (Viewport minus Header und Content-Padding
+        // aus ServiceLayout); Kopf und Reiter-Zeile ergeben sich per Flex, der
+        // aktive Tab füllt via flex-1 den Rest und scrollt in sich bzw. seinen
+        // Spalten.
+        <Tabs
+          defaultValue="order"
+          className="flex h-[calc(100dvh-5.5rem)] flex-col xl:h-[calc(100dvh-6.5rem)]"
         >
-          <TabsContent value="order" className={dockFreiraum}>
-            {!stateLoading && (
-              <Bestellung
-                backend={tischBackend}
-                tisch={tisch}
-                products={produkte}
-                productsLoading={isPending}
-                onErfolg={zeigeErfolg}
-              />
-            )}
+          {kopf}
+          <div className="mt-4 mb-4 max-w-md space-y-1">
+            {tabsLockedHinweis}
+            {tabsList}
+          </div>
+          <TabsContent value="order" className="min-h-0 flex-1">
+            {bestellenInhalt}
           </TabsContent>
-          <TabsContent value="payment" className={dockFreiraum}>
-            {!stateLoading && (
-              <Zahlung
-                backend={tischBackend}
-                tisch={tisch}
-                positionen={state.unbezahltePositionen}
-                onErfolg={zeigeErfolg}
-              />
-            )}
+          <TabsContent
+            value="payment"
+            className="min-h-0 flex-1 overflow-y-auto"
+          >
+            {kassierenInhalt}
           </TabsContent>
-          <TabsContent value="history" className={dockFreiraum}>
-            {!stateLoading && (
-              <TischHistorie
-                historie={historie}
-                historieLoading={historieLoading}
-                tisch={tisch}
-                backend={tischBackend}
-                onStornierungErteilt={reload}
-                onBestellungUmgebucht={reload}
-              />
-            )}
+          <TabsContent
+            value="history"
+            className="min-h-0 flex-1 overflow-y-auto"
+          >
+            {historieInhalt}
           </TabsContent>
-        </ServiceDock>
-      </Tabs>
+        </Tabs>
+      )}
       <ErfolgsPop
         open={erfolg.open}
         text={erfolg.text}

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -239,10 +239,7 @@ export function TablePage() {
           <TabsContent value="order" className="min-h-0 flex-1">
             {bestellenInhalt}
           </TabsContent>
-          <TabsContent
-            value="payment"
-            className="min-h-0 flex-1 overflow-y-auto"
-          >
+          <TabsContent value="payment" className="min-h-0 flex-1">
             {kassierenInhalt}
           </TabsContent>
           <TabsContent

--- a/frontend/src/service/components/ErfolgsPop.test.tsx
+++ b/frontend/src/service/components/ErfolgsPop.test.tsx
@@ -21,6 +21,12 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
+// Der Buchungsflow-Test unten prüft den Handy-Pfad (Dock-Button plus
+// Bottom-Sheet); ab lg trägt die feste Spalte den Abschluss.
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => true,
+}))
+
 describe('ErfolgsPop', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/frontend/src/service/components/ServiceSplitLayout.tsx
+++ b/frontend/src/service/components/ServiceSplitLayout.tsx
@@ -1,9 +1,10 @@
 // Zweispaltiges Service-Layout ab lg (1024px, ADR 07/08): links die Auswahl,
 // rechts die dauerhaft sichtbare Abschluss-Spalte. Beide Spalten scrollen
-// unabhängig; die Höhe ist an den Viewport gebunden (abzüglich Header und der
-// Reiter-Zeile darüber), damit unter jeder Spalte ein eigener Scrollbereich
-// entsteht statt eines gemeinsamen Seitenscrolls. Nur ab lg gerendert — die
-// aufrufende Fläche entscheidet per useIsMobile, welcher Container mountet.
+// unabhängig. Die Höhe kommt über `h-full` vom höhenbegrenzten Flex-Container
+// der Seite (Viewport minus Header und Reiter-Zeile), statt aus einem fest
+// verdrahteten calc — so bleibt das Layout robust, wenn sich Header oder
+// Reiter-Höhe ändern. Nur ab lg gerendert: die aufrufende Fläche entscheidet
+// per useIsMobile, welcher Container mountet.
 export function ServiceSplitLayout({
   auswahl,
   abschluss,
@@ -14,7 +15,7 @@ export function ServiceSplitLayout({
   abschluss: React.ReactNode
 }) {
   return (
-    <div className="grid h-[calc(100dvh-9rem)] grid-cols-[minmax(0,1fr)_22rem] gap-6 xl:h-[calc(100dvh-10rem)] xl:grid-cols-[minmax(0,1fr)_26rem]">
+    <div className="grid h-full grid-cols-[minmax(0,1fr)_22rem] gap-6 xl:grid-cols-[minmax(0,1fr)_26rem]">
       <div className="min-h-0 overflow-y-auto">{auswahl}</div>
       {abschluss}
     </div>

--- a/frontend/src/service/components/ServiceSplitLayout.tsx
+++ b/frontend/src/service/components/ServiceSplitLayout.tsx
@@ -1,0 +1,22 @@
+// Zweispaltiges Service-Layout ab lg (1024px, ADR 07/08): links die Auswahl,
+// rechts die dauerhaft sichtbare Abschluss-Spalte. Beide Spalten scrollen
+// unabhängig; die Höhe ist an den Viewport gebunden (abzüglich Header und der
+// Reiter-Zeile darüber), damit unter jeder Spalte ein eigener Scrollbereich
+// entsteht statt eines gemeinsamen Seitenscrolls. Nur ab lg gerendert — die
+// aufrufende Fläche entscheidet per useIsMobile, welcher Container mountet.
+export function ServiceSplitLayout({
+  auswahl,
+  abschluss,
+}: {
+  auswahl: React.ReactNode
+  // Die Abschluss-Spalte selbst (ein <aside> aus der jeweiligen
+  // Abschluss-Inhaltskomponente, variant="spalte").
+  abschluss: React.ReactNode
+}) {
+  return (
+    <div className="grid h-[calc(100dvh-9rem)] grid-cols-[minmax(0,1fr)_22rem] gap-6 xl:h-[calc(100dvh-10rem)] xl:grid-cols-[minmax(0,1fr)_26rem]">
+      <div className="min-h-0 overflow-y-auto">{auswahl}</div>
+      {abschluss}
+    </div>
+  )
+}

--- a/frontend/src/service/components/direktverkauf/Direktverkauf.test.tsx
+++ b/frontend/src/service/components/direktverkauf/Direktverkauf.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { useIsMobile } from '@/hooks/use-mobile'
+
 import type { Produkt } from '../../product/Produkt'
 import { ServiceDock } from '../ServiceDock'
 import { Direktverkauf } from './Direktverkauf'
@@ -10,15 +12,16 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
-// Diese Suite prüft das Handy-Layout (Dock-Aktionsbutton plus Bottom-Sheet).
-// Ab lg rendert Direktverkauf stattdessen die feste Abschluss-Spalte; deren
-// Verhalten deckt DirektverkaufAbschluss.test.tsx container-neutral ab.
+// Standardmäßig Handy-Layout (Dock-Aktionsbutton plus Bottom-Sheet); ein Test
+// unten schaltet auf Desktop, um die Verdrahtung der festen Spalte zu prüfen.
+// Das container-neutrale Verhalten der Spalte deckt DirektverkaufAbschluss.test.
 vi.mock('@/hooks/use-mobile', () => ({
-  useIsMobile: () => true,
+  useIsMobile: vi.fn(() => true),
 }))
 
 afterEach(() => {
   cleanup()
+  vi.mocked(useIsMobile).mockReturnValue(true)
 })
 
 const testProdukt: Produkt = {
@@ -102,5 +105,36 @@ describe('Direktverkauf', () => {
       expect(dialog).not.toBeInTheDocument()
     })
     expect(screen.getByRole('button', { name: /Kassieren/ })).toBeDisabled()
+  })
+
+  it('rendert ab lg die feste Abschluss-Spalte statt Dock und Drawer', async () => {
+    vi.mocked(useIsMobile).mockReturnValue(false)
+    const user = userEvent.setup()
+    const direktverkaufTaetigen = vi.fn().mockResolvedValue(undefined)
+    // Kein ServiceDock: die feste Spalte trägt den Aktionsbutton selbst.
+    render(
+      <Direktverkauf
+        backend={{ direktverkaufTaetigen }}
+        products={[testProdukt]}
+        productsLoading={false}
+      />,
+    )
+
+    expect(screen.getByText('Bratwurst')).toBeInTheDocument()
+    // Der Aktionsbutton der Spalte ist ohne Auswahl deaktiviert; es gibt keinen
+    // Dock-„Kassieren"-Button.
+    const button = screen.getByRole('button', { name: 'Verkauf abschließen' })
+    expect(button).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: /Kassieren/ }),
+    ).not.toBeInTheDocument()
+
+    // Auswahl links aktiviert den Button rechts (gemeinsamer Mengen-State).
+    await user.click(
+      screen.getByRole('button', { name: 'Variante hinzufügen' }),
+    )
+    expect(
+      screen.getByRole('button', { name: 'Verkauf abschließen' }),
+    ).toBeEnabled()
   })
 })

--- a/frontend/src/service/components/direktverkauf/Direktverkauf.test.tsx
+++ b/frontend/src/service/components/direktverkauf/Direktverkauf.test.tsx
@@ -10,6 +10,13 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
+// Diese Suite prüft das Handy-Layout (Dock-Aktionsbutton plus Bottom-Sheet).
+// Ab lg rendert Direktverkauf stattdessen die feste Abschluss-Spalte; deren
+// Verhalten deckt DirektverkaufAbschluss.test.tsx container-neutral ab.
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => true,
+}))
+
 afterEach(() => {
   cleanup()
 })

--- a/frontend/src/service/components/direktverkauf/Direktverkauf.tsx
+++ b/frontend/src/service/components/direktverkauf/Direktverkauf.tsx
@@ -1,9 +1,12 @@
 import { useMengen } from '@/hooks/use-mengen'
+import { useIsMobile } from '@/hooks/use-mobile'
 
 import type { DirektverkaufBackend } from '../../direktverkauf/DirektverkaufBackend'
 import type { Produkt } from '../../product/Produkt'
+import { ServiceSplitLayout } from '../ServiceSplitLayout'
 import { calculateTotalPrice, toBestellungData } from '../table/drawerUtils'
 import { ProductList, ProductListSkeleton } from '../table/ProductList'
+import { DirektverkaufAbschluss } from './DirektverkaufAbschluss'
 import { DirektverkaufDrawer } from './DirektverkaufDrawer'
 
 interface DirektverkaufProps {
@@ -21,6 +24,7 @@ export function Direktverkauf({
   productsLoading,
   onErfolg,
 }: DirektverkaufProps) {
+  const isMobile = useIsMobile()
   const { mengen, add, remove, reset } = useMengen<number>()
 
   const { receiptItems, inputItems } = toBestellungData(products, mengen)
@@ -31,6 +35,41 @@ export function Direktverkauf({
     return <ProductListSkeleton />
   }
 
+  const verkaufAbgeschlossen = () => {
+    reset()
+    onErfolg?.('Verkauf abgeschlossen.')
+  }
+
+  const productList = (
+    <ProductList
+      products={products}
+      variantMengen={mengen}
+      onAdd={add}
+      onRemove={remove}
+    />
+  )
+
+  // Ab lg: feste Abschluss-Spalte rechts, Produkte links. Der extrahierte
+  // Abschluss-Inhalt mountet genau einmal (isMobile entscheidet den Zweig).
+  if (!isMobile) {
+    return (
+      <ServiceSplitLayout
+        auswahl={productList}
+        abschluss={
+          <DirektverkaufAbschluss
+            variant="spalte"
+            backend={backend}
+            receiptItems={receiptItems}
+            positionen={inputItems}
+            totalCents={total}
+            verkaufAbgeschlossen={verkaufAbgeschlossen}
+          />
+        }
+      />
+    )
+  }
+
+  // Unter lg: unverändert Dock-Aktionsbutton plus Bottom-Sheet-Drawer.
   return (
     <>
       <DirektverkaufDrawer
@@ -39,17 +78,9 @@ export function Direktverkauf({
         positionen={inputItems}
         anzahl={anzahl}
         totalCents={total}
-        verkaufAbgeschlossen={() => {
-          reset()
-          onErfolg?.('Verkauf abgeschlossen.')
-        }}
+        verkaufAbgeschlossen={verkaufAbgeschlossen}
       />
-      <ProductList
-        products={products}
-        variantMengen={mengen}
-        onAdd={add}
-        onRemove={remove}
-      />
+      {productList}
     </>
   )
 }

--- a/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.test.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.test.tsx
@@ -1,0 +1,158 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { DirektverkaufTaetigen } from '../../direktverkauf/Direktverkauf'
+import type { ReceiptPosition } from '../table/Receipt'
+import { DirektverkaufAbschluss } from './DirektverkaufAbschluss'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+const receiptItems: ReceiptPosition[] = [
+  { name: 'Bratwurst Normal', einzelpreisCents: 350, menge: 2 },
+]
+const positionen = [{ produktId: 1, varianteId: 1, menge: 2 }]
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+// Die feste Spalte (variant="spalte") ist container-neutral testbar: kein
+// Drawer, kein Dock. Sie ist im Leerzustand deaktiviert, rechnet Rückgeld und
+// ruft das Backend genau einmal mit stabilem verkaufId je Vorgang auf.
+function renderSpalte(
+  direktverkaufTaetigen: () => Promise<void> = vi
+    .fn()
+    .mockResolvedValue(undefined),
+) {
+  const verkaufAbgeschlossen = vi.fn()
+  render(
+    <DirektverkaufAbschluss
+      variant="spalte"
+      backend={{ direktverkaufTaetigen }}
+      receiptItems={receiptItems}
+      positionen={positionen}
+      totalCents={700}
+      verkaufAbgeschlossen={verkaufAbgeschlossen}
+    />,
+  )
+  return { direktverkaufTaetigen, verkaufAbgeschlossen }
+}
+
+describe('DirektverkaufAbschluss (Spalte)', () => {
+  it('zeigt im Leerzustand einen Hinweis und deaktiviert den Aktionsbutton', () => {
+    render(
+      <DirektverkaufAbschluss
+        variant="spalte"
+        backend={{ direktverkaufTaetigen: vi.fn() }}
+        receiptItems={[]}
+        positionen={[]}
+        totalCents={0}
+        verkaufAbgeschlossen={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/Produkte auswählen/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Verkauf abschließen' }),
+    ).toBeDisabled()
+  })
+
+  it('rechnet das Rückgeld aus dem erhaltenen Betrag', async () => {
+    const user = userEvent.setup()
+    renderSpalte()
+
+    await user.type(screen.getByLabelText('Erhalten'), '10,00')
+
+    const rueckgeld = screen.getByText('Rückgeld').nextElementSibling
+    expect(rueckgeld).toHaveTextContent('3,00')
+  })
+
+  it('schließt den Verkauf mit genau einem Backend-Call und erwarteter Nutzlast ab', async () => {
+    const user = userEvent.setup()
+    const { direktverkaufTaetigen, verkaufAbgeschlossen } = renderSpalte()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Verkauf abschließen' }),
+    )
+
+    await waitFor(() => {
+      expect(direktverkaufTaetigen).toHaveBeenCalledTimes(1)
+    })
+    expect(direktverkaufTaetigen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        verkaufId: expect.stringMatching(UUID),
+        positionen,
+        kommentar: '',
+      }),
+    )
+    expect(verkaufAbgeschlossen).toHaveBeenCalledTimes(1)
+  })
+
+  it('behält den verkaufId über einen Retry und wechselt ihn beim neuen Vorgang', async () => {
+    const user = userEvent.setup()
+    const direktverkaufTaetigen = vi
+      .fn<(verkauf: DirektverkaufTaetigen) => Promise<void>>()
+      .mockRejectedValueOnce(new Error('kaputt'))
+      .mockResolvedValue(undefined)
+
+    // Testrahmen, der die Auswahl von „gefüllt" nach „leer" (erfolgreicher
+    // Abschluss) und zurück schalten kann, um den Vorgangswechsel zu prüfen.
+    function Harness() {
+      const [leer, setLeer] = useState(false)
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              setLeer((v) => !v)
+            }}
+          >
+            toggle
+          </button>
+          <DirektverkaufAbschluss
+            variant="spalte"
+            backend={{ direktverkaufTaetigen }}
+            receiptItems={leer ? [] : receiptItems}
+            positionen={leer ? [] : positionen}
+            totalCents={leer ? 0 : 700}
+            verkaufAbgeschlossen={vi.fn()}
+          />
+        </>
+      )
+    }
+    render(<Harness />)
+
+    const abschliessen = () =>
+      screen.getByRole('button', { name: 'Verkauf abschließen' })
+
+    // Erster (fehlschlagender) Versuch.
+    await user.click(abschliessen())
+    await waitFor(() => {
+      expect(direktverkaufTaetigen).toHaveBeenCalledTimes(1)
+    })
+    const ersterKey = direktverkaufTaetigen.mock.calls[0][0].verkaufId
+
+    // Retry desselben Vorgangs: gleicher Schlüssel.
+    await user.click(abschliessen())
+    await waitFor(() => {
+      expect(direktverkaufTaetigen).toHaveBeenCalledTimes(2)
+    })
+    expect(direktverkaufTaetigen.mock.calls[1][0].verkaufId).toBe(ersterKey)
+
+    // Neuer logischer Vorgang: Auswahl leeren (Abschluss) und neu füllen.
+    await user.click(screen.getByRole('button', { name: 'toggle' }))
+    await user.click(screen.getByRole('button', { name: 'toggle' }))
+    await user.click(abschliessen())
+    await waitFor(() => {
+      expect(direktverkaufTaetigen).toHaveBeenCalledTimes(3)
+    })
+    expect(direktverkaufTaetigen.mock.calls[2][0].verkaufId).not.toBe(ersterKey)
+  })
+})

--- a/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.test.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.test.tsx
@@ -95,6 +95,47 @@ describe('DirektverkaufAbschluss (Spalte)', () => {
     expect(verkaufAbgeschlossen).toHaveBeenCalledTimes(1)
   })
 
+  it('setzt Erhalten und Kommentar beim neuen Vorgang zurück (kein Übertrag)', async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [leer, setLeer] = useState(false)
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              setLeer((v) => !v)
+            }}
+          >
+            toggle
+          </button>
+          <DirektverkaufAbschluss
+            variant="spalte"
+            backend={{ direktverkaufTaetigen: vi.fn() }}
+            receiptItems={leer ? [] : receiptItems}
+            positionen={leer ? [] : positionen}
+            totalCents={leer ? 0 : 700}
+            verkaufAbgeschlossen={vi.fn()}
+          />
+        </>
+      )
+    }
+    render(<Harness />)
+
+    await user.type(screen.getByLabelText('Erhalten'), '10,00')
+    await user.type(screen.getByPlaceholderText(/Kommentar/), 'Für Tisch 3')
+    expect(screen.getByLabelText('Erhalten')).toHaveValue('10,00')
+
+    // Auswahl leeren (abgebrochener Vorgang) und neu beginnen: der neue Vorgang
+    // startet mit leeren Eingaben, damit nichts aus dem alten übertragen wird.
+    await user.click(screen.getByRole('button', { name: 'toggle' }))
+    await user.click(screen.getByRole('button', { name: 'toggle' }))
+
+    expect(screen.getByLabelText('Erhalten')).toHaveValue('')
+    expect(screen.getByPlaceholderText(/Kommentar/)).toHaveValue('')
+  })
+
   it('behält den verkaufId über einen Retry und wechselt ihn beim neuen Vorgang', async () => {
     const user = userEvent.setup()
     const direktverkaufTaetigen = vi

--- a/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { EuroInput } from '@/components/common/EuroInput'
+import { Button } from '@/components/ui/button'
+import {
+  DrawerBody,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+} from '@/components/ui/drawer'
+import { Label } from '@/components/ui/label'
+import { Spinner } from '@/components/ui/spinner'
+import { useActionSubmit } from '@/hooks/use-action-submit'
+import { formatCents, parseCents } from '@/lib/utils'
+
+import type { DirektverkaufBackend } from '../../direktverkauf/DirektverkaufBackend'
+import { AbschlussHeader } from '../table/AbschlussHeader'
+import { AbschlussLeer } from '../table/AbschlussLeer'
+import { KommentarField } from '../table/CommentField'
+import { calculateZahlungsbetraege } from '../table/drawerUtils'
+import type { ReceiptPosition } from '../table/Receipt'
+import { Receipt } from '../table/Receipt'
+
+interface VerkaufPositionInput {
+  produktId: number
+  varianteId: number
+  menge: number
+}
+
+interface DirektverkaufAbschlussProps {
+  backend: Pick<DirektverkaufBackend, 'direktverkaufTaetigen'>
+  receiptItems: ReceiptPosition[]
+  positionen: VerkaufPositionInput[]
+  totalCents: number
+  // Nach erfolgreichem Verkauf: Auswahl zurücksetzen und Erfolgs-Pop auslösen
+  // (im Handy-Container zusätzlich den Drawer schließen).
+  verkaufAbgeschlossen: () => void
+  // 'sheet' rendert den Bottom-Sheet-Drawer-Inhalt (Handy), 'spalte' die feste
+  // Abschluss-Spalte (ab lg). Einzige Quelle des Abschluss-Inhalts; die beiden
+  // Varianten unterscheiden sich nur im umschließenden Container.
+  variant: 'sheet' | 'spalte'
+}
+
+// Presentation-neutraler Abschluss-Inhalt des Direktverkaufs (Beleg,
+// Erhalten/Rückgeld, Kommentar, „Verkauf abschließen"). Trägt den vollständigen
+// Zustand samt verkaufId-Lebenszyklus und Submit-/Fehler-/Retry-Verhalten und
+// wird sowohl im Handy-Drawer als auch in der festen Spalte gerendert.
+export function DirektverkaufAbschluss(props: DirektverkaufAbschlussProps) {
+  const [erhaltenEuro, setErhaltenEuro] = useState('')
+  const [kommentar, setKommentar] = useState('')
+
+  const noPositionenSelected = props.positionen.length === 0
+
+  // verkaufId je logischem Vorgang: neu, sobald eine Zusammenstellung aus dem
+  // Leerzustand beginnt, und — weil ein erfolgreicher Abschluss die Auswahl leert
+  // — erneut beim nächsten Aufbau. Ein Retry desselben Vorgangs behält seinen
+  // Schlüssel, weil die Auswahl dabei nicht leer wird.
+  const [verkaufId, setVerkaufId] = useState(() => crypto.randomUUID())
+  const warLeerRef = useRef(noPositionenSelected)
+  useEffect(() => {
+    if (warLeerRef.current && !noPositionenSelected) {
+      setVerkaufId(crypto.randomUUID())
+    }
+    warLeerRef.current = noPositionenSelected
+  }, [noPositionenSelected])
+
+  const { rueckgeldCents } = calculateZahlungsbetraege(
+    props.totalCents,
+    parseCents(erhaltenEuro),
+    0,
+  )
+
+  const { loading, run } = useActionSubmit({
+    actionLabel: 'Verkauf abschließen',
+    byCode: {
+      kasse_nicht_geoeffnet:
+        'Es ist keine Kassensitzung geöffnet. Bitte zuerst die Kasse öffnen.',
+      produkt_not_found:
+        'Ein ausgewähltes Produkt ist nicht mehr verfügbar. Bitte Auswahl aktualisieren.',
+    },
+    onSuccess: () => {
+      setErhaltenEuro('')
+      setKommentar('')
+      props.verkaufAbgeschlossen()
+    },
+  })
+
+  const onSubmit = async () => {
+    await run(async () => {
+      await props.backend.direktverkaufTaetigen({
+        verkaufId,
+        positionen: props.positionen,
+        kommentar,
+      })
+    })
+  }
+
+  const inhalt = (
+    <>
+      <AbschlussHeader
+        variant={props.variant}
+        eyebrow="Verkauf abschließen"
+        title="Direktverkauf"
+        description="Verkauf abschließen"
+      />
+      <DrawerBody className="mx-auto w-full max-w-sm">
+        {noPositionenSelected ? (
+          <AbschlussLeer>Produkte auswählen, um zu kassieren.</AbschlussLeer>
+        ) : (
+          <>
+            <Receipt
+              positionen={props.receiptItems}
+              totalPrice={props.totalCents}
+            />
+            <div className="flex flex-col gap-2 px-4 pt-3">
+              <div className="flex items-center justify-between gap-3">
+                <Label htmlFor="erhalten">Erhalten</Label>
+                <EuroInput
+                  id="erhalten"
+                  value={erhaltenEuro}
+                  onValueChange={setErhaltenEuro}
+                  className="w-28"
+                />
+              </div>
+              {rueckgeldCents !== null && (
+                <div className="flex items-baseline justify-between pt-1">
+                  <div className="text-[15px] font-semibold">Rückgeld</div>
+                  <div className="text-xl font-bold tabular-nums">
+                    {formatCents(rueckgeldCents)}&nbsp;€
+                  </div>
+                </div>
+              )}
+            </div>
+            <div className="px-4 pt-3">
+              <KommentarField
+                onChange={(value) => {
+                  setKommentar(value)
+                }}
+              />
+            </div>
+          </>
+        )}
+      </DrawerBody>
+      <DrawerFooter className="mx-auto w-full max-w-sm">
+        <Button
+          disabled={loading || noPositionenSelected}
+          onClick={() => {
+            void onSubmit()
+          }}
+        >
+          {loading ? <Spinner /> : null} Verkauf abschließen
+        </Button>
+        {props.variant === 'sheet' && (
+          <DrawerClose asChild>
+            <Button variant="outline" disabled={loading}>
+              Abbrechen
+            </Button>
+          </DrawerClose>
+        )}
+      </DrawerFooter>
+    </>
+  )
+
+  if (props.variant === 'sheet') {
+    return <DrawerContent pending={loading}>{inhalt}</DrawerContent>
+  }
+
+  // Feste Spalte: dieselben Header/Body/Footer-Primitive wie im Sheet, nur in
+  // einem eigenen, unabhängig scrollenden Container. group/drawer-content +
+  // data-pending übernehmen das Body-Dimming des Drawers während des Submits.
+  return (
+    <aside
+      data-pending={loading || undefined}
+      className="group/drawer-content flex min-h-0 flex-col overflow-hidden rounded-xl border bg-popover text-sm text-popover-foreground"
+    >
+      {inhalt}
+    </aside>
+  )
+}

--- a/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.tsx
@@ -54,12 +54,18 @@ export function DirektverkaufAbschluss(props: DirektverkaufAbschlussProps) {
   // verkaufId je logischem Vorgang: neu, sobald eine Zusammenstellung aus dem
   // Leerzustand beginnt, und — weil ein erfolgreicher Abschluss die Auswahl leert
   // — erneut beim nächsten Aufbau. Ein Retry desselben Vorgangs behält seinen
-  // Schlüssel, weil die Auswahl dabei nicht leer wird.
+  // Schlüssel, weil die Auswahl dabei nicht leer wird. Mit dem neuen Schlüssel
+  // starten auch die Eingaben leer: In der dauerhaften Spalte überlebt der State
+  // sonst über einen Auswahl-Reset hinweg und würde Erhalten/Kommentar eines
+  // abgebrochenen Vorgangs in den nächsten tragen (der Idempotenz-Schlüssel und
+  // die Eingaben bleiben so an derselben Vorgangsgrenze konsistent).
   const [verkaufId, setVerkaufId] = useState(() => crypto.randomUUID())
   const warLeerRef = useRef(noPositionenSelected)
   useEffect(() => {
     if (warLeerRef.current && !noPositionenSelected) {
       setVerkaufId(crypto.randomUUID())
+      setErhaltenEuro('')
+      setKommentar('')
     }
     warLeerRef.current = noPositionenSelected
   }, [noPositionenSelected])
@@ -133,6 +139,7 @@ export function DirektverkaufAbschluss(props: DirektverkaufAbschlussProps) {
             </div>
             <div className="px-4 pt-3">
               <KommentarField
+                value={kommentar}
                 onChange={(value) => {
                   setKommentar(value)
                 }}

--- a/frontend/src/service/components/direktverkauf/DirektverkaufDrawer.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufDrawer.tsx
@@ -1,29 +1,11 @@
 import { useState } from 'react'
 
-import { EuroInput } from '@/components/common/EuroInput'
-import { Button } from '@/components/ui/button'
-import {
-  Drawer,
-  DrawerBody,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from '@/components/ui/drawer'
-import { Label } from '@/components/ui/label'
-import { Spinner } from '@/components/ui/spinner'
-import { useActionSubmit } from '@/hooks/use-action-submit'
-import { formatCents, parseCents } from '@/lib/utils'
+import { Drawer, DrawerTrigger } from '@/components/ui/drawer'
 
 import type { DirektverkaufBackend } from '../../direktverkauf/DirektverkaufBackend'
-import { KommentarField } from '../table/CommentField'
 import { DockActionButton } from '../table/DockActionButton'
-import { calculateZahlungsbetraege } from '../table/drawerUtils'
 import type { ReceiptPosition } from '../table/Receipt'
-import { Receipt } from '../table/Receipt'
+import { DirektverkaufAbschluss } from './DirektverkaufAbschluss'
 
 interface VerkaufPositionInput {
   produktId: number
@@ -40,56 +22,15 @@ interface DirektverkaufDrawerProps {
   verkaufAbgeschlossen: () => void
 }
 
+// Handy-Container (unter lg): Dock-Aktionsbutton als Trigger plus
+// Bottom-Sheet-Drawer, der den gemeinsamen Abschluss-Inhalt trägt. Ab lg rendert
+// die Fläche stattdessen die feste Abschluss-Spalte (siehe Direktverkauf).
 export function DirektverkaufDrawer(props: DirektverkaufDrawerProps) {
   const [open, setOpen] = useState(false)
-  const [erhaltenEuro, setErhaltenEuro] = useState('')
-  const [kommentar, setKommentar] = useState('')
-  // verkaufId pro logischem Vorgang, nicht pro Retry — die Regeneration erfolgt
-  // beim Öffnen in onOpenChange(true).
-  const [verkaufId, setVerkaufId] = useState('')
-
-  const { rueckgeldCents } = calculateZahlungsbetraege(
-    props.totalCents,
-    parseCents(erhaltenEuro),
-    0,
-  )
   const noPositionenSelected = props.positionen.length === 0
 
-  const { loading, run } = useActionSubmit({
-    actionLabel: 'Verkauf abschließen',
-    byCode: {
-      kasse_nicht_geoeffnet:
-        'Es ist keine Kassensitzung geöffnet. Bitte zuerst die Kasse öffnen.',
-      produkt_not_found:
-        'Ein ausgewähltes Produkt ist nicht mehr verfügbar. Bitte Auswahl aktualisieren.',
-    },
-    onSuccess: () => {
-      setOpen(false)
-      setErhaltenEuro('')
-      setKommentar('')
-      props.verkaufAbgeschlossen()
-    },
-  })
-
-  const onSubmit = async () => {
-    await run(async () => {
-      await props.backend.direktverkaufTaetigen({
-        verkaufId,
-        positionen: props.positionen,
-        kommentar,
-      })
-    })
-  }
-
   const onOpenChange = (isOpen: boolean) => {
-    const nextOpen = noPositionenSelected ? false : isOpen
-    if (nextOpen) {
-      setVerkaufId(crypto.randomUUID())
-    }
-    setOpen(nextOpen)
-    if (!nextOpen) {
-      setErhaltenEuro('')
-    }
+    setOpen(noPositionenSelected ? false : isOpen)
   }
 
   return (
@@ -102,66 +43,17 @@ export function DirektverkaufDrawer(props: DirektverkaufDrawerProps) {
           disabled={noPositionenSelected}
         />
       </DrawerTrigger>
-      <DrawerContent pending={loading}>
-        <DrawerHeader className="mx-auto w-full max-w-sm">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Verkauf abschließen
-          </p>
-          <DrawerTitle className="text-[22px] font-semibold">
-            Direktverkauf
-          </DrawerTitle>
-          <DrawerDescription className="sr-only">
-            Verkauf abschließen
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerBody className="mx-auto w-full max-w-sm">
-          <Receipt
-            positionen={props.receiptItems}
-            totalPrice={props.totalCents}
-          />
-          <div className="flex flex-col gap-2 px-4 pt-3">
-            <div className="flex items-center justify-between gap-3">
-              <Label htmlFor="erhalten">Erhalten</Label>
-              <EuroInput
-                id="erhalten"
-                value={erhaltenEuro}
-                onValueChange={setErhaltenEuro}
-                className="w-28"
-              />
-            </div>
-            {rueckgeldCents !== null && (
-              <div className="flex items-baseline justify-between pt-1">
-                <div className="text-[15px] font-semibold">Rückgeld</div>
-                <div className="text-xl font-bold tabular-nums">
-                  {formatCents(rueckgeldCents)}&nbsp;€
-                </div>
-              </div>
-            )}
-          </div>
-          <div className="px-4 pt-3">
-            <KommentarField
-              onChange={(value) => {
-                setKommentar(value)
-              }}
-            />
-          </div>
-        </DrawerBody>
-        <DrawerFooter className="mx-auto w-full max-w-sm">
-          <Button
-            disabled={loading}
-            onClick={() => {
-              void onSubmit()
-            }}
-          >
-            {loading ? <Spinner /> : null} Verkauf abschließen
-          </Button>
-          <DrawerClose asChild>
-            <Button variant="outline" disabled={loading}>
-              Abbrechen
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
+      <DirektverkaufAbschluss
+        variant="sheet"
+        backend={props.backend}
+        receiptItems={props.receiptItems}
+        positionen={props.positionen}
+        totalCents={props.totalCents}
+        verkaufAbgeschlossen={() => {
+          setOpen(false)
+          props.verkaufAbgeschlossen()
+        }}
+      />
     </Drawer>
   )
 }

--- a/frontend/src/service/components/table/AbschlussHeader.tsx
+++ b/frontend/src/service/components/table/AbschlussHeader.tsx
@@ -1,0 +1,47 @@
+import {
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer'
+
+interface AbschlussHeaderProps {
+  // 'sheet' nutzt die Radix-Dialog-Primitive DrawerTitle/DrawerDescription (für
+  // die A11y des Bottom-Sheets nötig); 'spalte' rendert eine schlichte
+  // Überschrift, weil dort kein Dialog-Kontext existiert.
+  variant: 'sheet' | 'spalte'
+  eyebrow: string
+  title: string
+  // Nur im Sheet als sr-only Dialog-Description verwendet.
+  description: string
+}
+
+// Gemeinsamer Kopf der drei Abschluss-Flächen (Direktverkauf, Bestellen,
+// Kassieren): eine kleine Eyebrow-Zeile plus dominante Überschrift.
+export function AbschlussHeader({
+  variant,
+  eyebrow,
+  title,
+  description,
+}: AbschlussHeaderProps) {
+  return (
+    <DrawerHeader className="mx-auto w-full max-w-sm">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {eyebrow}
+      </p>
+      {variant === 'sheet' ? (
+        <>
+          <DrawerTitle className="text-[22px] font-semibold">
+            {title}
+          </DrawerTitle>
+          <DrawerDescription className="sr-only">
+            {description}
+          </DrawerDescription>
+        </>
+      ) : (
+        <h2 className="font-heading text-[22px] font-semibold text-foreground">
+          {title}
+        </h2>
+      )}
+    </DrawerHeader>
+  )
+}

--- a/frontend/src/service/components/table/AbschlussLeer.tsx
+++ b/frontend/src/service/components/table/AbschlussLeer.tsx
@@ -1,0 +1,11 @@
+// Leerzustand der festen Abschluss-Spalte: ein Hinweistext, solange nichts
+// ausgewählt ist. Gleichbedeutend mit dem heute deaktivierten Dock-Button —
+// der Aktionsbutton der Spalte ist in diesem Zustand ebenfalls deaktiviert.
+// Im Handy-Drawer nie sichtbar (der öffnet nur mit Auswahl).
+export function AbschlussLeer({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-40 items-center justify-center px-6 py-10 text-center text-sm text-muted-foreground">
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/service/components/table/Bestellung.test.tsx
+++ b/frontend/src/service/components/table/Bestellung.test.tsx
@@ -11,6 +11,13 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
+// Diese Suite prüft das Handy-Layout (Dock-Aktionsbutton); ab lg rendert
+// Bestellung die feste Abschluss-Spalte, deren Verhalten
+// BestellungAbschluss.test.tsx container-neutral abdeckt.
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => true,
+}))
+
 afterEach(() => {
   cleanup()
 })

--- a/frontend/src/service/components/table/Bestellung.test.tsx
+++ b/frontend/src/service/components/table/Bestellung.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { useIsMobile } from '@/hooks/use-mobile'
+
 import type { Produkt } from '../../product/Produkt'
 import type { Tisch } from '../../table/Tisch'
 import { ServiceDock } from '../ServiceDock'
@@ -11,15 +13,16 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
-// Diese Suite prüft das Handy-Layout (Dock-Aktionsbutton); ab lg rendert
-// Bestellung die feste Abschluss-Spalte, deren Verhalten
-// BestellungAbschluss.test.tsx container-neutral abdeckt.
+// Standardmäßig Handy-Layout (Dock-Aktionsbutton); ein Test unten schaltet auf
+// Desktop, um die Verdrahtung der festen Spalte zu prüfen. Deren
+// container-neutrales Verhalten deckt BestellungAbschluss.test.tsx ab.
 vi.mock('@/hooks/use-mobile', () => ({
-  useIsMobile: () => true,
+  useIsMobile: vi.fn(() => true),
 }))
 
 afterEach(() => {
   cleanup()
+  vi.mocked(useIsMobile).mockReturnValue(true)
 })
 
 const tisch: Tisch = { id: 1, name: 'Stammtisch', saldoCents: 0 }
@@ -71,5 +74,34 @@ describe('Bestellung Aktionsleiste', () => {
     const bar = screen.getByRole('button', { name: /Bestellung überprüfen/ })
     expect(bar).toBeEnabled()
     expect(bar).toHaveTextContent('3,50')
+  })
+
+  it('rendert ab lg die feste Abschluss-Spalte statt Dock und Drawer', async () => {
+    vi.mocked(useIsMobile).mockReturnValue(false)
+    const user = userEvent.setup()
+    // Kein ServiceDock: die feste Spalte trägt den Aktionsbutton selbst.
+    render(
+      <Bestellung
+        backend={{ bestellungAufnehmen: vi.fn().mockResolvedValue(undefined) }}
+        tisch={tisch}
+        products={[testProdukt]}
+        productsLoading={false}
+        onErfolg={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Bratwurst')).toBeInTheDocument()
+    const button = screen.getByRole('button', { name: 'Bestellung aufnehmen' })
+    expect(button).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: /Bestellung überprüfen/ }),
+    ).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: 'Variante hinzufügen' }),
+    )
+    expect(
+      screen.getByRole('button', { name: 'Bestellung aufnehmen' }),
+    ).toBeEnabled()
   })
 })

--- a/frontend/src/service/components/table/Bestellung.tsx
+++ b/frontend/src/service/components/table/Bestellung.tsx
@@ -1,9 +1,13 @@
 import { useMengen } from '@/hooks/use-mengen'
+import { useIsMobile } from '@/hooks/use-mobile'
 
 import type { Produkt } from '../../product/Produkt'
 import type { Tisch } from '../../table/Tisch'
 import type { TischBackend } from '../../table/TischBackend'
+import { ServiceSplitLayout } from '../ServiceSplitLayout'
+import { BestellungAbschluss } from './BestellungAbschluss'
 import { BestellungDrawer } from './BestellungDrawer'
+import { calculateTotalPrice, toBestellungData } from './drawerUtils'
 import { ProductList, ProductListSkeleton } from './ProductList'
 
 interface BestellungProps {
@@ -23,12 +27,50 @@ export function Bestellung({
   productsLoading,
   onErfolg,
 }: BestellungProps) {
+  const isMobile = useIsMobile()
   const { mengen, add, remove, reset } = useMengen<number>()
 
   if (productsLoading) {
     return <ProductListSkeleton />
   }
 
+  const bestellungAufgenommen = () => {
+    reset()
+    onErfolg('Bestellung wurde aufgenommen.')
+  }
+
+  const productList = (
+    <ProductList
+      products={products}
+      variantMengen={mengen}
+      onAdd={add}
+      onRemove={remove}
+    />
+  )
+
+  // Ab lg: feste Abschluss-Spalte rechts, Produkte links. Der extrahierte
+  // Abschluss-Inhalt mountet genau einmal (isMobile entscheidet den Zweig).
+  if (!isMobile) {
+    const { receiptItems, inputItems } = toBestellungData(products, mengen)
+    return (
+      <ServiceSplitLayout
+        auswahl={productList}
+        abschluss={
+          <BestellungAbschluss
+            variant="spalte"
+            backend={backend}
+            tisch={tisch}
+            receiptItems={receiptItems}
+            positionen={inputItems}
+            totalCents={calculateTotalPrice(receiptItems)}
+            bestellungAufgenommen={bestellungAufgenommen}
+          />
+        }
+      />
+    )
+  }
+
+  // Unter lg: unverändert Dock-Aktionsbutton plus Bottom-Sheet-Drawer.
   return (
     <>
       <BestellungDrawer
@@ -36,17 +78,9 @@ export function Bestellung({
         tisch={tisch}
         products={products}
         mengen={mengen}
-        bestellungAufgenommen={() => {
-          reset()
-          onErfolg('Bestellung wurde aufgenommen.')
-        }}
+        bestellungAufgenommen={bestellungAufgenommen}
       />
-      <ProductList
-        products={products}
-        variantMengen={mengen}
-        onAdd={add}
-        onRemove={remove}
-      />
+      {productList}
     </>
   )
 }

--- a/frontend/src/service/components/table/BestellungAbschluss.test.tsx
+++ b/frontend/src/service/components/table/BestellungAbschluss.test.tsx
@@ -1,0 +1,195 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { BestellungAufnehmen } from '../../table/Bestellung'
+import type { Tisch } from '../../table/Tisch'
+import { BestellungAbschluss } from './BestellungAbschluss'
+import type { ReceiptPosition } from './Receipt'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+const tisch: Tisch = { id: 1, name: 'Stammtisch', saldoCents: 0 }
+const receiptItems: ReceiptPosition[] = [
+  { name: 'Bratwurst Normal', einzelpreisCents: 350, menge: 2 },
+]
+const positionen = [{ produktId: 1, varianteId: 1, menge: 2 }]
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+// Die feste Spalte (variant="spalte") ist container-neutral testbar: kein
+// Drawer, kein Dock.
+function renderSpalte(
+  bestellungAufnehmen: () => Promise<void> = vi
+    .fn()
+    .mockResolvedValue(undefined),
+) {
+  const bestellungAufgenommen = vi.fn()
+  render(
+    <BestellungAbschluss
+      variant="spalte"
+      backend={{ bestellungAufnehmen }}
+      tisch={tisch}
+      receiptItems={receiptItems}
+      positionen={positionen}
+      totalCents={700}
+      bestellungAufgenommen={bestellungAufgenommen}
+    />,
+  )
+  return { bestellungAufnehmen, bestellungAufgenommen }
+}
+
+describe('BestellungAbschluss (Spalte)', () => {
+  it('zeigt im Leerzustand einen Hinweis und deaktiviert den Aktionsbutton', () => {
+    render(
+      <BestellungAbschluss
+        variant="spalte"
+        backend={{ bestellungAufnehmen: vi.fn() }}
+        tisch={tisch}
+        receiptItems={[]}
+        positionen={[]}
+        totalCents={0}
+        bestellungAufgenommen={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/Produkte auswählen/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Bestellung aufnehmen' }),
+    ).toBeDisabled()
+  })
+
+  it('zeigt Beleg, Tischname und Gesamtsumme und nimmt mit genau einem Backend-Call auf', async () => {
+    const user = userEvent.setup()
+    const { bestellungAufnehmen, bestellungAufgenommen } = renderSpalte()
+
+    expect(screen.getByRole('heading', { name: 'Stammtisch' })).toBeVisible()
+    expect(screen.getByText(/Bratwurst/)).toBeInTheDocument()
+    // Gesamt-Zeile im Footer zeigt die Summe (der Beleg zeigt dieselbe Zahl
+    // zusätzlich in der Positionszeile).
+    expect(screen.getByText('Gesamt').nextElementSibling).toHaveTextContent(
+      '7,00',
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Bestellung aufnehmen' }),
+    )
+
+    await waitFor(() => {
+      expect(bestellungAufnehmen).toHaveBeenCalledTimes(1)
+    })
+    expect(bestellungAufnehmen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        bestellungId: expect.stringMatching(UUID),
+        tischId: 1,
+        positionen,
+        kommentar: '',
+      }),
+    )
+    expect(bestellungAufgenommen).toHaveBeenCalledTimes(1)
+  })
+
+  it('behält den bestellungId über einen Retry und wechselt ihn beim neuen Vorgang', async () => {
+    const user = userEvent.setup()
+    const bestellungAufnehmen = vi
+      .fn<(b: BestellungAufnehmen) => Promise<void>>()
+      .mockRejectedValueOnce(new Error('kaputt'))
+      .mockResolvedValue(undefined)
+
+    function Harness() {
+      const [leer, setLeer] = useState(false)
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              setLeer((v) => !v)
+            }}
+          >
+            toggle
+          </button>
+          <BestellungAbschluss
+            variant="spalte"
+            backend={{ bestellungAufnehmen }}
+            tisch={tisch}
+            receiptItems={leer ? [] : receiptItems}
+            positionen={leer ? [] : positionen}
+            totalCents={leer ? 0 : 700}
+            bestellungAufgenommen={vi.fn()}
+          />
+        </>
+      )
+    }
+    render(<Harness />)
+
+    const aufnehmen = () =>
+      screen.getByRole('button', { name: 'Bestellung aufnehmen' })
+
+    await user.click(aufnehmen())
+    await waitFor(() => {
+      expect(bestellungAufnehmen).toHaveBeenCalledTimes(1)
+    })
+    const ersterKey = bestellungAufnehmen.mock.calls[0][0].bestellungId
+
+    await user.click(aufnehmen())
+    await waitFor(() => {
+      expect(bestellungAufnehmen).toHaveBeenCalledTimes(2)
+    })
+    expect(bestellungAufnehmen.mock.calls[1][0].bestellungId).toBe(ersterKey)
+
+    // Neuer logischer Vorgang: Auswahl leeren und neu füllen.
+    await user.click(screen.getByRole('button', { name: 'toggle' }))
+    await user.click(screen.getByRole('button', { name: 'toggle' }))
+    await user.click(aufnehmen())
+    await waitFor(() => {
+      expect(bestellungAufnehmen).toHaveBeenCalledTimes(3)
+    })
+    expect(bestellungAufnehmen.mock.calls[2][0].bestellungId).not.toBe(
+      ersterKey,
+    )
+  })
+
+  it('setzt den Kommentar beim neuen Vorgang zurück', async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [leer, setLeer] = useState(false)
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              setLeer((v) => !v)
+            }}
+          >
+            toggle
+          </button>
+          <BestellungAbschluss
+            variant="spalte"
+            backend={{ bestellungAufnehmen: vi.fn() }}
+            tisch={tisch}
+            receiptItems={leer ? [] : receiptItems}
+            positionen={leer ? [] : positionen}
+            totalCents={leer ? 0 : 700}
+            bestellungAufgenommen={vi.fn()}
+          />
+        </>
+      )
+    }
+    render(<Harness />)
+
+    await user.type(screen.getByPlaceholderText(/Kommentar/), 'Ohne Zwiebeln')
+    await user.click(screen.getByRole('button', { name: 'toggle' }))
+    await user.click(screen.getByRole('button', { name: 'toggle' }))
+
+    expect(screen.getByPlaceholderText(/Kommentar/)).toHaveValue('')
+  })
+})

--- a/frontend/src/service/components/table/BestellungAbschluss.tsx
+++ b/frontend/src/service/components/table/BestellungAbschluss.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  DrawerBody,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+} from '@/components/ui/drawer'
+import { Spinner } from '@/components/ui/spinner'
+import { useActionSubmit } from '@/hooks/use-action-submit'
+import { formatCents } from '@/lib/utils'
+
+import type { BestellPositionInput } from '../../table/Bestellung'
+import type { Tisch } from '../../table/Tisch'
+import type { TischBackend } from '../../table/TischBackend'
+import { AbschlussHeader } from './AbschlussHeader'
+import { AbschlussLeer } from './AbschlussLeer'
+import { KommentarField } from './CommentField'
+import type { ReceiptPosition } from './Receipt'
+import { Receipt } from './Receipt'
+
+interface BestellungAbschlussProps {
+  backend: Pick<TischBackend, 'bestellungAufnehmen'>
+  tisch: Tisch
+  receiptItems: ReceiptPosition[]
+  positionen: BestellPositionInput[]
+  totalCents: number
+  bestellungAufgenommen: () => void
+  // 'sheet' rendert den Bottom-Sheet-Drawer-Inhalt (Handy), 'spalte' die feste
+  // Abschluss-Spalte (ab lg). Einzige Quelle des Abschluss-Inhalts; die beiden
+  // Varianten unterscheiden sich nur im umschließenden Container.
+  variant: 'sheet' | 'spalte'
+}
+
+// Presentation-neutraler Abschluss-Inhalt des Tisch-Bestellens (Beleg,
+// Kommentar, Gesamt, „Bestellung aufnehmen"). Trägt den vollständigen Zustand
+// samt bestellungId-Lebenszyklus und Submit-/Fehler-/Retry-Verhalten und wird
+// sowohl im Handy-Drawer als auch in der festen Spalte gerendert.
+export function BestellungAbschluss(props: BestellungAbschlussProps) {
+  const [kommentar, setKommentar] = useState('')
+
+  const noPositionenSelected = props.positionen.length === 0
+
+  // bestellungId je logischem Vorgang: neu, sobald eine Zusammenstellung aus dem
+  // Leerzustand beginnt, und erneut nach jedem erfolgreichen Abschluss (der die
+  // Auswahl leert). Ein Retry desselben Vorgangs behält seinen Schlüssel. Mit dem
+  // neuen Schlüssel startet auch der Kommentar leer, damit in der dauerhaften
+  // Spalte nichts aus einem abgebrochenen Vorgang übertragen wird.
+  const [bestellungId, setBestellungId] = useState(() => crypto.randomUUID())
+  const warLeerRef = useRef(noPositionenSelected)
+  useEffect(() => {
+    if (warLeerRef.current && !noPositionenSelected) {
+      setBestellungId(crypto.randomUUID())
+      setKommentar('')
+    }
+    warLeerRef.current = noPositionenSelected
+  }, [noPositionenSelected])
+
+  const { loading, run } = useActionSubmit({
+    actionLabel: 'Bestellung aufnehmen',
+    byCode: {
+      produkt_not_found:
+        'Ein ausgewähltes Produkt ist nicht mehr verfügbar. Bitte Auswahl aktualisieren.',
+    },
+    onSuccess: () => {
+      setKommentar('')
+      props.bestellungAufgenommen()
+    },
+  })
+
+  const onSubmit = async () => {
+    await run(async () => {
+      await props.backend.bestellungAufnehmen({
+        bestellungId,
+        tischId: props.tisch.id,
+        positionen: props.positionen,
+        kommentar,
+      })
+    })
+  }
+
+  const inhalt = (
+    <>
+      <AbschlussHeader
+        variant={props.variant}
+        eyebrow="Bestellung für"
+        title={props.tisch.name}
+        description={`Bestellung für ${props.tisch.name}`}
+      />
+      <DrawerBody className="mx-auto w-full max-w-sm">
+        {noPositionenSelected ? (
+          <AbschlussLeer>Produkte auswählen, um zu bestellen.</AbschlussLeer>
+        ) : (
+          <>
+            <Receipt positionen={props.receiptItems} />
+            <div className="px-4">
+              <KommentarField
+                value={kommentar}
+                onChange={(value) => {
+                  setKommentar(value)
+                }}
+              />
+            </div>
+          </>
+        )}
+      </DrawerBody>
+      <DrawerFooter className="mx-auto w-full max-w-sm">
+        <div className="flex justify-between border-t-2 pt-2 font-bold">
+          <div>Gesamt</div>
+          <div>{formatCents(props.totalCents)}&nbsp;€</div>
+        </div>
+        <Button
+          disabled={loading || noPositionenSelected}
+          onClick={() => {
+            void onSubmit()
+          }}
+        >
+          {loading ? <Spinner /> : null} Bestellung aufnehmen
+        </Button>
+        {props.variant === 'sheet' && (
+          <DrawerClose asChild>
+            <Button variant="outline" disabled={loading}>
+              Abbrechen
+            </Button>
+          </DrawerClose>
+        )}
+      </DrawerFooter>
+    </>
+  )
+
+  if (props.variant === 'sheet') {
+    return <DrawerContent pending={loading}>{inhalt}</DrawerContent>
+  }
+
+  // Feste Spalte: dieselben Body/Footer-Primitive wie im Sheet, nur in einem
+  // eigenen, unabhängig scrollenden Container. group/drawer-content +
+  // data-pending übernehmen das Body-Dimming des Drawers während des Submits.
+  return (
+    <aside
+      data-pending={loading || undefined}
+      className="group/drawer-content flex min-h-0 flex-col overflow-hidden rounded-xl border bg-popover text-sm text-popover-foreground"
+    >
+      {inhalt}
+    </aside>
+  )
+}

--- a/frontend/src/service/components/table/BestellungDrawer.tsx
+++ b/frontend/src/service/components/table/BestellungDrawer.tsx
@@ -1,28 +1,13 @@
 import { useState } from 'react'
 
-import { Button } from '@/components/ui/button'
-import {
-  Drawer,
-  DrawerBody,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from '@/components/ui/drawer'
-import { Spinner } from '@/components/ui/spinner'
-import { useActionSubmit } from '@/hooks/use-action-submit'
-import { formatCents } from '@/lib/utils'
+import { Drawer, DrawerTrigger } from '@/components/ui/drawer'
 
 import type { Produkt } from '../../product/Produkt'
 import type { Tisch } from '../../table/Tisch'
 import type { TischBackend } from '../../table/TischBackend'
-import { KommentarField } from './CommentField'
+import { BestellungAbschluss } from './BestellungAbschluss'
 import { DockActionButton } from './DockActionButton'
 import { calculateTotalPrice, toBestellungData } from './drawerUtils'
-import { Receipt } from './Receipt'
 
 interface BestellungDrawerProps {
   backend: Pick<TischBackend, 'bestellungAufnehmen'>
@@ -32,11 +17,11 @@ interface BestellungDrawerProps {
   bestellungAufgenommen: () => void
 }
 
+// Handy-Container (unter lg): Dock-Aktionsbutton als Trigger plus
+// Bottom-Sheet-Drawer, der den gemeinsamen Abschluss-Inhalt trägt. Ab lg rendert
+// die Fläche stattdessen die feste Abschluss-Spalte (siehe Bestellung).
 export function BestellungDrawer(props: BestellungDrawerProps) {
   const [open, setOpen] = useState(false)
-  const [kommentar, setKommentar] = useState('')
-  // bestellungId pro logischem Vorgang (nicht pro Retry). Neue ID wenn Drawer öffnet.
-  const [bestellungId, setBestellungId] = useState(() => crypto.randomUUID())
   const { receiptItems, inputItems } = toBestellungData(
     props.products,
     props.mengen,
@@ -45,38 +30,8 @@ export function BestellungDrawer(props: BestellungDrawerProps) {
   const anzahl = inputItems.reduce((sum, item) => sum + item.menge, 0)
   const noPositionenSelected = inputItems.length === 0
 
-  const { loading, run } = useActionSubmit({
-    actionLabel: 'Bestellung aufnehmen',
-    byCode: {
-      produkt_not_found:
-        'Ein ausgewähltes Produkt ist nicht mehr verfügbar. Bitte Auswahl aktualisieren.',
-    },
-    onSuccess: () => {
-      props.bestellungAufgenommen()
-      setOpen(false)
-    },
-  })
-
-  const onSubmit = async () => {
-    await run(async () => {
-      await props.backend.bestellungAufnehmen({
-        bestellungId,
-        tischId: props.tisch.id,
-        positionen: inputItems,
-        kommentar,
-      })
-    })
-  }
-
   const onOpenChange = (isOpen: boolean) => {
-    if (noPositionenSelected) {
-      setOpen(false)
-    } else {
-      if (isOpen) {
-        setBestellungId(crypto.randomUUID())
-      }
-      setOpen(isOpen)
-    }
+    setOpen(noPositionenSelected ? false : isOpen)
   }
 
   return (
@@ -89,48 +44,18 @@ export function BestellungDrawer(props: BestellungDrawerProps) {
           disabled={noPositionenSelected}
         />
       </DrawerTrigger>
-      <DrawerContent pending={loading}>
-        <DrawerHeader className="mx-auto w-full max-w-sm">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Bestellung für
-          </p>
-          <DrawerTitle className="text-[22px] font-semibold">
-            {props.tisch.name}
-          </DrawerTitle>
-          <DrawerDescription className="sr-only">
-            Bestellung für {props.tisch.name}
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerBody className="mx-auto w-full max-w-sm">
-          <Receipt positionen={receiptItems} />
-          <div className="px-4">
-            <KommentarField
-              onChange={(value) => {
-                setKommentar(value)
-              }}
-            />
-          </div>
-        </DrawerBody>
-        <DrawerFooter className="mx-auto w-full max-w-sm">
-          <div className="flex justify-between border-t-2 pt-2 font-bold">
-            <div>Gesamt</div>
-            <div>{formatCents(totalPrice)}&nbsp;€</div>
-          </div>
-          <Button
-            disabled={loading}
-            onClick={() => {
-              void onSubmit()
-            }}
-          >
-            {loading ? <Spinner /> : null} Bestellung aufnehmen
-          </Button>
-          <DrawerClose asChild>
-            <Button variant="outline" disabled={loading}>
-              Abbrechen
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
+      <BestellungAbschluss
+        variant="sheet"
+        backend={props.backend}
+        tisch={props.tisch}
+        receiptItems={receiptItems}
+        positionen={inputItems}
+        totalCents={totalPrice}
+        bestellungAufgenommen={() => {
+          setOpen(false)
+          props.bestellungAufgenommen()
+        }}
+      />
     </Drawer>
   )
 }

--- a/frontend/src/service/components/table/CommentField.tsx
+++ b/frontend/src/service/components/table/CommentField.tsx
@@ -5,12 +5,19 @@ import { Textarea } from '@/components/ui/textarea'
 
 interface KommentarFieldProps {
   onChange: (value: string) => void
+  // Kontrolliert das Feld, wenn gesetzt. Die dauerhaft sichtbare
+  // Abschluss-Spalte braucht das, damit der angezeigte Text nie vom
+  // gesendeten kommentar-State abweicht (sonst würde ein remountetes,
+  // leeres Feld einen alten State verdecken). Die kurzlebigen
+  // Korrektur-Drawer bleiben unkontrolliert (sie remounten bei jedem Öffnen).
+  value?: string
   required?: boolean
   invalid?: boolean
 }
 
 export function KommentarField({
   onChange,
+  value,
   required = false,
   invalid = false,
 }: KommentarFieldProps) {
@@ -25,6 +32,7 @@ export function KommentarField({
         }
         rows={3}
         maxLength={100}
+        value={value}
         onChange={(e) => {
           setTouched(true)
           onChange(e.target.value)

--- a/frontend/src/service/components/table/RestbetragZeile.tsx
+++ b/frontend/src/service/components/table/RestbetragZeile.tsx
@@ -1,0 +1,15 @@
+import { formatCents } from '@/lib/utils'
+
+// „Nach dieser Zahlung noch offen"-Zeile. Unter lg rendert der Handy-Container
+// sie in den Dock-Slot, ab lg trägt die Abschluss-Spalte sie selbst im Footer —
+// dieselbe Darstellung, nur ein anderer Ort.
+export function RestbetragZeile({ cents }: { cents: number }) {
+  return (
+    <div className="flex items-center justify-between gap-3 text-[13px] text-muted-foreground">
+      <span>Nach dieser Zahlung noch offen</span>
+      <span className="font-semibold tabular-nums text-foreground">
+        {formatCents(cents)}&nbsp;€
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/service/components/table/Zahlung.test.tsx
+++ b/frontend/src/service/components/table/Zahlung.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { useIsMobile } from '@/hooks/use-mobile'
+
 import type { Position } from '../../table/Bestellung'
 import type { Tisch } from '../../table/Tisch'
 import { ServiceDock } from '../ServiceDock'
@@ -11,12 +13,20 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
+// Standardmäßig Handy-Layout (Dock-Button, Restbetrag im Dock-Slot); ein Test
+// unten schaltet auf Desktop, um die Verdrahtung der festen Spalte zu prüfen.
+// Deren container-neutrales Verhalten deckt ZahlungAbschluss.test.tsx ab.
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: vi.fn(() => true),
+}))
+
 vi.mock('@/lib/Auth', () => ({
   AuthSingleton: { userId: 1 },
 }))
 
 afterEach(() => {
   cleanup()
+  vi.mocked(useIsMobile).mockReturnValue(true)
 })
 
 const tisch: Tisch = { id: 1, name: 'Stammtisch', saldoCents: 900 }
@@ -62,6 +72,32 @@ function renderZahlung(positionen: Position[] = [position]) {
     </ServiceDock>,
   )
 }
+
+describe('Zahlung feste Spalte (ab lg)', () => {
+  it('rendert die Abschluss-Spalte mit Restbetrag statt Dock und Drawer', async () => {
+    vi.mocked(useIsMobile).mockReturnValue(false)
+    const user = userEvent.setup()
+    // Kein ServiceDock: die feste Spalte trägt Aktionsbutton und Restbetrag.
+    render(
+      <Zahlung
+        backend={{ zahlungKassieren: vi.fn().mockResolvedValue(undefined) }}
+        tisch={tisch}
+        positionen={[position]}
+        onErfolg={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Bratwurst Normal')).toBeInTheDocument()
+    // Restbetrag steht in der Spalte (nicht im Dock-Slot).
+    expect(screen.getByText('Nach dieser Zahlung noch offen')).toBeVisible()
+    const button = screen.getByRole('button', { name: 'Kassieren' })
+    expect(button).toBeDisabled()
+
+    // Auswahl links aktiviert den Kassieren-Button rechts.
+    await user.click(screen.getByRole('button', { name: 'Produkt hinzufügen' }))
+    expect(screen.getByRole('button', { name: 'Kassieren' })).toBeEnabled()
+  })
+})
 
 describe('Zahlung Aktionsleiste', () => {
   it('ist ohne Auswahl deaktiviert und zeigt nach Auswahl Anzahl und Summe', async () => {

--- a/frontend/src/service/components/table/Zahlung.tsx
+++ b/frontend/src/service/components/table/Zahlung.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/item'
 import { useErstAufbau } from '@/hooks/use-erst-aufbau'
 import { useMengen } from '@/hooks/use-mengen'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { AuthSingleton } from '@/lib/Auth'
 import {
   cn,
@@ -22,7 +23,10 @@ import {
 import type { Position } from '../../table/Bestellung'
 import type { Tisch } from '../../table/Tisch'
 import type { TischBackend } from '../../table/TischBackend'
+import { ServiceSplitLayout } from '../ServiceSplitLayout'
 import { Stepper } from '../Stepper'
+import { selectPositionen } from './drawerUtils'
+import { ZahlungAbschluss } from './ZahlungAbschluss'
 import { ZahlungDrawer } from './ZahlungDrawer'
 
 interface ZahlungProps {
@@ -40,6 +44,7 @@ export function Zahlung({
   positionen,
   onErfolg,
 }: ZahlungProps) {
+  const isMobile = useIsMobile()
   const [andereOffen, setAndereOffen] = useState(false)
   // Positionen treten nur beim ersten Aufbau gestaffelt ein; nach einer Zahlung
   // (Refetch) bleiben die verbleibenden Zeilen unbewegt.
@@ -71,6 +76,9 @@ export function Zahlung({
     0,
   )
   const restNachZahlung = tisch.saldoCents - auswahlSumme
+  // Die ausgewählten Positionen (Menge = Auswahl) für Beleg und Nutzlast der
+  // Abschluss-Spalte; auswahlSumme ist deren Gesamtsumme.
+  const positionenToPay = selectPositionen(positionen, mengen)
 
   const alleEigenenVollAusgewaehlt =
     meinePositionen.length > 0 &&
@@ -135,6 +143,98 @@ export function Zahlung({
     />
   )
 
+  const zahlungKassiert = () => {
+    reset()
+    onErfolg('Zahlung erfolgreich.')
+  }
+
+  const auswahl = (
+    <div className="my-4 space-y-3">
+      {meinePositionen.length > 0 && (
+        <button
+          type="button"
+          onClick={alleAuswaehlen}
+          className="flex h-11 w-full items-center justify-center gap-2 rounded-lg border border-primary/50 bg-primary/5 px-4 text-sm font-medium text-primary"
+        >
+          <CircleCheck className="size-5" />
+          {alleEigenenVollAusgewaehlt
+            ? 'Auswahl aufheben'
+            : formatAlleAuswaehlenLabel(
+                meinePositionen.length,
+                eigeneUnbezahltGesamt,
+              )}
+        </button>
+      )}
+      <ItemGroup className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
+        {meinePositionen.map((position, index) =>
+          renderPosition(position, false, erstAufbau ? index : undefined),
+        )}
+      </ItemGroup>
+      {anderePositionen.length > 0 && (
+        <div className="space-y-2">
+          <button
+            type="button"
+            onClick={() => {
+              setAndereOffen((offen) => !offen)
+            }}
+            className="flex w-full items-center justify-between gap-2 py-1 text-left"
+            aria-expanded={andereOffen}
+          >
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Von anderen · {anderePositionen.length}
+            </span>
+            <ChevronDown
+              className={cn(
+                'size-4 text-muted-foreground transition-transform',
+                andereOffen && 'rotate-180',
+              )}
+            />
+          </button>
+          {andereOffen ? (
+            <ItemGroup className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
+              {anderePositionen.map((position) =>
+                renderPosition(position, true),
+              )}
+            </ItemGroup>
+          ) : andereAusgewaehlteAnzahl > 0 ? (
+            <p className="text-[13px] font-medium text-primary/80">
+              {andereAusgewaehlteAnzahl} ausgewählt ·{' '}
+              {formatCents(andereAusgewaehlteSumme)}&nbsp;€
+            </p>
+          ) : (
+            <p className="text-[13px] text-muted-foreground">
+              {anderePositionenNamen} · {formatCents(anderePositionenSumme)}
+              &nbsp;€
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+
+  // Ab lg: offene Positionen links, Zahlungsübersicht rechts. Der extrahierte
+  // Abschluss-Inhalt mountet genau einmal (isMobile entscheidet den Zweig).
+  if (!isMobile) {
+    return (
+      <ServiceSplitLayout
+        auswahl={auswahl}
+        abschluss={
+          <ZahlungAbschluss
+            variant="spalte"
+            backend={backend}
+            tisch={tisch}
+            positionenToPay={positionenToPay}
+            totalCents={auswahlSumme}
+            restNachZahlungCents={restNachZahlung}
+            zahlungKassiert={zahlungKassiert}
+          />
+        }
+      />
+    )
+  }
+
+  // Unter lg: unverändert Dock-Aktionsbutton (plus Restbetrag im Dock-Slot) und
+  // Bottom-Sheet-Drawer.
   return (
     <>
       <ZahlungDrawer
@@ -143,72 +243,9 @@ export function Zahlung({
         unbezahltePositionen={positionen}
         mengen={mengen}
         restNachZahlungCents={restNachZahlung}
-        zahlungKassiert={() => {
-          reset()
-          onErfolg('Zahlung erfolgreich.')
-        }}
+        zahlungKassiert={zahlungKassiert}
       />
-      <div className="my-4 space-y-3">
-        {meinePositionen.length > 0 && (
-          <button
-            type="button"
-            onClick={alleAuswaehlen}
-            className="flex h-11 w-full items-center justify-center gap-2 rounded-lg border border-primary/50 bg-primary/5 px-4 text-sm font-medium text-primary"
-          >
-            <CircleCheck className="size-5" />
-            {alleEigenenVollAusgewaehlt
-              ? 'Auswahl aufheben'
-              : formatAlleAuswaehlenLabel(
-                  meinePositionen.length,
-                  eigeneUnbezahltGesamt,
-                )}
-          </button>
-        )}
-        <ItemGroup className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
-          {meinePositionen.map((position, index) =>
-            renderPosition(position, false, erstAufbau ? index : undefined),
-          )}
-        </ItemGroup>
-        {anderePositionen.length > 0 && (
-          <div className="space-y-2">
-            <button
-              type="button"
-              onClick={() => {
-                setAndereOffen((offen) => !offen)
-              }}
-              className="flex w-full items-center justify-between gap-2 py-1 text-left"
-              aria-expanded={andereOffen}
-            >
-              <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                Von anderen · {anderePositionen.length}
-              </span>
-              <ChevronDown
-                className={cn(
-                  'size-4 text-muted-foreground transition-transform',
-                  andereOffen && 'rotate-180',
-                )}
-              />
-            </button>
-            {andereOffen ? (
-              <ItemGroup className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
-                {anderePositionen.map((position) =>
-                  renderPosition(position, true),
-                )}
-              </ItemGroup>
-            ) : andereAusgewaehlteAnzahl > 0 ? (
-              <p className="text-[13px] font-medium text-primary/80">
-                {andereAusgewaehlteAnzahl} ausgewählt ·{' '}
-                {formatCents(andereAusgewaehlteSumme)}&nbsp;€
-              </p>
-            ) : (
-              <p className="text-[13px] text-muted-foreground">
-                {anderePositionenNamen} · {formatCents(anderePositionenSumme)}
-                &nbsp;€
-              </p>
-            )}
-          </div>
-        )}
-      </div>
+      {auswahl}
     </>
   )
 }

--- a/frontend/src/service/components/table/ZahlungAbschluss.test.tsx
+++ b/frontend/src/service/components/table/ZahlungAbschluss.test.tsx
@@ -1,0 +1,145 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Position } from '../../table/Bestellung'
+import type { Tisch } from '../../table/Tisch'
+import { ZahlungAbschluss } from './ZahlungAbschluss'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+const tisch: Tisch = { id: 1, name: 'Stammtisch', saldoCents: 900 }
+
+const position: Position = {
+  positionId: '00000000-0000-0000-0000-000000000001',
+  varianteId: 1,
+  produktName: 'Bratwurst',
+  varianteName: 'Normal',
+  kategorie: 'essen',
+  steuersatz: 'regel',
+  einzelpreisCents: 350,
+  menge: 2,
+  bestellerUserId: 1,
+  bestellerName: 'Tester',
+}
+
+// Die feste Spalte (variant="spalte") ist container-neutral testbar: kein
+// Drawer, kein Dock.
+function renderSpalte(
+  zahlungKassieren: () => Promise<void> = vi.fn().mockResolvedValue(undefined),
+) {
+  const zahlungKassiert = vi.fn()
+  render(
+    <ZahlungAbschluss
+      variant="spalte"
+      backend={{ zahlungKassieren }}
+      tisch={tisch}
+      positionenToPay={[{ ...position, menge: 2 }]}
+      totalCents={700}
+      restNachZahlungCents={200}
+      zahlungKassiert={zahlungKassiert}
+    />,
+  )
+  return { zahlungKassieren, zahlungKassiert }
+}
+
+describe('ZahlungAbschluss (Spalte)', () => {
+  it('zeigt im Leerzustand einen Hinweis und deaktiviert den Aktionsbutton', () => {
+    render(
+      <ZahlungAbschluss
+        variant="spalte"
+        backend={{ zahlungKassieren: vi.fn() }}
+        tisch={tisch}
+        positionenToPay={[]}
+        totalCents={0}
+        restNachZahlungCents={900}
+        zahlungKassiert={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/Positionen auswählen/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Kassieren' })).toBeDisabled()
+  })
+
+  it('zeigt die Restbetrag-Zeile in der Spalte', () => {
+    renderSpalte()
+    expect(screen.getByText('Nach dieser Zahlung noch offen')).toBeVisible()
+    expect(screen.getByText('2,00 €')).toBeInTheDocument()
+  })
+
+  it('rechnet Rückgeld ohne Zielbetrag und Trinkgeld mit Zielbetrag', async () => {
+    const user = userEvent.setup()
+    renderSpalte()
+
+    // Ohne Zielbetrag: Rückgeld = Erhalten − Gesamt.
+    await user.type(screen.getByLabelText('Erhalten'), '10,00')
+    expect(screen.getByText('Rückgeld').nextElementSibling).toHaveTextContent(
+      '3,00',
+    )
+
+    // Mit Zielbetrag (Aufrundung): Trinkgeld = Zielbetrag − Gesamt.
+    await user.type(screen.getByLabelText('Zahlbetrag inkl. Trinkgeld'), '8,00')
+    expect(screen.getByText('Trinkgeld').nextElementSibling).toHaveTextContent(
+      '1,00',
+    )
+    expect(screen.getByText('Rückgeld').nextElementSibling).toHaveTextContent(
+      '2,00',
+    )
+  })
+
+  it('kassiert mit genau einem Backend-Call und der erwarteten Nutzlast (ohne Schlüssel)', async () => {
+    const user = userEvent.setup()
+    const { zahlungKassieren, zahlungKassiert } = renderSpalte()
+
+    await user.click(screen.getByRole('button', { name: 'Kassieren' }))
+
+    await waitFor(() => {
+      expect(zahlungKassieren).toHaveBeenCalledTimes(1)
+    })
+    expect(zahlungKassieren).toHaveBeenCalledWith({
+      tischId: 1,
+      positionen: [{ positionId: position.positionId, menge: 2 }],
+      kommentar: '',
+    })
+    expect(zahlungKassiert).toHaveBeenCalledTimes(1)
+  })
+
+  it('löst bei Doppelklick keinen zweiten Aufruf aus', async () => {
+    const user = userEvent.setup()
+    let resolve: () => void = () => undefined
+    const zahlungKassieren = vi.fn(
+      () =>
+        new Promise<void>((r) => {
+          resolve = r
+        }),
+    )
+    render(
+      <ZahlungAbschluss
+        variant="spalte"
+        backend={{ zahlungKassieren }}
+        tisch={tisch}
+        positionenToPay={[{ ...position, menge: 2 }]}
+        totalCents={700}
+        restNachZahlungCents={200}
+        zahlungKassiert={vi.fn()}
+      />,
+    )
+
+    const button = screen.getByRole('button', { name: 'Kassieren' })
+    await user.click(button)
+    // Zweiter Klick während des laufenden Submits: der Loading-Guard
+    // deaktiviert den Button, es darf kein zweiter Aufruf entstehen.
+    await user.click(button)
+    resolve()
+
+    await waitFor(() => {
+      expect(zahlungKassieren).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/frontend/src/service/components/table/ZahlungAbschluss.tsx
+++ b/frontend/src/service/components/table/ZahlungAbschluss.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { EuroInput } from '@/components/common/EuroInput'
+import { Button } from '@/components/ui/button'
+import {
+  DrawerBody,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+} from '@/components/ui/drawer'
+import { Label } from '@/components/ui/label'
+import { Spinner } from '@/components/ui/spinner'
+import { useActionSubmit } from '@/hooks/use-action-submit'
+import { formatCents, parseCents } from '@/lib/utils'
+
+import type { Position } from '../../table/Bestellung'
+import type { Tisch } from '../../table/Tisch'
+import type { TischBackend } from '../../table/TischBackend'
+import { AbschlussHeader } from './AbschlussHeader'
+import { AbschlussLeer } from './AbschlussLeer'
+import { KommentarField } from './CommentField'
+import {
+  calculateZahlungsbetraege,
+  toPositionRefs,
+  toReceiptItems,
+} from './drawerUtils'
+import { Receipt } from './Receipt'
+import { RestbetragZeile } from './RestbetragZeile'
+
+interface ZahlungAbschlussProps {
+  backend: Pick<TischBackend, 'zahlungKassieren'>
+  tisch: Tisch
+  // Die ausgewählten, zu kassierenden Positionen (mit Auswahl-Menge).
+  positionenToPay: Position[]
+  totalCents: number
+  restNachZahlungCents: number
+  zahlungKassiert: () => void
+  // 'sheet' rendert den Bottom-Sheet-Drawer-Inhalt (Handy), 'spalte' die feste
+  // Abschluss-Spalte (ab lg). Einzige Quelle des Abschluss-Inhalts; die beiden
+  // Varianten unterscheiden sich nur im umschließenden Container.
+  variant: 'sheet' | 'spalte'
+}
+
+// Presentation-neutraler Abschluss-Inhalt des Tisch-Kassierens (Beleg, Erhalten,
+// Zielbetrag inkl. Trinkgeld, Rückgeld, Trinkgeld-Hinweis, Kommentar,
+// „Kassieren"). Trägt den vollständigen Eingabe-State und das Submit-/Fehler-/
+// Retry-Verhalten und wird sowohl im Handy-Drawer als auch in der festen Spalte
+// gerendert. Kein Client-Idempotenz-Schlüssel: die Idempotenz ist zustandsbasiert
+// (bereits bezahlte Positionen → position_nicht_bezahlbar), und der
+// Loading-Guard verhindert den Doppel-Submit.
+export function ZahlungAbschluss(props: ZahlungAbschlussProps) {
+  const [kommentar, setKommentar] = useState('')
+  const [erhaltenEuro, setErhaltenEuro] = useState('')
+  const [zielbetragEuro, setZielbetragEuro] = useState('')
+
+  const noPositionenSelected = props.positionenToPay.length === 0
+
+  // In der dauerhaften Spalte überlebt der Eingabe-State sonst über einen
+  // Auswahl-Reset hinweg. Beim Beginn einer neuen Zusammenstellung (aus dem
+  // Leerzustand) starten die Eingaben deshalb leer, damit nichts aus einer
+  // abgebrochenen Zahlung übertragen wird.
+  const warLeerRef = useRef(noPositionenSelected)
+  useEffect(() => {
+    if (warLeerRef.current && !noPositionenSelected) {
+      setErhaltenEuro('')
+      setZielbetragEuro('')
+      setKommentar('')
+    }
+    warLeerRef.current = noPositionenSelected
+  }, [noPositionenSelected])
+
+  const { rueckgeldCents, trinkgeldCents } = calculateZahlungsbetraege(
+    props.totalCents,
+    parseCents(erhaltenEuro),
+    parseCents(zielbetragEuro),
+  )
+
+  const { loading, run } = useActionSubmit({
+    actionLabel: 'Zahlung kassieren',
+    byCode: {
+      position_nicht_bezahlbar:
+        'Mindestens eine Position ist nicht mehr bezahlbar. Bitte Auswahl aktualisieren.',
+    },
+    onSuccess: () => {
+      setErhaltenEuro('')
+      setZielbetragEuro('')
+      setKommentar('')
+      props.zahlungKassiert()
+    },
+  })
+
+  const onSubmit = async () => {
+    await run(async () => {
+      await props.backend.zahlungKassieren({
+        tischId: props.tisch.id,
+        positionen: toPositionRefs(props.positionenToPay),
+        kommentar,
+      })
+    })
+  }
+
+  const inhalt = (
+    <>
+      <AbschlussHeader
+        variant={props.variant}
+        eyebrow="Zahlung für"
+        title={props.tisch.name}
+        description={`Zahlung für ${props.tisch.name}`}
+      />
+      <DrawerBody className="mx-auto w-full max-w-sm">
+        {noPositionenSelected ? (
+          <AbschlussLeer>Positionen auswählen, um zu kassieren.</AbschlussLeer>
+        ) : (
+          <>
+            <Receipt
+              positionen={toReceiptItems(props.positionenToPay)}
+              totalPrice={props.totalCents}
+            />
+            <div className="px-4 pt-3 flex flex-col gap-2">
+              <div className="flex items-center justify-between gap-3">
+                <Label htmlFor="erhalten">Erhalten</Label>
+                <EuroInput
+                  id="erhalten"
+                  value={erhaltenEuro}
+                  onValueChange={setErhaltenEuro}
+                  className="w-28"
+                />
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <Label htmlFor="zielbetrag">Zahlbetrag inkl. Trinkgeld</Label>
+                <EuroInput
+                  id="zielbetrag"
+                  value={zielbetragEuro}
+                  onValueChange={setZielbetragEuro}
+                  aria-describedby="zielbetrag-hinweis"
+                  className="w-28"
+                />
+              </div>
+              <p
+                id="zielbetrag-hinweis"
+                className="text-xs text-muted-foreground"
+              >
+                Nur ausfüllen, wenn der Gast aufrundet: den vollen Betrag
+                inklusive Trinkgeld eintragen, dann rechnet die Kasse das
+                Rückgeld passend.
+              </p>
+              {rueckgeldCents !== null && (
+                <div className="flex items-baseline justify-between pt-1">
+                  <div className="text-[15px] font-semibold">Rückgeld</div>
+                  <div className="text-xl font-bold tabular-nums">
+                    {formatCents(rueckgeldCents)}&nbsp;€
+                  </div>
+                </div>
+              )}
+              {trinkgeldCents !== null && (
+                <>
+                  <div className="flex justify-between font-medium">
+                    <div>Trinkgeld</div>
+                    <div className="tabular-nums">
+                      {formatCents(trinkgeldCents)}&nbsp;€
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Trinkgeld wird nicht als Kasseneinnahme gebucht und gehört
+                    nicht in die Kassenlade.
+                  </p>
+                </>
+              )}
+            </div>
+            <div className="px-4 pt-3">
+              <KommentarField
+                value={kommentar}
+                onChange={(value) => {
+                  setKommentar(value)
+                }}
+              />
+            </div>
+          </>
+        )}
+      </DrawerBody>
+      <DrawerFooter className="mx-auto w-full max-w-sm">
+        {props.variant === 'spalte' && (
+          <RestbetragZeile cents={props.restNachZahlungCents} />
+        )}
+        <Button
+          disabled={loading || noPositionenSelected}
+          onClick={() => {
+            void onSubmit()
+          }}
+        >
+          {loading ? <Spinner /> : null} Kassieren
+        </Button>
+        {props.variant === 'sheet' && (
+          <DrawerClose asChild>
+            <Button variant="outline" disabled={loading}>
+              Abbrechen
+            </Button>
+          </DrawerClose>
+        )}
+      </DrawerFooter>
+    </>
+  )
+
+  if (props.variant === 'sheet') {
+    return <DrawerContent pending={loading}>{inhalt}</DrawerContent>
+  }
+
+  // Feste Spalte: dieselben Body/Footer-Primitive wie im Sheet, nur in einem
+  // eigenen, unabhängig scrollenden Container. group/drawer-content +
+  // data-pending übernehmen das Body-Dimming des Drawers während des Submits.
+  return (
+    <aside
+      data-pending={loading || undefined}
+      className="group/drawer-content flex min-h-0 flex-col overflow-hidden rounded-xl border bg-popover text-sm text-popover-foreground"
+    >
+      {inhalt}
+    </aside>
+  )
+}

--- a/frontend/src/service/components/table/ZahlungDrawer.tsx
+++ b/frontend/src/service/components/table/ZahlungDrawer.tsx
@@ -1,37 +1,15 @@
 import { useState } from 'react'
 
-import { EuroInput } from '@/components/common/EuroInput'
-import { Button } from '@/components/ui/button'
-import {
-  Drawer,
-  DrawerBody,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from '@/components/ui/drawer'
-import { Label } from '@/components/ui/label'
-import { Spinner } from '@/components/ui/spinner'
-import { useActionSubmit } from '@/hooks/use-action-submit'
-import { formatCents, parseCents } from '@/lib/utils'
+import { Drawer, DrawerTrigger } from '@/components/ui/drawer'
 
 import type { Position } from '../../table/Bestellung'
 import type { Tisch } from '../../table/Tisch'
 import type { TischBackend } from '../../table/TischBackend'
 import { DockActionSlot } from '../ServiceDock'
-import { KommentarField } from './CommentField'
 import { DockActionButton } from './DockActionButton'
-import {
-  calculateTotalPrice,
-  calculateZahlungsbetraege,
-  selectPositionen,
-  toPositionRefs,
-  toReceiptItems,
-} from './drawerUtils'
-import { Receipt } from './Receipt'
+import { calculateTotalPrice, selectPositionen } from './drawerUtils'
+import { RestbetragZeile } from './RestbetragZeile'
+import { ZahlungAbschluss } from './ZahlungAbschluss'
 
 interface ZahlungDrawerProps {
   backend: Pick<TischBackend, 'zahlungKassieren'>
@@ -42,66 +20,28 @@ interface ZahlungDrawerProps {
   zahlungKassiert: () => void
 }
 
+// Handy-Container (unter lg): Dock-Aktionsbutton als Trigger, die Restbetrag-
+// Zeile im Dock-Slot plus Bottom-Sheet-Drawer mit dem gemeinsamen
+// Abschluss-Inhalt. Ab lg rendert die Fläche stattdessen die feste
+// Abschluss-Spalte (siehe Zahlung), die die Restbetrag-Zeile selbst trägt.
 export function ZahlungDrawer(props: ZahlungDrawerProps) {
   const [open, setOpen] = useState(false)
-  const [kommentar, setKommentar] = useState('')
-  const [erhaltenEuro, setErhaltenEuro] = useState('')
-  const [zielbetragEuro, setZielbetragEuro] = useState('')
   const positionenToPay = selectPositionen(
     props.unbezahltePositionen,
     props.mengen,
   )
   const totalPrice = calculateTotalPrice(positionenToPay)
   const anzahl = positionenToPay.reduce((sum, p) => sum + p.menge, 0)
-  const { rueckgeldCents, trinkgeldCents } = calculateZahlungsbetraege(
-    totalPrice,
-    parseCents(erhaltenEuro),
-    parseCents(zielbetragEuro),
-  )
   const noPositionenSelected = positionenToPay.length === 0
 
-  const { loading, run } = useActionSubmit({
-    actionLabel: 'Zahlung kassieren',
-    byCode: {
-      position_nicht_bezahlbar:
-        'Mindestens eine Position ist nicht mehr bezahlbar. Bitte Auswahl aktualisieren.',
-    },
-    onSuccess: () => {
-      props.zahlungKassiert()
-      setOpen(false)
-      setErhaltenEuro('')
-      setZielbetragEuro('')
-    },
-  })
-
-  const onSubmit = async () => {
-    await run(async () => {
-      await props.backend.zahlungKassieren({
-        tischId: props.tisch.id,
-        positionen: toPositionRefs(positionenToPay),
-        kommentar,
-      })
-    })
-  }
-
   const onOpenChange = (isOpen: boolean) => {
-    const nextOpen = noPositionenSelected ? false : isOpen
-    setOpen(nextOpen)
-    if (!nextOpen) {
-      setErhaltenEuro('')
-      setZielbetragEuro('')
-    }
+    setOpen(noPositionenSelected ? false : isOpen)
   }
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DockActionSlot>
-        <div className="flex items-center justify-between gap-3 text-[13px] text-muted-foreground">
-          <span>Nach dieser Zahlung noch offen</span>
-          <span className="font-semibold tabular-nums text-foreground">
-            {formatCents(props.restNachZahlungCents)}&nbsp;€
-          </span>
-        </div>
+        <RestbetragZeile cents={props.restNachZahlungCents} />
       </DockActionSlot>
       <DrawerTrigger asChild>
         <DockActionButton
@@ -111,98 +51,18 @@ export function ZahlungDrawer(props: ZahlungDrawerProps) {
           disabled={noPositionenSelected}
         />
       </DrawerTrigger>
-      <DrawerContent pending={loading}>
-        <DrawerHeader className="mx-auto w-full max-w-sm">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Zahlung für
-          </p>
-          <DrawerTitle className="text-[22px] font-semibold">
-            {props.tisch.name}
-          </DrawerTitle>
-          <DrawerDescription className="sr-only">
-            Zahlung für {props.tisch.name}
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerBody className="mx-auto w-full max-w-sm">
-          <Receipt
-            positionen={toReceiptItems(positionenToPay)}
-            totalPrice={totalPrice}
-          />
-          <div className="px-4 pt-3 flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-3">
-              <Label htmlFor="erhalten">Erhalten</Label>
-              <EuroInput
-                id="erhalten"
-                value={erhaltenEuro}
-                onValueChange={setErhaltenEuro}
-                className="w-28"
-              />
-            </div>
-            <div className="flex items-center justify-between gap-3">
-              <Label htmlFor="zielbetrag">Zahlbetrag inkl. Trinkgeld</Label>
-              <EuroInput
-                id="zielbetrag"
-                value={zielbetragEuro}
-                onValueChange={setZielbetragEuro}
-                aria-describedby="zielbetrag-hinweis"
-                className="w-28"
-              />
-            </div>
-            <p
-              id="zielbetrag-hinweis"
-              className="text-xs text-muted-foreground"
-            >
-              Nur ausfüllen, wenn der Gast aufrundet: den vollen Betrag
-              inklusive Trinkgeld eintragen, dann rechnet die Kasse das Rückgeld
-              passend.
-            </p>
-            {rueckgeldCents !== null && (
-              <div className="flex items-baseline justify-between pt-1">
-                <div className="text-[15px] font-semibold">Rückgeld</div>
-                <div className="text-xl font-bold tabular-nums">
-                  {formatCents(rueckgeldCents)}&nbsp;€
-                </div>
-              </div>
-            )}
-            {trinkgeldCents !== null && (
-              <>
-                <div className="flex justify-between font-medium">
-                  <div>Trinkgeld</div>
-                  <div className="tabular-nums">
-                    {formatCents(trinkgeldCents)}&nbsp;€
-                  </div>
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  Trinkgeld wird nicht als Kasseneinnahme gebucht und gehört
-                  nicht in die Kassenlade.
-                </p>
-              </>
-            )}
-          </div>
-          <div className="px-4 pt-3">
-            <KommentarField
-              onChange={(value) => {
-                setKommentar(value)
-              }}
-            />
-          </div>
-        </DrawerBody>
-        <DrawerFooter className="mx-auto w-full max-w-sm">
-          <Button
-            disabled={loading}
-            onClick={() => {
-              void onSubmit()
-            }}
-          >
-            {loading ? <Spinner /> : null} Kassieren
-          </Button>
-          <DrawerClose asChild>
-            <Button variant="outline" disabled={loading}>
-              Abbrechen
-            </Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
+      <ZahlungAbschluss
+        variant="sheet"
+        backend={props.backend}
+        tisch={props.tisch}
+        positionenToPay={positionenToPay}
+        totalCents={totalPrice}
+        restNachZahlungCents={props.restNachZahlungCents}
+        zahlungKassiert={() => {
+          setOpen(false)
+          props.zahlungKassiert()
+        }}
+      />
     </Drawer>
   )
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,23 @@
 import '@testing-library/jest-dom/vitest'
+
+// jsdom implementiert window.matchMedia nicht. useIsMobile (Service-Split,
+// ADR 07/08) ruft es im Effect auf; ohne Polyfill würde jede Komponente, die
+// den Hook nutzt, im Test werfen. useIsMobile liest die Breite über
+// window.innerWidth (jsdom: 1024px ≥ lg → Desktop), nicht über `matches`;
+// Tests fürs schmale Handy-Layout mocken useIsMobile explizit auf true.
+// `prefers-reduced-motion` wird bewusst als aktiv gemeldet, damit bewegungs-
+// abhängige Hooks (useCountUp) im Test weiterhin sofort den Endwert liefern
+// statt zu animieren.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = (query: string): MediaQueryList =>
+    ({
+      matches: query.includes('prefers-reduced-motion'),
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }) as MediaQueryList
+}


### PR DESCRIPTION
Setzt den Plan `docs/plans/plan-service-split-screen.md` (PRD `docs/prds/prd-service-split-screen-tablet.md`, ADR 08) vollständig um: Der Service-Bereich wird ab `lg` (1024px) responsiv zweispaltig. Unter `lg` bleibt alles unverändert (einspaltig, fixierte Dock-Leiste, Bottom-Sheet-Drawer). Reiner Präsentations-Layer — freeze-konform, nur `frontend/src/service/**`, das Drawer-Primitive und `docs/`.

## Was sich ändert

Ab `lg` erhalten die drei Zusammenstellungs-Flächen eine dauerhaft sichtbare Abschluss-Spalte (Auswahl links, Abschluss rechts), die Reiter liegen oben im Inhaltsbereich, die fixierte Dock-Leiste entfällt. Der heutige Drawer-Inhalt jeder Fläche wurde als **eine** darstellungsneutrale Abschluss-Komponente extrahiert und wird in beiden Containern gerendert (`variant: 'sheet' | 'spalte'`); die Container-Wahl trifft `useIsMobile()`, damit der Inhalt genau einmal mountet.

## Phasen (je ein Commit, jeweils grün)

1. **Direktverkauf-Verkaufen** zweispaltig + `DirektverkaufAbschluss`, ADR 08, README. Fix-Commit: Eingabe-Reset am Vorgangswechsel, kontrolliertes Kommentarfeld, robustere Split-Höhe.
2. **Tisch-Bestellen** zweispaltig + `BestellungAbschluss`; `TablePage`-Shell responsiv.
3. **Tisch-Kassieren** zweispaltig + `ZahlungAbschluss`; Restbetrag-Zeile geteilt (Dock-Slot schmal, Spalten-Footer breit). **Kein** Client-Idempotenz-Schlüssel — Kassieren bleibt zustandsbasiert, der Loading-Guard verhindert den Doppel-Submit.
4. **Korrekturvorgänge** (Storno/Umbuchung Tisch, Storno Direktverkauf) ab `lg` als mittig zentrierter Dialog statt Bottom-Sheet — responsive Variante im einen `DrawerContent`, kein Fork. Der ADR-03-Handy-Vertrag (85dvh, Safe-Area, ein Scrollbereich, kein Drag-Handle) gilt unter `lg` unverändert.

## Idempotenz & Eingabe-State

- `verkaufId`/`bestellungId` werden je logischem Vorgang erzeugt (Beginn aus dem Leerzustand, erneut nach erfolgreichem Abschluss) und sind über einen Retry stabil.
- Eingaben (Erhalten/Zielbetrag/Kommentar) werden je Vorgang zurückgesetzt (nicht beim Drawer-Schließen) — bewusst vereinheitlicht für Handy und Spalte, ohne Geld-/Nutzlast-Effekt (in ADR 08 festgehalten).

## Tests

Verhaltenstests statt Container/CSS. Die extrahierten Abschluss-Komponenten werden container-neutral geprüft (Beträge, Nutzlast, genau ein Backend-Call, Schlüssel-Stabilität, Leerzustand); die bestehenden Drawer-Verhaltenstests laufen unverändert weiter; dünne Desktop-Smoke-Tests decken die Split-Verdrahtung ab. Ein `matchMedia`-Polyfill (`src/test/setup.ts`) verhindert, dass `useIsMobile` im Test wirft, und hält `useCountUp` nicht-animierend. Zweispaltige Darstellung und Breakpoint-Verhalten sind manuelle Abnahme (keine Snapshot-Tests).

`make check` (frontend: `format:check`, `lint`, `test` = 414, `build`) grün. Kein Backend/Schema/Event/API berührt.

## Review-Hinweise

- **Sicherheitsrelevant:** Tisch-Kassieren und Direktverkauf sind die geld-/kassenrelevanten Flächen. Die Extraktion ist verhaltensgleich zum bisherigen Drawer; Nutzlasten, Betragsberechnung und der Doppel-Submit-Guard sind unverändert.
- Jede Phase wurde von einem separaten Reviewer auf Korrektheit, Einfachheit und Scope geprüft; gemeldete Punkte sind eingearbeitet oder in ADR 08 dokumentiert.
- Manuell abzunehmen: Zweispalt und Dialog-Präsentation über die Breakpoints (schmal, Querformat-Tablet, Laptop; Hell/Dunkel).