### PR TITLE
docs: add PRD and plan for UI refinements

### DIFF
--- a/docs/plans/plan-ui-refinements.md
+++ b/docs/plans/plan-ui-refinements.md
@@ -1,0 +1,336 @@
+# Plan: UI-Verfeinerungen (Dashboard, Produktstatistik, Autofokus, Tischsuche)
+
+> Source PRD: `docs/prds/prd-ui-refinements.md`
+
+## Goal
+
+Mehrere zusammenhängende UI-Reibungspunkte beheben — mobil-first, für
+ehrenamtliche Helfer unter Stress:
+
+1. Admin-Übersicht: Stornierungen über die Produktstatistik ziehen; die
+   Produktstatistik-Liste scrollbar deckeln.
+2. Produkt-„Umsatz" auf dieselbe Ereignis-Grundlage wie „Ausgegeben" stellen
+   (bestellbasiert), Beschreibungstext kürzen.
+3. Automatisches Öffnen der Mobil-Tastatur beim Öffnen von Overlays zentral
+   unterbinden; Admin-Dialoge scrollbar mit gepinnter Aktionsleiste machen.
+4. Service-Hauptsuche über alle aktiven Tische statt nur Favoriten; zweite
+   Suche im „Alle Tische"-Drawer entfernen.
+5. Politur: Zählhilfe-Touch-Ziele, `formatEuro`-Konsistenz, Begriffe.
+
+## Architectural decisions
+
+Durable decisions across all phases:
+
+- **Keine Schema-/Event-Änderungen.** Freeze-Disziplin gewahrt: nur ein
+  Read-Query-Eingriff (`GetProduktStatistik`), keine Migration, keine
+  Event-Format-Änderung, keine persistierten Daten berührt.
+- **Backend als Single Source of Truth.** Die Umsatz-Definition ändert sich in
+  der SQL-Query, nicht im Frontend. Frontend-DTOs/Typen (`ProduktStatistik`,
+  `VarianteStatistik` mit `umsatzCents`/`ausgegebeneMenge`) bleiben unverändert
+  — nur der gelieferte Zahlenwert ändert sich.
+- **Fiskalische Größen bleiben kassenbasiert.** `GetUmsatzPositionszeilen`
+  (Steuer-Aufschlüsselung, DSFinV-K, „Kassierter Umsatz"-KPI, Umsatz je
+  Servicekraft) wird **nicht** angefasst. Nur die Produktstatistik
+  (`GetProduktStatistik`) wechselt auf Bestellbasis.
+- **Zentrale Overlay-Primitive.** Autofokus-Unterdrückung und
+  Dialog-Scroll/Fußleiste werden in den geteilten `components/ui`-Primitiven
+  gelöst, nicht je Aufrufstelle. Der Drawer ist bereits Vorbild
+  (`max-h-[85dvh]` + einziger Scrollbereich `DrawerBody` + gepinnter Footer).
+- **„Meine Tische" = Favoriten** bleibt bestehen; kein neues „zuletzt
+  bearbeitet"-Konzept. Die Hauptsuche wechselt lediglich die Datenquelle beim
+  Suchen auf „alle aktiven Tische".
+- **Kanonische Begriffe** laut `docs/language.md`: Rolle = „Servicekraft";
+  Person mit Zugang = „Benutzer"; Zugang/Credential = „Benutzername". Für die
+  Helfer-Verwaltung wird die **Person** durchgängig „Helfer" genannt (Feld
+  „Benutzername" bleibt).
+
+## Inventory
+
+**Dashboard / Reporting (Frontend):**
+- `frontend/src/admin/reporting/LiveReportingSection.tsx` — Live-Übersicht;
+  enthält den `VerkaufStatistik`-Block und darunter den Stornierungen-
+  `Collapsible` (zu vertauschen). Nutzt `formatBediener`.
+- `frontend/src/admin/reporting/VerkaufStatistik.tsx` — geteilte
+  Produktstatistik-Tabelle; Beschreibungs-`<p>` und Listen-Wrapper
+  (`<div className="overflow-hidden rounded-lg border">`) ohne Höhen-Cap.
+- `frontend/src/admin/reporting/ReportingResults.tsx` — „Berichte & Export";
+  rendert `VerkaufStatistik`, Stornierungen stehen dort bereits darüber.
+- `frontend/src/admin/reporting/KassenberichtePage.tsx` — Seitenrahmen „Berichte
+  & Export".
+
+**Umsatz-Query (Backend):**
+- `backend/sqlc/queries/reporting.sql — GetProduktStatistik` — der Umsatz-Term
+  (`umsatz_cents`) und der WHERE-Event-Filter; Doc-Kommentar darüber.
+- `backend/sqlc/dbgen/reporting.sql.go` — generiert; via `make sqlc`
+  neu erzeugen, **nie** von Hand editieren.
+- `backend/api/reporting/application/query.go — gruppiereProduktStatistik()` —
+  summiert `umsatz_cents`/`ausgegebene_menge`; bleibt unverändert.
+- `backend/repository/reporting_repo/repo_test.go`,
+  `backend/api/reporting/application/query_test.go` — Prior-Art-Tests für die
+  Produktstatistik.
+- `backend/api/reporting/application/query_export_konsistenz_test.go` — prüft
+  Steuer-Aufschlüsselung gegen DSFinV-K über `GetUmsatzPositionszeilen`;
+  **nicht** betroffen (verifiziert).
+
+**Overlay-Primitive (Frontend):**
+- `frontend/src/components/ui/drawer.tsx` — Vorbild: `DrawerBody` als einziger
+  Scrollbereich, `max-h-[85dvh]`, gepinnter Footer.
+- `frontend/src/components/ui/dialog.tsx`, `frontend/src/components/ui/sheet.tsx`,
+  `frontend/src/components/ui/alert-dialog.tsx` — Radix-Wrapper ohne
+  `onOpenAutoFocus`-Override; `dialog.tsx`/`alert-dialog.tsx` ohne Höhen-Cap/
+  internen Scroll.
+
+**Service-Suche (Frontend):**
+- `frontend/src/service/TableSelectionPage.tsx` — Hauptseite; `suche`-State
+  filtert `useMeineTischeState()` (favoritengebunden).
+- `frontend/src/service/components/TischAuswahlDrawer.tsx` — „Alle Tische"-
+  Drawer; eigener `suche`-State über `useAktiveTischeMitFavoriten()`.
+- `frontend/src/service/table/hooks.ts — useMeineTischeState`,
+  `useAktiveTischeMitFavoriten` — Datenquellen.
+- `frontend/src/service/components/MeinTischCard.tsx` — Navigation zum Tisch.
+- `frontend/src/service/TablePage.test.tsx`,
+  `frontend/src/service/components/TischAuswahlDrawer.test.tsx` — Prior-Art-Tests.
+
+**Politur (Frontend):**
+- `frontend/src/admin/kasse/ZaehlhilfeDialog.tsx` — Zähl-Eingaben `h-8 w-20`.
+- `frontend/src/lib/utils.ts — formatEuro()` (geschütztes Leerzeichen),
+  `formatCents()`.
+- `frontend/src/admin/kasse/KasseAbschliessenSection.tsx`,
+  `frontend/src/service/components/TischAuswahlDrawer.tsx` — nutzen
+  `` `${formatCents(x)} €` `` mit normalem Leerzeichen.
+- `frontend/src/admin/users/NewUserDialog.tsx`,
+  `frontend/src/admin/users/EditUserDialog.tsx`,
+  `frontend/src/admin/users/AdminUsersPage.tsx` — „Helfer"/„Benutzer" gemischt.
+- `frontend/src/admin/reporting/utils.ts — formatBediener()` (+ Aufrufer
+  `LiveReportingSection.tsx`, `StornoItem.tsx`, `StornoServicekraft.tsx`,
+  `ReportingResults.tsx`) — internes Bezeichner-Naming „Bediener".
+- `docs/language.md` — Begriffs-Quelle der Wahrheit.
+
+## Resolved decisions
+
+- **Umsatz-Grundlage:** Produkt-Umsatz nutzt dieselbe Ereignismenge/Gewichtung
+  wie „Ausgegeben" (`bestellung-aufgenommen` +, `bestellung-korrigiert` −,
+  `direktverkauf-getaetigt` +), gewichtet mit `einzelpreisCents × menge`. Die
+  Event-Typen `zahlung-kassiert`, `stornierung-erteilt`, `direktverkauf-storniert`
+  entfallen im Umsatz-Term und im WHERE-Filter der Query.
+- **Umsatz-Reichweite:** beide Seiten (Übersicht **und** „Berichte & Export").
+- **Autofokus:** zentral in allen Overlays (Drawer/Dialog/Sheet) unterdrückt;
+  `AlertDialog` (Bestätigungen) bleibt button-fokussiert.
+- **Tischsuche:** Hauptsuche über alle aktiven Tische, Treffer öffnet Tisch
+  direkt; zweites Suchfeld im Drawer entfällt.
+- **Begriff Person:** „Helfer" durchgängig in der Helfer-Verwaltung; „Benutzername"
+  als Feld bleibt.
+- **Beschreibungstext** der Produktstatistik: kurze Aussage, z. B. „Zahlen
+  basieren auf Bestellungen".
+
+## Open questions / Risks
+
+- **Produkt-Umsatz ≠ Kassierter Umsatz bei Stornos.** Bewusst und in der PRD
+  dokumentiert. Prior-Art-Tests, die für die Produktstatistik implizit
+  Umsatz = kassiert annehmen, sind entsprechend auf die Bestellbasis
+  anzupassen (siehe Phase 2). Der DSFinV-K/Steuer-Konsistenztest ist **nicht**
+  betroffen (verifiziert, andere Query).
+- **`formatBediener`-Umbenennung** ist ein rein internes Bezeichner-Refactoring
+  (keine benutzer-sichtbare „Bediener"-Zeichenkette; Überschriften lauten bereits
+  „Servicekraft"). Niedriges Risiko, aber mehrere Aufrufstellen.
+
+---
+
+## Phase 1: Dashboard umsortieren und Produktstatistik scrollbar
+
+**User stories**: 1, 2
+
+### Context
+
+- `frontend/src/admin/reporting/LiveReportingSection.tsx` — die zwei
+  Geschwister-Blöcke (Produktstatistik-`<div>` und Stornierungen-`Collapsible`)
+  stehen in einer `space-y-6`-Spalte; Reihenfolge tauschen (Stornierungen
+  zuerst). Rein präsentational, kein geteilter State.
+- `frontend/src/admin/reporting/VerkaufStatistik.tsx` — Listen-Wrapper erhält
+  Höhen-Cap + `overflow-y-auto`, sodass die Liste innerhalb ihres Rahmens
+  scrollt. Wirkt geteilt auch auf „Berichte & Export".
+- `frontend/src/admin/reporting/ReportingResults.tsx` — hat Stornierungen
+  bereits über `VerkaufStatistik`; profitiert nur vom Scroll-Cap, keine
+  Umsortierung nötig.
+
+### What to build
+
+Auf der Live-Übersicht erscheint der Stornierungen-Block über der
+Produktstatistik. Die Produktstatistik-Tabelle bekommt eine sinnvolle maximale
+Höhe mit eigenem vertikalem Scroll, damit sie bei vielen Produkten die Seite
+nicht überlängt — auf Übersicht und „Berichte & Export".
+
+### Acceptance criteria
+
+- [ ] Auf der Admin-Übersicht steht der Stornierungen-Abschnitt oberhalb von
+      „Verkäufe pro Produkt".
+- [ ] Die Produktstatistik-Liste scrollt innerhalb eines gedeckelten Bereichs
+      statt die Seite unbegrenzt zu verlängern — auf beiden Seiten.
+- [ ] Auf „Berichte & Export" bleibt die bestehende Reihenfolge (Stornierungen
+      vor Produktstatistik) erhalten.
+- [ ] `make lint` ist grün; keine Änderung an gelieferten Zahlen.
+
+---
+
+## Phase 2: Produkt-Umsatz auf Bestellbasis + Beschreibungstext
+
+**User stories**: 3, 4
+
+### Context
+
+- `backend/sqlc/queries/reporting.sql — GetProduktStatistik` — Umsatz-Term auf
+  dieselbe Ereignismenge/Gewichtung wie den Ausgegeben-Term umstellen; die drei
+  kassenbasierten Event-Typen aus Umsatz-`CASE` und WHERE-Filter entfernen;
+  Doc-Kommentar (Grundlage + Cross-Reference auf `GetUmsatzPositionszeilen`)
+  aktualisieren.
+- `make sqlc` regeneriert `backend/sqlc/dbgen/reporting.sql.go` (nicht manuell
+  editieren).
+- `backend/api/reporting/application/query.go — gruppiereProduktStatistik()` —
+  unverändert (summiert nur die gelieferten Felder).
+- `frontend/src/admin/reporting/VerkaufStatistik.tsx` — Beschreibungs-`<p>` auf
+  kurze Aussage kürzen (z. B. „Zahlen basieren auf Bestellungen").
+- `backend/repository/reporting_repo/repo_test.go`,
+  `backend/api/reporting/application/query_test.go` — Produktstatistik-Tests auf
+  die neue Bestellbasis anpassen/ergänzen.
+
+### What to build
+
+Der Produkt-Umsatz je Variante ist der Euro-Wert (zu Bestellzeit-Preisen) genau
+der Portionen, die „Ausgegeben" zählt. Nachträgliche Stornierungen und
+kassierte Zahlungen fließen nicht mehr in den Produkt-Umsatz ein. Die
+Tabellenbeschreibung wird auf eine knappe Aussage reduziert. „Kassierter
+Umsatz"-KPI, Umsatz je Servicekraft und Steuer-/DSFinV-K-Größen bleiben
+kassenbasiert.
+
+### Acceptance criteria
+
+- [ ] `GetProduktStatistik` liefert Umsatz je Variante = Σ
+      `einzelpreisCents × menge` über `bestellung-aufgenommen` (+),
+      `bestellung-korrigiert` (−), `direktverkauf-getaetigt` (+).
+- [ ] Eine nachträgliche kassenwirksame Stornierung reduziert den
+      Produkt-Umsatz **nicht** (Test belegt das).
+- [ ] Die separate „Kassierter Umsatz"-KPI/Steueraufschlüsselung bleibt
+      kassenbasiert unverändert (DSFinV-K-Konsistenztest weiterhin grün).
+- [ ] Der Beschreibungstext über der Tabelle ist auf eine kurze Aussage gekürzt.
+- [ ] `make sqlc` ausgeführt, `dbgen` regeneriert; `make verify` grün.
+
+---
+
+## Phase 3: Autofokus zentral unterdrücken + Admin-Dialoge scrollbar
+
+**User stories**: 5, 6, 9
+
+### Context
+
+- `frontend/src/components/ui/dialog.tsx`,
+  `frontend/src/components/ui/drawer.tsx`,
+  `frontend/src/components/ui/sheet.tsx` — Radix `onOpenAutoFocus` beim Öffnen
+  verhindern (kein Auto-Fokus auf das erste Feld), ohne Fokus-Trap/Escape/
+  Fokusrückgabe zu brechen.
+- `frontend/src/components/ui/dialog.tsx`,
+  `frontend/src/components/ui/alert-dialog.tsx` — Höhen-Cap (analog Drawer
+  `max-h-[85dvh]`) + intern scrollender Inhaltsbereich + gepinnte Fußleiste, so
+  dass die Aktionsschaltflächen bei geöffneter Tastatur/viel Inhalt erreichbar
+  bleiben. `drawer.tsx` (`DrawerBody`-Muster) als Vorbild.
+- `frontend/src/service/components/table/BestellungAbschluss.tsx` — bestes
+  Beispiel für den Autofokus-Test (erstes Feld ist das optionale Kommentarfeld).
+
+### What to build
+
+Kein Overlay öffnet beim Erscheinen automatisch die Mobil-Tastatur; der Nutzer
+tippt selbst das gewünschte Feld an. Admin-`Dialog`/`AlertDialog` bekommen die
+Drawer-Behandlung (Höhen-Cap, interner Scroll, gepinnte Fußleiste), damit die
+primäre Aktion nie hinter der Tastatur oder unterhalb des Inhalts verschwindet.
+
+### Acceptance criteria
+
+- [ ] Beim Öffnen von Drawer/Dialog/Sheet erhält **kein** Eingabefeld den Fokus
+      (Test am Bestell-Drawer belegt: `document.activeElement` ist kein Input).
+- [ ] `AlertDialog`-Bestätigungen bleiben unverändert (button-fokussiert).
+- [ ] Admin-Formulardialoge (u. a. Zählhilfe, Kassenabschluss, Produkt-/Tisch-/
+      Benutzer-Dialoge) haben einen Höhen-Cap mit internem Scroll und gepinnter
+      Fußleiste; die Absende-Schaltfläche bleibt erreichbar.
+- [ ] Tastaturbedienung (Tab-Fokus-Trap, Escape, Fokusrückgabe) funktioniert
+      weiter; `make lint` grün.
+
+---
+
+## Phase 4: Tischsuche über alle Tische vereinheitlichen
+
+**User stories**: 7, 8
+
+### Context
+
+- `frontend/src/service/TableSelectionPage.tsx` — bei leerem Suchfeld weiterhin
+  Favoriten anzeigen; sobald gesucht wird, über alle aktiven Tische filtern
+  (Datenquelle `useAktiveTischeMitFavoriten()` nutzen) und einen Treffer direkt
+  öffnen. Vorhandene „In allen Tischen suchen"-Notlösung entfällt damit.
+- `frontend/src/service/table/hooks.ts — useMeineTischeState`,
+  `useAktiveTischeMitFavoriten` — favoriten- vs. alle-aktiven-Datenquelle.
+- `frontend/src/service/components/TischAuswahlDrawer.tsx` — eigenes Suchfeld
+  (`suche`-State + `Input`) entfernen; Drawer bleibt zum Durchblättern/
+  Favorisieren.
+- `frontend/src/service/components/MeinTischCard.tsx` — Navigationsmuster zum
+  Tisch als Vorbild für Treffer-Navigation.
+- `frontend/src/service/TablePage.test.tsx`,
+  `frontend/src/service/components/TischAuswahlDrawer.test.tsx` — Prior-Art.
+
+### What to build
+
+Die Suche auf der Service-Hauptseite findet jeden aktiven Tisch (nicht nur
+Favoriten) und öffnet ihn per Treffer direkt. Der „Alle Tische"-Drawer bleibt
+für das Durchblättern und Favorisieren, hat aber kein eigenes Suchfeld mehr.
+
+### Acceptance criteria
+
+- [ ] Ein Suchbegriff auf der Hauptseite, der auf einen **nicht favorisierten**
+      aktiven Tisch passt, zeigt diesen als Treffer (Test belegt das).
+- [ ] Ein Treffer öffnet den Tisch direkt.
+- [ ] Bei leerem Suchfeld zeigt die Hauptseite unverändert die Favoriten
+      („Meine Tische"), gruppiert in „Noch offen"/„Erledigt".
+- [ ] Der „Alle Tische"-Drawer hat kein zweites Suchfeld mehr, bleibt aber zum
+      Durchblättern/Favorisieren funktionsfähig.
+- [ ] `make lint` grün; bestehende Service-Tabellentests grün.
+
+---
+
+## Phase 5: Politur — Touch-Ziele, Währungsformat, Begriffe
+
+**User stories**: 10, 11, 12
+
+### Context
+
+- `frontend/src/admin/kasse/ZaehlhilfeDialog.tsx` — Zähl-Eingaben von `h-8` auf
+  ein mobiltaugliches Touch-Maß (mind. ~44 px Höhe) vergrößern, Layout kompakt
+  halten.
+- `frontend/src/lib/utils.ts — formatEuro()` — vorhandene Hilfe mit geschütztem
+  Leerzeichen; in Admin-Code statt `` `${formatCents(x)} €` `` verwenden
+  (`frontend/src/admin/kasse/KasseAbschliessenSection.tsx`,
+  `frontend/src/service/components/TischAuswahlDrawer.tsx`).
+- `frontend/src/admin/users/NewUserDialog.tsx`,
+  `frontend/src/admin/users/EditUserDialog.tsx`,
+  `frontend/src/admin/users/AdminUsersPage.tsx` — Person durchgängig „Helfer"
+  (Trigger, Titel, Schaltfläche, Toast); „Benutzername"-Feld bleibt.
+- `frontend/src/admin/reporting/utils.ts — formatBediener()` (+ Aufrufer) —
+  internes Bezeichner-Refactoring zur Domänenkonsistenz („Servicekraft"); keine
+  benutzer-sichtbare Änderung.
+- `docs/language.md` — bei benutzer-sichtbaren Begriffsänderungen Ist/Soll
+  angleichen.
+
+### What to build
+
+Kleinere Konsistenz- und Ergonomie-Politur: größere Zählhilfe-Eingaben, überall
+`formatEuro` für Beträge (kein umbrechendes „€"), und einheitliche Begriffe
+(Person = „Helfer" in der Verwaltung; interne `formatBediener`-Benennung an
+„Servicekraft" angleichen).
+
+### Acceptance criteria
+
+- [ ] Zählhilfe-Eingaben erfüllen ein mobiltaugliches Touch-Maß (≥ ~44 px Höhe).
+- [ ] Admin-seitige Beträge nutzen `formatEuro`; „€" bricht nicht mehr allein um.
+- [ ] Die Helfer-Verwaltung nennt die Person durchgängig „Helfer" (Trigger,
+      Titel, Schaltfläche, Toast); das Zugangsfeld heißt weiter „Benutzername".
+- [ ] `formatBediener` ist zur Domänenkonsistenz umbenannt; keine
+      benutzer-sichtbare „Bediener"-Zeichenkette verbleibt.
+- [ ] `docs/language.md` spiegelt geänderte benutzer-sichtbare Begriffe;
+      `make lint` grün.

--- a/docs/prds/prd-ui-refinements.md
+++ b/docs/prds/prd-ui-refinements.md
@@ -1,0 +1,238 @@
+# PRD: UI-Verfeinerungen (Dashboard, Produktstatistik, Autofokus, Tischsuche)
+
+## Problem Statement
+
+Mehrere zusammenhängende UI-Reibungspunkte erschweren die Bedienung — besonders
+mobil (BYOD), unter Stress, durch ehrenamtliche Helfer:
+
+1. **Admin-Dashboard-Layout.** Auf der Übersicht steht die Produktstatistik
+   („Verkäufe pro Produkt") als lange, ungedeckelte Liste ohne eigenen Scroll —
+   sie wächst mit der Produktzahl unbegrenzt die Seite hinunter. Die wichtigeren
+   Stornierungen stehen darunter und rutschen dadurch aus dem Blick.
+2. **Verwirrende Produktzahlen.** In der Produktstatistik ruhen „Ausgegeben"
+   (bestellt − Korrekturen) und „Umsatz" (kassiert − Storno) auf
+   unterschiedlichen Grundlagen. Sie gehen nicht ineinander auf, was verwirrt:
+   die Euro-Spalte ist nicht der Wert der gezählten Portionen.
+3. **Automatische Tastatur.** Dialoge und Formulare fokussieren beim Öffnen
+   automatisch das erste Eingabefeld, wodurch die Mobil-Tastatur aufspringt. Im
+   Bestell-Drawer ist das erste Feld sogar das *optionale* Kommentarfeld; die
+   Tastatur verdeckt die primäre Aktion („Bestellung aufnehmen" / „Kassieren"),
+   der Nutzer muss die Tastatur erst schließen, um abzusenden.
+4. **Tischsuche sucht das Falsche.** Die Suche auf der Service-Hauptseite filtert
+   nur die Favoriten („Meine Tische") — eine kleine Menge, in der man selten
+   sucht. Um einen beliebigen Tisch zu finden, muss man erst den „Alle Tische"-
+   Drawer öffnen, der eine *zweite*, getrennte Suche über alle aktiven Tische
+   hat. Zwei Suchfelder, zwei Datenbestände, verwirrend.
+
+Begleitend traten beim Audit weitere Reibungspunkte derselben Klasse zutage
+(primäre Aktion hinter der Tastatur, zu kleine Touch-Ziele,
+Formatierungs- und Begriffs-Inkonsistenzen), die mitbehoben werden.
+
+## Solution
+
+1. **Dashboard umsortieren und scrollbar machen.** Auf der Live-Übersicht rückt
+   der Stornierungen-Block über die Produktstatistik. Die geteilte
+   Produktstatistik-Liste bekommt eine Höhenbegrenzung mit eigenem vertikalem
+   Scroll — auf der Übersicht *und* auf „Berichte & Export". (Auf „Berichte &
+   Export" stehen die Stornierungen bereits über der Produktstatistik; dort ist
+   nur der Scroll nötig.)
+2. **Umsatz auf Bestellbasis umstellen.** „Umsatz" in der Produktstatistik wird
+   auf dieselbe Ereignis-Grundlage wie „Ausgegeben" gestellt: der Euro-Wert
+   (zu Bestellzeit-Preisen) genau der Portionen, die „Ausgegeben" zählt (bestellt
+   − Korrekturen, inkl. Direktverkauf). Damit ist die Produkttabelle in sich
+   stimmig (Umsatz = Wert der ausgegebenen Portionen) und geht im Normalfall
+   ohne nachträgliche Stornos mit dem kassierten Gesamtumsatz auf. Der
+   Beschreibungstext wird auf eine kurze Aussage reduziert (z. B. „Zahlen
+   basieren auf Bestellungen"). Gilt auf Übersicht und „Berichte & Export".
+3. **Keine automatische Tastatur.** Der Autofokus beim Öffnen wird zentral in
+   den geteilten Overlay-Primitiven (Drawer/Dialog/Sheet) unterdrückt — kein
+   Dialog und kein Formular öffnet mehr beim Erscheinen die Tastatur. Der Nutzer
+   tippt selbst das Feld an, das er befüllen will; die primäre Aktion bleibt
+   sichtbar.
+4. **Eine Suche über alle Tische.** Die Suche auf der Service-Hauptseite sucht
+   direkt über alle aktiven Tische; ein Treffer öffnet den Tisch direkt. Der
+   „Alle Tische"-Drawer bleibt zum Durchblättern und Favorisieren erhalten,
+   verliert aber sein nun redundantes zweites Suchfeld.
+
+Begleitend (derselbe Problemkreis):
+
+5. **Admin-Dialoge scrollbar mit fixierter Aktionsleiste.** `Dialog`/
+   `AlertDialog` erhalten dieselbe Behandlung wie der Drawer (Höhen-Cap +
+   interner Scroll + gepinnte Fußleiste), damit die Absende-Schaltfläche nie
+   hinter der Tastatur verschwindet — u. a. Zählhilfe und Kassenabschluss.
+6. **Zählhilfe-Touch-Ziele.** Die zu kleinen (32 px) Zähl-Eingaben werden auf
+   ein mobiltaugliches Touch-Maß vergrößert.
+7. **Währungsformat konsistent.** Admin-seitige Beträge werden über die
+   vorhandene `formatEuro`-Hilfe (geschütztes Leerzeichen) gerendert, damit das
+   „€" auf schmalen Displays nicht in die nächste Zeile umbricht.
+8. **Begriffe vereinheitlichen.** Für die Servicekraft-Rolle wird durchgängig
+   „Servicekraft" statt „Bediener" verwendet; in der Helfer-Verwaltung wird die
+   Person durchgängig als „Helfer" benannt (Feld „Benutzername" als Zugangs-
+   Credential bleibt), statt „Helfer"/„Benutzer" im selben Fluss zu mischen.
+
+## User Stories
+
+1. Als Admin möchte ich auf der Übersicht die Stornierungen über der
+   Produktstatistik sehen, damit die wichtigeren Vorgänge nicht unter einer
+   langen Produktliste verschwinden.
+2. Als Admin möchte ich, dass die Produktstatistik-Liste einen eigenen Scroll
+   hat, damit sie bei vielen Produkten nicht die ganze Seite hinunterwächst —
+   auf der Übersicht und auf „Berichte & Export".
+3. Als Admin möchte ich, dass „Ausgegeben" und „Umsatz" je Produkt auf
+   derselben Grundlage beruhen (Umsatz = Wert der ausgegebenen Portionen),
+   damit die Zahlen nachvollziehbar zusammenpassen.
+4. Als Admin möchte ich einen kurzen, klaren Hinweis („Zahlen basieren auf
+   Bestellungen"), damit ich die Grundlage der Zahlen sofort verstehe.
+5. Als Servicekraft möchte ich, dass beim Öffnen eines Drawers/Dialogs nicht
+   automatisch die Tastatur aufspringt, damit die primäre Aktion sichtbar
+   bleibt und ich nicht erst die Tastatur schließen muss.
+6. Als Admin möchte ich, dass beim Öffnen eines Formulardialogs nicht
+   automatisch die Tastatur aufspringt, aus demselben Grund.
+7. Als Servicekraft möchte ich die Suche auf der Hauptseite über alle aktiven
+   Tische nutzen und einen Treffer direkt öffnen, damit ich jeden Tisch finde,
+   ohne erst einen Drawer zu öffnen.
+8. Als Servicekraft möchte ich weiterhin den „Alle Tische"-Drawer zum
+   Durchblättern und Favorisieren nutzen — ohne verwirrendes zweites Suchfeld.
+9. Als Admin möchte ich, dass in Formulardialogen (inkl. Zählhilfe,
+   Kassenabschluss) die Absende-Schaltfläche erreichbar bleibt (Scroll,
+   fixierte Fußleiste), damit ich die Aktion auch bei geöffneter Tastatur oder
+   viel Inhalt auslösen kann.
+10. Als Admin möchte ich in der Zählhilfe ausreichend große Eingabefelder,
+    damit ich mich beim Zählen unter Stress nicht vertippe.
+11. Als Nutzer möchte ich Beträge ohne umgebrochenes „€" sehen, damit Salden
+    und Summen sauber lesbar sind.
+12. Als Nutzer möchte ich innerhalb eines Ablaufs konsistente Begriffe
+    („Servicekraft", „Helfer"), damit die Oberfläche nicht verwirrt.
+
+## Implementation Decisions
+
+**Dashboard-Layout (Übersicht):**
+- In der Live-Reporting-Sektion werden die beiden Geschwister-Blöcke
+  Produktstatistik und Stornierungen vertauscht (Stornierungen zuerst). Rein
+  präsentational, kein geteilter State.
+
+**Produktstatistik-Scroll (geteilt):**
+- Die geteilte Produktstatistik-Komponente erhält einen Höhen-Cap mit
+  `overflow-y-auto`, sodass die Liste innerhalb ihres Rahmens scrollt statt die
+  Seite zu verlängern. Da die Komponente auf Übersicht und „Berichte & Export"
+  geteilt wird, wirkt die Änderung auf beiden Seiten.
+
+**Umsatz auf Bestellbasis (Backend, Single Source of Truth):**
+- Die Reporting-Query für die Produktstatistik wird angepasst: der Umsatz-Term
+  je Variante verwendet **dieselbe Ereignismenge und Gewichtung wie der
+  Ausgegeben-Term** (`bestellung-aufgenommen` +, `bestellung-korrigiert` −,
+  `direktverkauf-getaetigt` +), jeweils `einzelpreisCents × menge`. Damit ist
+  der Umsatz je Variante der Euro-Wert genau der in „Ausgegeben" gezählten
+  Portionen (zu den zum Bestellzeitpunkt eingefrorenen Preisen).
+- `zahlung-kassiert`, `stornierung-erteilt` und `direktverkauf-storniert`
+  fließen nicht länger in den **Produkt**-Umsatz ein.
+- Bewusste Divergenz: Die KPI „Kassierter Umsatz", die Umsätze je Servicekraft
+  und die fiskalischen Größen (Z-Bon / DSFinV-K) bleiben **kassenbasiert** und
+  unverändert. Bei nachträglichen (kassenwirksamen) Stornos weicht der
+  Produkt-Umsatz vom kassierten Umsatz um genau diese Storno-Beträge ab; ohne
+  solche Stornos stimmen sie überein.
+- Reiner Read-Query-/Read-Model-Eingriff: keine Migration, keine Änderung an
+  Event-Formaten oder persistierten Daten (Freeze-Disziplin gewahrt). Nach der
+  Query-Änderung `make sqlc` ausführen.
+
+**Beschreibungstext:**
+- Der erklärende Absatz über der Produkttabelle (geteilt) wird auf eine kurze
+  Aussage reduziert (z. B. „Zahlen basieren auf Bestellungen"). Die
+  Spaltenüberschriften „Ausgegeben"/„Umsatz" bleiben.
+
+**Autofokus zentral unterdrücken (Frontend-Primitive):**
+- In den geteilten Overlay-Content-Komponenten (Drawer, Dialog, Sheet) wird das
+  Standard-Verhalten „ersten fokussierbaren Nachfahren fokussieren" beim Öffnen
+  unterbunden (Radix `onOpenAutoFocus` verhindern), ohne den Fokus-Trap / die
+  Tastaturbedienung (Tab, Escape, Fokusrückgabe beim Schließen) zu brechen.
+- `AlertDialog` (reine Bestätigungen) fokussiert weiterhin eine Schaltfläche und
+  bleibt unverändert.
+
+**Tischsuche vereinheitlichen (Service):**
+- Die Hauptseiten-Suche filtert über **alle aktiven Tische** (die bereits
+  vorhandene „aktive Tische mit Favoriten"-Datenquelle wird genutzt), nicht mehr
+  nur über Favoriten. Bei leerem Suchfeld zeigt die Hauptseite weiterhin die
+  Favoriten („Meine Tische"); sobald gesucht wird, erscheinen Treffer aus allen
+  aktiven Tischen, und ein Treffer öffnet den Tisch direkt.
+- Das zweite Suchfeld im „Alle Tische"-Drawer entfällt; der Drawer bleibt zum
+  Durchblättern (sortiert) und Favorisieren erhalten.
+- Der Platzhaltertext der Hauptseiten-Suche wird passend gehalten (Suche über
+  Tischname, der die Nummer enthält).
+
+**Admin-Dialoge scrollbar mit fixierter Fußleiste (Frontend-Primitive):**
+- `Dialog`/`AlertDialog`-Content bekommen einen Höhen-Cap (analog Drawer,
+  `max-h`), einen intern scrollenden Inhaltsbereich und eine gepinnte Fußleiste,
+  sodass die Aktionsschaltflächen bei geöffneter Tastatur oder viel Inhalt
+  erreichbar bleiben. Wirkt auf alle Admin-Formulardialoge (u. a. Produkt-,
+  Benutzer-, Tisch-Dialoge, Geldtransit, Zählhilfe, Kassenabschluss).
+
+**Zählhilfe-Touch-Ziele:**
+- Die Zähl-Eingaben werden auf ein mobiltaugliches Touch-Maß vergrößert
+  (mindestens ~44 px Höhe), Layout weiterhin kompakt.
+
+**Währungsformat:**
+- Admin-seitige Beträge (u. a. Kassenabschluss, Tischauswahl-Saldo) werden über
+  die vorhandene `formatEuro`-Hilfe gerendert statt „`{formatCents(x)} €`" mit
+  normalem Leerzeichen.
+
+**Begriffe:**
+- Reporting-Oberfläche: „Bediener" → „Servicekraft" (kanonisch laut
+  `docs/language.md`).
+- Helfer-Verwaltung: Person durchgängig „Helfer" (Trigger, Dialogtitel,
+  Schaltfläche, Toast); das Zugangsfeld bleibt „Benutzername". Falls das Team
+  stattdessen die Entität „Benutzer" bevorzugt, gilt: eine Wahl, konsistent
+  angewandt. `docs/language.md` bleibt Quelle der Wahrheit und wird bei
+  UI-Begriffsänderung mitgezogen.
+
+## Testing Decisions
+
+Gute Tests prüfen **externes Verhalten**, nicht Implementierungsdetails.
+
+- **Produkt-Umsatz (Backend, höchster Testwert).** Query-/Repository-Test für
+  die Produktstatistik: Nach Bestellung + Korrektur + Kassierung ist der
+  Produkt-Umsatz je Variante gleich dem Euro-Wert der ausgegebenen Portionen
+  (bestellt − Korrektur, inkl. Direktverkauf). Insbesondere: eine nachträgliche
+  (kassenwirksame) **Stornierung reduziert den Produkt-Umsatz nicht** (sie
+  reduziert weiterhin die separate kassenbasierte KPI). Prior art: bestehende
+  Reporting-Query-/Repository-Tests im Reporting-Kontext.
+- **Tischsuche (Frontend).** Test der Service-Hauptseite: Eingabe eines
+  Suchbegriffs, der auf einen **nicht favorisierten** aktiven Tisch passt, zeigt
+  diesen als Treffer und ermöglicht das Öffnen. Prior art: `TablePage.test.tsx`,
+  `TischAuswahlDrawer.test.tsx`.
+- **Autofokus (Frontend).** Test, dass beim Öffnen eines Drawers/Dialogs **kein
+  Eingabefeld** den Fokus erhält (kein Auto-Öffnen der Tastatur), am Beispiel
+  des Bestell-Drawers (optionales Kommentarfeld). Externes, beobachtbares
+  Verhalten (`document.activeElement`).
+- **Nicht gesondert getestet** (rein präsentational / geringer Testwert, visuell
+  zu verifizieren): Block-Reihenfolge auf der Übersicht, Scroll-Cap der
+  Produktliste, Admin-Dialog-Scroll/Fußleiste, Touch-Ziel-Größen,
+  `formatEuro`-Umstellung, Begriffs-Strings.
+
+## Out of Scope
+
+- Änderung der KPI „Kassierter Umsatz", der Umsätze je Servicekraft oder der
+  fiskalischen Auswertungen (Z-Bon, DSFinV-K) — diese bleiben kassenbasiert.
+- Änderung der Bedeutung von „Ausgegeben" (die Ereignismenge des
+  Ausgegeben-Terms bleibt unverändert; der Umsatz zieht mit).
+- Änderungen an Event-Formaten, DB-Schema oder persistierten Daten.
+- Ein neues „zuletzt bearbeitete Tische"-Konzept getrennt von Favoriten —
+  „Meine Tische" bleibt gleichbedeutend mit Favoriten.
+- Vollständige, repo-weite Begriffs-Migration über die genannten Flächen hinaus
+  (Reporting-Rolle, Helfer-Verwaltung); weitergehende Sprachpflege wäre ein
+  eigenes Vorhaben.
+- Verhaltensänderung des `AlertDialog`-Autofokus (Bestätigungsdialoge bleiben
+  auf einer Schaltfläche fokussiert).
+
+## Further Notes
+
+- **Vertikale Slices für den Plan** (weitgehend unabhängig, einzeln
+  auslieferbar): (1) Dashboard-Reihenfolge + Produktliste-Scroll; (2)
+  Produkt-Umsatz auf Bestellbasis + Beschreibungstext; (3) Autofokus zentral +
+  Admin-Dialog-Scroll/Fußleiste (gemeinsamer Problemkreis „primäre Aktion hinter
+  Tastatur"); (4) Tischsuche über alle Tische + Drawer-Suchfeld entfernen; (5)
+  kleinere Politur: Zählhilfe-Touch-Ziele, `formatEuro`, Begriffe.
+- Slice 3 verbindet die vom Nutzer genannte Autofokus-Reibung mit dem beim Audit
+  gefundenen Admin-Dialog-Scroll-Problem, weil beide dieselbe Ursache-Klasse
+  („primäre Aktion nicht erreichbar") betreffen und sich in denselben geteilten
+  Primitiven lösen lassen.
+- Nach Backend-Query-Änderung `make sqlc`; nach Frontend-Änderungen `make lint`.


### PR DESCRIPTION
## Summary

Adds a PRD and a phased implementation plan for a mobile-first UI refinement pass. **Docs only — no code changes yet.**

- `docs/prds/prd-ui-refinements.md`
- `docs/plans/plan-ui-refinements.md`

## Scope covered

1. **Dashboard** — move Stornierungen above the product statistics on the Übersicht; give the shared product-statistics list a height cap + internal scroll (also benefits "Berichte & Export").
2. **Produkt-Umsatz** — switch per-product `Umsatz` to the *same event set* as "Ausgegeben" (order value at order-time prices) so the table is internally consistent. Deliberate, documented divergence: the cash-based "Kassierter Umsatz" KPI, per-Servicekraft sums, and Z-Bon/DSFinV-K figures stay cash-based (separate `GetUmsatzPositionszeilen` query — verified untouched). Read-query change only; no migration, no event-format change.
3. **Autofocus** — suppress the default keyboard-opening autofocus centrally in the shared Drawer/Dialog/Sheet primitives; give admin `Dialog`/`AlertDialog` the Drawer's scroll + pinned-footer treatment so the submit button never hides behind the keyboard.
4. **Tischsuche** — main-page service search covers all active tables and opens a hit directly; the redundant second search in the "Alle Tische" drawer is removed.
5. **Politur** — Zählhilfe touch targets, `formatEuro` (non-breaking space) consistency, terminology unification (Person → "Helfer"; internal `formatBediener` → domain term).

## Plan phases

1. Dashboard reorder + product-statistics scroll cap
2. Order-based product Umsatz + shortened caption
3. Central autofocus suppression + admin dialog scroll/footer
4. Unified table search across all active tables
5. Polish (touch targets, formatEuro, terminology)

## Notes for the reviewer

- The Umsatz basis change is the one semantic decision worth a close look — it makes the product table reconcile with cash in the no-storno case and diverge by exactly the post-payment Storno amounts otherwise. Confirmed the DSFinV-K/tax-consistency test rests on a different query and is unaffected.
- Terminology "Bediener" is only an internal identifier today (headings already say "Servicekraft"), so that part is an internal rename, not a user-facing string change.
