### PR TITLE
feat(ui): dashboard order, order-based product revenue, overlay polish, table search

### DIFF
--- a/backend/repository/reporting_repo/repo_test.go
+++ b/backend/repository/reporting_repo/repo_test.go
@@ -140,13 +140,14 @@ func produktPosition(varianteID int, produktName, varianteName, kategorie string
 	}
 }
 
-// TestGetProduktStatistik_MengeUndUmsatzMitVorzeichen prüft die beiden getrennten
-// Zahlen je Variante über alle beteiligten Event-Typen: Bestellung (+Menge),
-// Korrektur (−Menge, geldneutral), Zahlung (+Umsatz), Warenrücknahme (−Umsatz,
-// menge-neutral), Direktverkauf (+Menge/+Umsatz) und Direktverkauf-Storno
-// (−Umsatz). Zugleich die Konsistenz-Invariante: Σ Produkt-Umsatz == Σ Brutto
-// der Umsatz-Positionszeilen derselben Sitzung (kein WHERE-type-Drift).
-func TestGetProduktStatistik_MengeUndUmsatzMitVorzeichen(t *testing.T) {
+// TestGetProduktStatistik_MengeUndUmsatzAufBestellbasis prüft, dass Menge und
+// Umsatz je Variante auf derselben Ereignismenge (Bestellbasis) ruhen:
+// Bestellung (+Menge/+Umsatz), Korrektur (−Menge/−Umsatz), Direktverkauf
+// (+Menge/+Umsatz). Nachträgliche kassenwirksame Vorgänge — Zahlung,
+// Warenrücknahme (stornierung-erteilt) und Direktverkauf-Storno — sind bewusst
+// vorhanden, dürfen den Produkt-Umsatz aber NICHT verändern: er ist der
+// Bestellwert der ausgegebenen Portionen, nicht der kassierte Umsatz.
+func TestGetProduktStatistik_MengeUndUmsatzAufBestellbasis(t *testing.T) {
 	db := dbpkg.OpenTestDatabase()
 	defer func() { _ = db.Close() }()
 	cleanDB(t, db)
@@ -200,7 +201,9 @@ func TestGetProduktStatistik_MengeUndUmsatzMitVorzeichen(t *testing.T) {
 		t.Fatalf("expected 2 variant rows, got %d: %+v", len(zeilen), zeilen)
 	}
 
-	// Pommes: ausgegebene Menge 5 − 1 = 4; Umsatz 1200 − 300 = 900.
+	// Pommes: ausgegebene Menge 5 − 1 = 4; Umsatz 1500 bestellt − 300 korrigiert
+	// = 1200. Die spätere Warenrücknahme (stornierung-erteilt) mindert den
+	// Produkt-Umsatz bewusst NICHT.
 	pommesZeile := byVariante[10]
 	if pommesZeile.ProduktName != "Pommes" || pommesZeile.VarianteName != "groß" || pommesZeile.Kategorie != "essen" {
 		t.Errorf("unexpected Pommes identity: %+v", pommesZeile)
@@ -208,35 +211,18 @@ func TestGetProduktStatistik_MengeUndUmsatzMitVorzeichen(t *testing.T) {
 	if pommesZeile.AusgegebeneMenge != 4 {
 		t.Errorf("expected Pommes menge 4 (5 bestellt − 1 korrigiert), got %d", pommesZeile.AusgegebeneMenge)
 	}
-	if pommesZeile.UmsatzCents != 900 {
-		t.Errorf("expected Pommes umsatz 900 (1200 kassiert − 300 Warenrücknahme), got %d", pommesZeile.UmsatzCents)
+	if pommesZeile.UmsatzCents != 1200 {
+		t.Errorf("expected Pommes umsatz 1200 (1500 bestellt − 300 korrigiert, Warenrücknahme umsatzneutral), got %d", pommesZeile.UmsatzCents)
 	}
 
-	// Cola: Direktverkauf-Storno mindert nur den Umsatz, nicht die Menge.
+	// Cola: Direktverkauf zählt Menge und Umsatz; der Direktverkauf-Storno
+	// mindert weder Menge noch Umsatz (Produkt-Umsatz ist bestellbasiert).
 	colaZeile := byVariante[20]
 	if colaZeile.AusgegebeneMenge != 3 {
 		t.Errorf("expected Cola menge 3 (Direktverkauf, Storno menge-neutral), got %d", colaZeile.AusgegebeneMenge)
 	}
-	if colaZeile.UmsatzCents != 500 {
-		t.Errorf("expected Cola umsatz 500 (750 Direktverkauf − 250 Storno), got %d", colaZeile.UmsatzCents)
-	}
-
-	// Konsistenz-Invariante: Σ Produkt-Umsatz == Σ Brutto der Umsatz-Positionszeilen
-	// derselben Sitzung — dieselbe WHERE-type-/Vorzeichenbasis, kein Drift.
-	data, err := repo.GetReporting(ctx, ksNr)
-	if err != nil {
-		t.Fatalf("GetReporting failed: %v", err)
-	}
-	summeZeilenBrutto := 0
-	for _, z := range data.UmsatzProSteuersatz {
-		summeZeilenBrutto += z.BruttoCents
-	}
-	summeProduktUmsatz := 0
-	for _, z := range zeilen {
-		summeProduktUmsatz += z.UmsatzCents
-	}
-	if summeProduktUmsatz != summeZeilenBrutto {
-		t.Errorf("Σ Produkt-Umsatz %d != Σ Positionszeilen-Brutto %d (WHERE-type-Drift)", summeProduktUmsatz, summeZeilenBrutto)
+	if colaZeile.UmsatzCents != 750 {
+		t.Errorf("expected Cola umsatz 750 (Direktverkauf, Storno umsatzneutral), got %d", colaZeile.UmsatzCents)
 	}
 }
 
@@ -273,8 +259,8 @@ func TestGetProduktStatistik_UmbuchungZaehltNicht(t *testing.T) {
 	if zeilen[0].AusgegebeneMenge != 2 {
 		t.Errorf("expected menge 2 (Umbuchung zählt nicht), got %d", zeilen[0].AusgegebeneMenge)
 	}
-	if zeilen[0].UmsatzCents != 0 {
-		t.Errorf("expected umsatz 0 (nur Bestellung, keine Zahlung), got %d", zeilen[0].UmsatzCents)
+	if zeilen[0].UmsatzCents != 600 {
+		t.Errorf("expected umsatz 600 (2 × 300 bestellt, Umbuchung zählt nicht), got %d", zeilen[0].UmsatzCents)
 	}
 }
 

--- a/backend/sqlc/dbgen/reporting.sql.go
+++ b/backend/sqlc/dbgen/reporting.sql.go
@@ -174,8 +174,8 @@ SELECT
     ), 0)::int AS ausgegebene_menge,
     COALESCE(SUM(
         ((position->>'einzelpreisCents')::int * (position->>'menge')::int) * CASE
-            WHEN kj.type IN ('zahlung-kassiert:v1', 'direktverkauf-getaetigt:v1') THEN 1
-            WHEN kj.type IN ('stornierung-erteilt:v1', 'direktverkauf-storniert:v1') THEN -1
+            WHEN kj.type IN ('bestellung-aufgenommen:v1', 'direktverkauf-getaetigt:v1') THEN 1
+            WHEN kj.type = 'bestellung-korrigiert:v1' THEN -1
             ELSE 0
         END
     ), 0)::int AS umsatz_cents
@@ -184,10 +184,7 @@ CROSS JOIN LATERAL jsonb_array_elements(kj.data->'positionen') AS position
 WHERE kj.type IN (
     'bestellung-aufgenommen:v1',
     'bestellung-korrigiert:v1',
-    'direktverkauf-getaetigt:v1',
-    'zahlung-kassiert:v1',
-    'stornierung-erteilt:v1',
-    'direktverkauf-storniert:v1'
+    'direktverkauf-getaetigt:v1'
 )
 AND kj.kassensitzung_nr = $1
 GROUP BY kategorie, variante_id, produkt_name, variante_name
@@ -205,16 +202,22 @@ type GetProduktStatistikRow struct {
 // Tagesabrechnung/Live: Verkäufe je Produkt und Variante einer Kassensitzung,
 // aus den eingefrorenen Fat-Event-Positionen aggregiert (kein Stammdaten-Join).
 // Flache Zeilen je Variante mit zwei bewusst getrennten Zahlen — die
-// Anwendungsschicht gruppiert und sortiert sie zu Kategorie-Abschnitten:
+// Anwendungsschicht gruppiert und sortiert sie zu Kategorie-Abschnitten. Beide
+// Zahlen ruhen auf derselben Ereignismenge/Gewichtung (Bestellbasis):
 //
 //	Ausgegebene Menge (Produktion) = Σ menge: bestellung-aufgenommen (+),
 //	  bestellung-korrigiert (−), direktverkauf-getaetigt (+).
-//	Umsatz (Einnahmen) = Σ einzelpreisCents × menge: zahlung-kassiert (+),
-//	  direktverkauf-getaetigt (+), stornierung-erteilt (−), direktverkauf-storniert (−).
+//	Umsatz (Bestellwert) = Σ einzelpreisCents × menge über dieselbe Ereignismenge
+//	  und Gewichtung: bestellung-aufgenommen (+), bestellung-korrigiert (−),
+//	  direktverkauf-getaetigt (+). Es ist der Euro-Wert genau der Portionen, die
+//	  „Ausgegeben" zählt (Preise zum Bestellzeitpunkt).
 //
 // bestellung-umgebucht zählt nicht (Positionen bereits bei der Bestellung erfasst).
-// Dieselbe Positions-/Vorzeichenbasis wie GetUmsatzPositionszeilen für den
-// Umsatzanteil, damit Σ umsatzCents dem kassierten Gesamtumsatz entspricht.
+// Bewusst NICHT kassenbasiert: nachträgliche Zahlungen und Stornierungen
+// (zahlung-kassiert, stornierung-erteilt, direktverkauf-storniert) ändern den
+// Produkt-Umsatz nicht. Die fiskalische, kassierte Umsatzbasis liefert separat
+// GetUmsatzPositionszeilen (Steuer-Aufschlüsselung, DSFinV-K, „Kassierter Umsatz");
+// beide Größen weichen bei Stornos bewusst voneinander ab.
 func (q *Queries) GetProduktStatistik(ctx context.Context, kassensitzungNr int) ([]GetProduktStatistikRow, error) {
 	rows, err := q.db.QueryContext(ctx, getProduktStatistik, kassensitzungNr)
 	if err != nil {

--- a/backend/sqlc/queries/reporting.sql
+++ b/backend/sqlc/queries/reporting.sql
@@ -112,14 +112,20 @@ AND kj.kassensitzung_nr = @kassensitzung_nr;
 -- Tagesabrechnung/Live: Verkäufe je Produkt und Variante einer Kassensitzung,
 -- aus den eingefrorenen Fat-Event-Positionen aggregiert (kein Stammdaten-Join).
 -- Flache Zeilen je Variante mit zwei bewusst getrennten Zahlen — die
--- Anwendungsschicht gruppiert und sortiert sie zu Kategorie-Abschnitten:
+-- Anwendungsschicht gruppiert und sortiert sie zu Kategorie-Abschnitten. Beide
+-- Zahlen ruhen auf derselben Ereignismenge/Gewichtung (Bestellbasis):
 --   Ausgegebene Menge (Produktion) = Σ menge: bestellung-aufgenommen (+),
 --     bestellung-korrigiert (−), direktverkauf-getaetigt (+).
---   Umsatz (Einnahmen) = Σ einzelpreisCents × menge: zahlung-kassiert (+),
---     direktverkauf-getaetigt (+), stornierung-erteilt (−), direktverkauf-storniert (−).
+--   Umsatz (Bestellwert) = Σ einzelpreisCents × menge über dieselbe Ereignismenge
+--     und Gewichtung: bestellung-aufgenommen (+), bestellung-korrigiert (−),
+--     direktverkauf-getaetigt (+). Es ist der Euro-Wert genau der Portionen, die
+--     „Ausgegeben" zählt (Preise zum Bestellzeitpunkt).
 -- bestellung-umgebucht zählt nicht (Positionen bereits bei der Bestellung erfasst).
--- Dieselbe Positions-/Vorzeichenbasis wie GetUmsatzPositionszeilen für den
--- Umsatzanteil, damit Σ umsatzCents dem kassierten Gesamtumsatz entspricht.
+-- Bewusst NICHT kassenbasiert: nachträgliche Zahlungen und Stornierungen
+-- (zahlung-kassiert, stornierung-erteilt, direktverkauf-storniert) ändern den
+-- Produkt-Umsatz nicht. Die fiskalische, kassierte Umsatzbasis liefert separat
+-- GetUmsatzPositionszeilen (Steuer-Aufschlüsselung, DSFinV-K, „Kassierter Umsatz");
+-- beide Größen weichen bei Stornos bewusst voneinander ab.
 SELECT
     (position->>'kategorie')::text AS kategorie,
     (position->>'varianteId')::int AS variante_id,
@@ -134,8 +140,8 @@ SELECT
     ), 0)::int AS ausgegebene_menge,
     COALESCE(SUM(
         ((position->>'einzelpreisCents')::int * (position->>'menge')::int) * CASE
-            WHEN kj.type IN ('zahlung-kassiert:v1', 'direktverkauf-getaetigt:v1') THEN 1
-            WHEN kj.type IN ('stornierung-erteilt:v1', 'direktverkauf-storniert:v1') THEN -1
+            WHEN kj.type IN ('bestellung-aufgenommen:v1', 'direktverkauf-getaetigt:v1') THEN 1
+            WHEN kj.type = 'bestellung-korrigiert:v1' THEN -1
             ELSE 0
         END
     ), 0)::int AS umsatz_cents
@@ -144,10 +150,7 @@ CROSS JOIN LATERAL jsonb_array_elements(kj.data->'positionen') AS position
 WHERE kj.type IN (
     'bestellung-aufgenommen:v1',
     'bestellung-korrigiert:v1',
-    'direktverkauf-getaetigt:v1',
-    'zahlung-kassiert:v1',
-    'stornierung-erteilt:v1',
-    'direktverkauf-storniert:v1'
+    'direktverkauf-getaetigt:v1'
 )
 AND kj.kassensitzung_nr = @kassensitzung_nr
 GROUP BY kategorie, variante_id, produkt_name, variante_name;

--- a/docs/language.md
+++ b/docs/language.md
@@ -64,6 +64,12 @@ Das Finanzamt teilt einen Verein in vier steuerliche Sphären, die Buchführungs
 
 Person mit Zugang zum System, identifiziert durch einen eindeutigen Benutzernamen.
 
+In der Admin-Helfer-Verwaltung (Seite „Helfer & Zugänge", `src/admin/users/`) wird
+die Person durchgängig **„Helfer"** genannt (ehrenamtliche Servicekraft) — in
+Triggern, Dialogtiteln, Schaltflächen und Toasts. Das Zugangs-/Anmeldedatum
+heißt weiterhin **„Benutzername"**; „Benutzer" bleibt der kanonische Oberbegriff
+für die Person mit Zugang (u. a. in Login/Auth-Kontexten).
+
 Go-Struct: `User` · TS-Typ: `User` · DB-Tabelle: `users`
 
 #### Rolle

--- a/docs/plans/plan-ui-refinements.md
+++ b/docs/plans/plan-ui-refinements.md
@@ -162,13 +162,13 @@ nicht überlängt — auf Übersicht und „Berichte & Export".
 
 ### Acceptance criteria
 
-- [ ] Auf der Admin-Übersicht steht der Stornierungen-Abschnitt oberhalb von
+- [x] Auf der Admin-Übersicht steht der Stornierungen-Abschnitt oberhalb von
       „Verkäufe pro Produkt".
-- [ ] Die Produktstatistik-Liste scrollt innerhalb eines gedeckelten Bereichs
+- [x] Die Produktstatistik-Liste scrollt innerhalb eines gedeckelten Bereichs
       statt die Seite unbegrenzt zu verlängern — auf beiden Seiten.
-- [ ] Auf „Berichte & Export" bleibt die bestehende Reihenfolge (Stornierungen
+- [x] Auf „Berichte & Export" bleibt die bestehende Reihenfolge (Stornierungen
       vor Produktstatistik) erhalten.
-- [ ] `make lint` ist grün; keine Änderung an gelieferten Zahlen.
+- [x] `make lint` ist grün; keine Änderung an gelieferten Zahlen.
 
 ---
 
@@ -204,15 +204,15 @@ kassenbasiert.
 
 ### Acceptance criteria
 
-- [ ] `GetProduktStatistik` liefert Umsatz je Variante = Σ
+- [x] `GetProduktStatistik` liefert Umsatz je Variante = Σ
       `einzelpreisCents × menge` über `bestellung-aufgenommen` (+),
       `bestellung-korrigiert` (−), `direktverkauf-getaetigt` (+).
-- [ ] Eine nachträgliche kassenwirksame Stornierung reduziert den
+- [x] Eine nachträgliche kassenwirksame Stornierung reduziert den
       Produkt-Umsatz **nicht** (Test belegt das).
-- [ ] Die separate „Kassierter Umsatz"-KPI/Steueraufschlüsselung bleibt
+- [x] Die separate „Kassierter Umsatz"-KPI/Steueraufschlüsselung bleibt
       kassenbasiert unverändert (DSFinV-K-Konsistenztest weiterhin grün).
-- [ ] Der Beschreibungstext über der Tabelle ist auf eine kurze Aussage gekürzt.
-- [ ] `make sqlc` ausgeführt, `dbgen` regeneriert; `make verify` grün.
+- [x] Der Beschreibungstext über der Tabelle ist auf eine kurze Aussage gekürzt.
+- [x] `make sqlc` ausgeführt, `dbgen` regeneriert; `make verify` grün.
 
 ---
 
@@ -244,13 +244,13 @@ primäre Aktion nie hinter der Tastatur oder unterhalb des Inhalts verschwindet.
 
 ### Acceptance criteria
 
-- [ ] Beim Öffnen von Drawer/Dialog/Sheet erhält **kein** Eingabefeld den Fokus
+- [x] Beim Öffnen von Drawer/Dialog/Sheet erhält **kein** Eingabefeld den Fokus
       (Test am Bestell-Drawer belegt: `document.activeElement` ist kein Input).
-- [ ] `AlertDialog`-Bestätigungen bleiben unverändert (button-fokussiert).
-- [ ] Admin-Formulardialoge (u. a. Zählhilfe, Kassenabschluss, Produkt-/Tisch-/
+- [x] `AlertDialog`-Bestätigungen bleiben unverändert (button-fokussiert).
+- [x] Admin-Formulardialoge (u. a. Zählhilfe, Kassenabschluss, Produkt-/Tisch-/
       Benutzer-Dialoge) haben einen Höhen-Cap mit internem Scroll und gepinnter
       Fußleiste; die Absende-Schaltfläche bleibt erreichbar.
-- [ ] Tastaturbedienung (Tab-Fokus-Trap, Escape, Fokusrückgabe) funktioniert
+- [x] Tastaturbedienung (Tab-Fokus-Trap, Escape, Fokusrückgabe) funktioniert
       weiter; `make lint` grün.
 
 ---
@@ -283,14 +283,14 @@ für das Durchblättern und Favorisieren, hat aber kein eigenes Suchfeld mehr.
 
 ### Acceptance criteria
 
-- [ ] Ein Suchbegriff auf der Hauptseite, der auf einen **nicht favorisierten**
+- [x] Ein Suchbegriff auf der Hauptseite, der auf einen **nicht favorisierten**
       aktiven Tisch passt, zeigt diesen als Treffer (Test belegt das).
-- [ ] Ein Treffer öffnet den Tisch direkt.
-- [ ] Bei leerem Suchfeld zeigt die Hauptseite unverändert die Favoriten
+- [x] Ein Treffer öffnet den Tisch direkt.
+- [x] Bei leerem Suchfeld zeigt die Hauptseite unverändert die Favoriten
       („Meine Tische"), gruppiert in „Noch offen"/„Erledigt".
-- [ ] Der „Alle Tische"-Drawer hat kein zweites Suchfeld mehr, bleibt aber zum
+- [x] Der „Alle Tische"-Drawer hat kein zweites Suchfeld mehr, bleibt aber zum
       Durchblättern/Favorisieren funktionsfähig.
-- [ ] `make lint` grün; bestehende Service-Tabellentests grün.
+- [x] `make lint` grün; bestehende Service-Tabellentests grün.
 
 ---
 
@@ -326,11 +326,11 @@ Kleinere Konsistenz- und Ergonomie-Politur: größere Zählhilfe-Eingaben, über
 
 ### Acceptance criteria
 
-- [ ] Zählhilfe-Eingaben erfüllen ein mobiltaugliches Touch-Maß (≥ ~44 px Höhe).
-- [ ] Admin-seitige Beträge nutzen `formatEuro`; „€" bricht nicht mehr allein um.
-- [ ] Die Helfer-Verwaltung nennt die Person durchgängig „Helfer" (Trigger,
+- [x] Zählhilfe-Eingaben erfüllen ein mobiltaugliches Touch-Maß (≥ ~44 px Höhe).
+- [x] Admin-seitige Beträge nutzen `formatEuro`; „€" bricht nicht mehr allein um.
+- [x] Die Helfer-Verwaltung nennt die Person durchgängig „Helfer" (Trigger,
       Titel, Schaltfläche, Toast); das Zugangsfeld heißt weiter „Benutzername".
-- [ ] `formatBediener` ist zur Domänenkonsistenz umbenannt; keine
+- [x] `formatBediener` ist zur Domänenkonsistenz umbenannt; keine
       benutzer-sichtbare „Bediener"-Zeichenkette verbleibt.
-- [ ] `docs/language.md` spiegelt geänderte benutzer-sichtbare Begriffe;
+- [x] `docs/language.md` spiegelt geänderte benutzer-sichtbare Begriffe;
       `make lint` grün.

--- a/e2e/support/servicekraft.ts
+++ b/e2e/support/servicekraft.ts
@@ -42,12 +42,12 @@ export async function oeffneHistorienDetail(
 }
 
 // oeffneTisch navigiert von der Tischauswahl zur Detailseite eines Tisches
-// über den „Alle Tische"-Drawer (funktioniert unabhängig davon, ob der Tisch
-// bereits in „Meine Tische" markiert ist).
+// über die Hauptsuche, die über alle aktiven Tische greift und einen Treffer
+// direkt öffnet (funktioniert unabhängig davon, ob der Tisch bereits in
+// „Meine Tische" markiert ist).
 export async function oeffneTisch(page: Page, tisch: string): Promise<void> {
   await page.goto('/service/tische')
-  await page.getByRole('button', { name: 'Alle Tische' }).click()
-  await page.getByPlaceholder('Tisch suchen...').fill(tisch)
+  await page.getByPlaceholder('Tisch suchen').fill(tisch)
   await page
     .getByRole('button', { name: new RegExp(`^${tisch}\\b.*€`) })
     .click()

--- a/e2e/tests/admin-benutzer-verwalten.spec.ts
+++ b/e2e/tests/admin-benutzer-verwalten.spec.ts
@@ -3,12 +3,12 @@ import { expect, test } from '@playwright/test'
 import { anmelden } from '../support/anmelden'
 import { resetAndSeed } from '../support/seed'
 
-// Deckt den Verwaltungspfad für Benutzer ab: Anlegen (inkl. Anzeige des
+// Deckt den Verwaltungspfad für Helfer ab: Anlegen (inkl. Anzeige des
 // Einmalpasswort-Codes) und Deaktivieren. Die Seite „Helfer & Zugänge" zeigt
-// die Benutzer als Tabelle mit Status-Switch je Zeile.
+// die Helfer als Tabelle mit Status-Switch je Zeile.
 
-test.describe('Admin verwaltet Benutzer', () => {
-  test('Benutzer anlegen zeigt das Einmalpasswort und der Benutzer lässt sich deaktivieren', async ({
+test.describe('Admin verwaltet Helfer', () => {
+  test('Helfer anlegen zeigt das Einmalpasswort und der Helfer lässt sich deaktivieren', async ({
     page,
     request,
   }) => {
@@ -20,19 +20,19 @@ test.describe('Admin verwaltet Benutzer', () => {
       page.getByRole('heading', { name: 'Helfer & Zugänge' }),
     ).toBeVisible()
 
-    // Neuen Benutzer anlegen.
+    // Neuen Helfer anlegen.
     await page.getByRole('button', { name: 'Neuer Helfer' }).click()
     const newDialog = page.getByRole('dialog')
     await newDialog.getByLabel('Name', { exact: true }).fill('Petra Neumann')
     await newDialog.getByLabel('Benutzername').fill('petra')
-    await newDialog.getByRole('button', { name: 'Benutzer anlegen' }).click()
+    await newDialog.getByRole('button', { name: 'Helfer anlegen' }).click()
     await expect(
-      page.getByText('Neuer Benutzer "Petra Neumann" wurde erstellt.'),
+      page.getByText('Neuer Helfer "Petra Neumann" wurde erstellt.'),
     ).toBeVisible()
 
     // Der Einmalpasswort-Dialog zeigt Benutzername und Code an.
     const createdDialog = page.getByRole('dialog').filter({
-      hasText: 'Benutzer wurde angelegt!',
+      hasText: 'Helfer wurde angelegt!',
     })
     await expect(createdDialog).toBeVisible()
     await expect(createdDialog.getByText('petra', { exact: true })).toBeVisible()
@@ -46,7 +46,7 @@ test.describe('Admin verwaltet Benutzer', () => {
     )
     await createdDialog.getByRole('button', { name: 'Okay' }).click()
 
-    // Neue Benutzer starten inaktiv (Passwort noch nicht gesetzt): erst
+    // Neue Helfer starten inaktiv (Passwort noch nicht gesetzt): erst
     // aktivieren, dann den Deaktivieren-Pfad prüfen. Die Tabellenzeile wird
     // über den Namen und ihren Status-Switch aufgelöst.
     const userRow = page

--- a/e2e/tests/admin-live-reporting.spec.ts
+++ b/e2e/tests/admin-live-reporting.spec.ts
@@ -41,7 +41,7 @@ test.describe('Admin sieht das Live-Dashboard', () => {
       liveSection.getByRole('heading', { name: 'Offene Tische' }),
     ).toBeVisible()
 
-    // Team-Block zeigt die aktiven Bediener des Sonntags.
+    // Team-Block zeigt die aktiven Servicekräfte des Sonntags.
     await expect(
       liveSection.getByRole('heading', { name: 'Team' }),
     ).toBeVisible()

--- a/frontend/src/admin/kasse/GeldtransitDialog.tsx
+++ b/frontend/src/admin/kasse/GeldtransitDialog.tsx
@@ -8,6 +8,7 @@ import { EuroField } from '@/components/common/FormFields'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -102,57 +103,60 @@ export function GeldtransitDialog({
               : 'Bargeld aus der Kasse nehmen (z.B. Abschöpfung in den Tresor). Der Soll-Bestand sinkt entsprechend.'}
           </DialogDescription>
         </DialogHeader>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault()
-            void form.handleSubmit(onSubmit)()
-          }}
-        >
-          <FieldGroup>
-            <EuroField
-              form={form}
-              name="betragCents"
-              label="Betrag"
-              withLabel
-              placeholder="z.B. 25,00"
-              className="w-44"
-            />
-            <Field
-              data-invalid={!!form.formState.errors.kommentar}
-              className="gap-1"
-            >
-              <FieldLabel htmlFor="bewegung-kommentar">Kommentar</FieldLabel>
-              <Input
-                id="bewegung-kommentar"
-                {...form.register('kommentar')}
-                aria-invalid={!!form.formState.errors.kommentar}
-                placeholder={
-                  istEinlage
-                    ? 'z.B. Wechselgeld Nachschub'
-                    : 'z.B. Abschöpfung in den Tresor'
-                }
+        <DialogBody>
+          <form
+            id="geldtransit-form"
+            onSubmit={(e) => {
+              e.preventDefault()
+              void form.handleSubmit(onSubmit)()
+            }}
+          >
+            <FieldGroup>
+              <EuroField
+                form={form}
+                name="betragCents"
+                label="Betrag"
+                withLabel
+                placeholder="z.B. 25,00"
+                className="w-44"
               />
-              {form.formState.errors.kommentar && (
-                <FieldError errors={[form.formState.errors.kommentar]} />
-              )}
-            </Field>
-          </FieldGroup>
-          <DialogFooter className="mt-4">
-            <Button
-              type="button"
-              variant="outline"
-              disabled={loading}
-              onClick={() => {
-                onOpenChange(false)
-              }}
-            >
-              Abbrechen
-            </Button>
-            <Button type="submit" disabled={loading}>
-              {titel}
-            </Button>
-          </DialogFooter>
-        </form>
+              <Field
+                data-invalid={!!form.formState.errors.kommentar}
+                className="gap-1"
+              >
+                <FieldLabel htmlFor="bewegung-kommentar">Kommentar</FieldLabel>
+                <Input
+                  id="bewegung-kommentar"
+                  {...form.register('kommentar')}
+                  aria-invalid={!!form.formState.errors.kommentar}
+                  placeholder={
+                    istEinlage
+                      ? 'z.B. Wechselgeld Nachschub'
+                      : 'z.B. Abschöpfung in den Tresor'
+                  }
+                />
+                {form.formState.errors.kommentar && (
+                  <FieldError errors={[form.formState.errors.kommentar]} />
+                )}
+              </Field>
+            </FieldGroup>
+          </form>
+        </DialogBody>
+        <DialogFooter className="mt-4">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={loading}
+            onClick={() => {
+              onOpenChange(false)
+            }}
+          >
+            Abbrechen
+          </Button>
+          <Button type="submit" form="geldtransit-form" disabled={loading}>
+            {titel}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/frontend/src/admin/kasse/KasseAbschliessenSection.tsx
+++ b/frontend/src/admin/kasse/KasseAbschliessenSection.tsx
@@ -11,6 +11,7 @@ import { EuroField } from '@/components/common/FormFields'
 import {
   AlertDialog,
   AlertDialogAction,
+  AlertDialogBody,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -21,7 +22,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { BackendError } from '@/lib/Backend'
 import { getActionErrorMessage } from '@/lib/errorMessages'
-import { cn, formatCents } from '@/lib/utils'
+import { cn, formatEuro } from '@/lib/utils'
 
 import { kasseBackend, useKassenbestand } from './hooks'
 import {
@@ -75,7 +76,7 @@ function offeneTischeWarnung(
 ): string | null {
   if (anzahl <= 0) return null
   const tischWort = anzahl === 1 ? 'Tisch ist' : 'Tische sind'
-  return `${String(anzahl)} ${tischWort} noch offen (${formatCents(saldoCents)} €).`
+  return `${String(anzahl)} ${tischWort} noch offen (${formatEuro(saldoCents)}).`
 }
 
 export function KasseAbschliessenSection({
@@ -225,15 +226,13 @@ export function KasseAbschliessenSection({
             <div className="text-right">
               <div className="text-muted-foreground">Soll</div>
               <div className="text-base font-semibold">
-                {sollBestandCents !== null
-                  ? `${formatCents(sollBestandCents)} €`
-                  : '—'}
+                {sollBestandCents !== null ? formatEuro(sollBestandCents) : '—'}
               </div>
             </div>
             <div className="text-right">
               <div className="text-muted-foreground">Gezählt</div>
               <div className="text-base font-semibold">
-                {formatCents(gezaehltCents)} €
+                {formatEuro(gezaehltCents)}
               </div>
             </div>
             <div className="text-right">
@@ -247,7 +246,7 @@ export function KasseAbschliessenSection({
                 )}
               >
                 {liveDifferenzCents !== null
-                  ? `${formatCents(liveDifferenzCents)} €`
+                  ? formatEuro(liveDifferenzCents)
                   : '—'}
               </div>
             </div>
@@ -283,30 +282,26 @@ export function KasseAbschliessenSection({
             </AlertDialogDescription>
           </AlertDialogHeader>
 
-          <div className="space-y-4 text-sm">
+          <AlertDialogBody className="space-y-4 text-sm">
             <dl className="space-y-1">
               <div className="flex justify-between gap-4">
                 <dt className="text-muted-foreground">Soll-Bestand</dt>
                 <dd>
                   {sollBestandCents !== null
-                    ? `${formatCents(sollBestandCents)} €`
+                    ? formatEuro(sollBestandCents)
                     : '—'}
                 </dd>
               </div>
               <div className="flex justify-between gap-4">
                 <dt className="text-muted-foreground">Ist-Bestand (gezählt)</dt>
                 <dd>
-                  {istBestandCents !== null
-                    ? `${formatCents(istBestandCents)} €`
-                    : '—'}
+                  {istBestandCents !== null ? formatEuro(istBestandCents) : '—'}
                 </dd>
               </div>
               <div className="flex justify-between gap-4 font-medium">
                 <dt>Differenz</dt>
                 <dd>
-                  {differenzCents !== null
-                    ? `${formatCents(differenzCents)} €`
-                    : '—'}
+                  {differenzCents !== null ? formatEuro(differenzCents) : '—'}
                 </dd>
               </div>
             </dl>
@@ -318,7 +313,7 @@ export function KasseAbschliessenSection({
                   <dt className="text-muted-foreground">Umsatz</dt>
                   <dd>
                     {liveData
-                      ? `${formatCents(liveData.summary.gesamtUmsatzCents)} €`
+                      ? formatEuro(liveData.summary.gesamtUmsatzCents)
                       : '—'}
                   </dd>
                 </div>
@@ -326,7 +321,7 @@ export function KasseAbschliessenSection({
                   <dt className="text-muted-foreground">Stornierungen</dt>
                   <dd>
                     {liveData
-                      ? `${formatCents(liveData.summary.gesamtStornierungenCents)} €`
+                      ? formatEuro(liveData.summary.gesamtStornierungenCents)
                       : '—'}
                   </dd>
                 </div>
@@ -334,13 +329,13 @@ export function KasseAbschliessenSection({
                   <dt className="text-muted-foreground">Geldtransit</dt>
                   <dd>
                     {liveData
-                      ? `${formatCents(liveData.summary.geldtransitCents)} €`
+                      ? formatEuro(liveData.summary.geldtransitCents)
                       : '—'}
                   </dd>
                 </div>
               </dl>
             </div>
-          </div>
+          </AlertDialogBody>
 
           <AlertDialogFooter>
             <AlertDialogCancel disabled={loading}>Abbrechen</AlertDialogCancel>

--- a/frontend/src/admin/kasse/ZaehlhilfeDialog.tsx
+++ b/frontend/src/admin/kasse/ZaehlhilfeDialog.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -11,7 +12,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { formatCents } from '@/lib/utils'
+import { formatEuro } from '@/lib/utils'
 
 import {
   type Nennwert,
@@ -53,43 +54,47 @@ function ZaehlhilfeInhalt({
 
   return (
     <>
-      <div className="grid grid-cols-2 gap-x-6 gap-y-2">
-        {NENNWERTE_CENTS.map((nennwert) => {
-          const id = `zaehlhilfe-${String(nennwert)}`
-          const anzahl = stueckzahlen[nennwert]
-          return (
-            <div
-              key={nennwert}
-              className="flex items-center justify-between gap-3"
-            >
-              <Label htmlFor={id} className="w-14 shrink-0">
-                {nennwertLabel(nennwert)}
-              </Label>
-              <Input
-                id={id}
-                type="text"
-                inputMode="numeric"
-                placeholder="0"
-                className="h-8 w-20 text-right"
-                value={anzahl !== undefined && anzahl > 0 ? String(anzahl) : ''}
-                onChange={(e) => {
-                  setAnzahl(nennwert, e.target.value)
-                }}
-              />
-            </div>
-          )
-        })}
-      </div>
+      <DialogBody className="flex flex-col gap-6">
+        <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+          {NENNWERTE_CENTS.map((nennwert) => {
+            const id = `zaehlhilfe-${String(nennwert)}`
+            const anzahl = stueckzahlen[nennwert]
+            return (
+              <div
+                key={nennwert}
+                className="flex items-center justify-between gap-3"
+              >
+                <Label htmlFor={id} className="w-14 shrink-0">
+                  {nennwertLabel(nennwert)}
+                </Label>
+                <Input
+                  id={id}
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="0"
+                  className="h-11 w-20 text-right"
+                  value={
+                    anzahl !== undefined && anzahl > 0 ? String(anzahl) : ''
+                  }
+                  onChange={(e) => {
+                    setAnzahl(nennwert, e.target.value)
+                  }}
+                />
+              </div>
+            )
+          })}
+        </div>
 
-      <div className="flex items-center justify-between border-t pt-4 text-sm">
-        <span className="text-muted-foreground">Summe</span>
-        <span
-          className="text-base font-semibold"
-          data-testid="zaehlhilfe-summe"
-        >
-          {formatCents(summeCents)} €
-        </span>
-      </div>
+        <div className="flex items-center justify-between border-t pt-4 text-sm">
+          <span className="text-muted-foreground">Summe</span>
+          <span
+            className="text-base font-semibold"
+            data-testid="zaehlhilfe-summe"
+          >
+            {formatEuro(summeCents)}
+          </span>
+        </div>
+      </DialogBody>
 
       <DialogFooter>
         <Button

--- a/frontend/src/admin/products/EditProductDialog.tsx
+++ b/frontend/src/admin/products/EditProductDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -94,19 +95,21 @@ export function EditProductDialog(props: EditProductDialogProps) {
             Du kannst Name und Kategorie des Produkts ändern.
           </DialogDescription>
         </DialogHeader>
-        <form
-          id="product-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-            void form.handleSubmit(onSubmit)()
-          }}
-        >
-          <FieldGroup>
-            <NameField form={form} withLabel />
-            <CategoryField form={form} withLabel />
-            <SteuersatzField form={form} withLabel />
-          </FieldGroup>
-        </form>
+        <DialogBody>
+          <form
+            id="product-form"
+            onSubmit={(e) => {
+              e.preventDefault()
+              void form.handleSubmit(onSubmit)()
+            }}
+          >
+            <FieldGroup>
+              <NameField form={form} withLabel />
+              <CategoryField form={form} withLabel />
+              <SteuersatzField form={form} withLabel />
+            </FieldGroup>
+          </form>
+        </DialogBody>
         <DialogFooter className="mt-4">
           <DialogClose asChild>
             <Button

--- a/frontend/src/admin/products/EditVariantDialog.tsx
+++ b/frontend/src/admin/products/EditVariantDialog.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -106,22 +107,24 @@ export function EditVariantDialog(props: EditVariantDialogProps) {
             Name und Preis der Variante ändern.
           </DialogDescription>
         </DialogHeader>
-        <form
-          id="edit-variant-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-            void form.handleSubmit(onSubmit)()
-          }}
-        >
-          <FieldGroup>
-            <NameField
-              form={form}
-              withLabel
-              placeholder="z.B. Klein, Groß, 0.5L"
-            />
-            <PriceField form={form} withLabel />
-          </FieldGroup>
-        </form>
+        <DialogBody>
+          <form
+            id="edit-variant-form"
+            onSubmit={(e) => {
+              e.preventDefault()
+              void form.handleSubmit(onSubmit)()
+            }}
+          >
+            <FieldGroup>
+              <NameField
+                form={form}
+                withLabel
+                placeholder="z.B. Klein, Groß, 0.5L"
+              />
+              <PriceField form={form} withLabel />
+            </FieldGroup>
+          </form>
+        </DialogBody>
         <DialogFooter className="mt-4 sm:justify-between">
           <Button
             variant="ghost"

--- a/frontend/src/admin/products/NewProductDialog.tsx
+++ b/frontend/src/admin/products/NewProductDialog.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -98,23 +99,25 @@ export function NewProductDialog(props: NewProductDialogProps) {
             können später hinzugefügt werden.
           </DialogDescription>
         </DialogHeader>
-        <form
-          id="product-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-            void form.handleSubmit(onSubmit)()
-          }}
-        >
-          <FieldGroup>
-            <NameField
-              form={form}
-              withLabel
-              placeholder="Produktname eingeben"
-            />
-            <CategoryField form={form} withLabel />
-            <SteuersatzField form={form} withLabel />
-          </FieldGroup>
-        </form>
+        <DialogBody>
+          <form
+            id="product-form"
+            onSubmit={(e) => {
+              e.preventDefault()
+              void form.handleSubmit(onSubmit)()
+            }}
+          >
+            <FieldGroup>
+              <NameField
+                form={form}
+                withLabel
+                placeholder="Produktname eingeben"
+              />
+              <CategoryField form={form} withLabel />
+              <SteuersatzField form={form} withLabel />
+            </FieldGroup>
+          </form>
+        </DialogBody>
         <DialogFooter className="mt-4">
           <DialogClose asChild>
             <Button

--- a/frontend/src/admin/products/NewVariantDialog.tsx
+++ b/frontend/src/admin/products/NewVariantDialog.tsx
@@ -7,6 +7,7 @@ import { NameField, PriceField } from '@/components/common/FormFields'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -77,22 +78,24 @@ export function NewVariantDialog(props: NewVariantDialogProps) {
             werden.
           </DialogDescription>
         </DialogHeader>
-        <form
-          id="variant-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-            void form.handleSubmit(onSubmit)()
-          }}
-        >
-          <FieldGroup>
-            <NameField
-              form={form}
-              withLabel
-              placeholder="z.B. Klein, Groß, 0.5L"
-            />
-            <PriceField form={form} withLabel />
-          </FieldGroup>
-        </form>
+        <DialogBody>
+          <form
+            id="variant-form"
+            onSubmit={(e) => {
+              e.preventDefault()
+              void form.handleSubmit(onSubmit)()
+            }}
+          >
+            <FieldGroup>
+              <NameField
+                form={form}
+                withLabel
+                placeholder="z.B. Klein, Groß, 0.5L"
+              />
+              <PriceField form={form} withLabel />
+            </FieldGroup>
+          </form>
+        </DialogBody>
         <DialogFooter className="mt-4">
           <DialogClose asChild>
             <Button

--- a/frontend/src/admin/reporting/LiveReportingSection.tsx
+++ b/frontend/src/admin/reporting/LiveReportingSection.tsx
@@ -30,7 +30,7 @@ import { StornoItem } from './StornoItem'
 import { StornoAggregat } from './StornoServicekraft'
 import { SummaryCard } from './SummaryCard'
 import type { LiveReportingData } from './types'
-import { formatBediener, formatDatum, formatStand } from './utils'
+import { formatDatum, formatServicekraft, formatStand } from './utils'
 import { VerkaufStatistik } from './VerkaufStatistik'
 
 // Nach fünf Einträgen wird die Liste offener Tische gekürzt; „Alle n anzeigen"
@@ -228,7 +228,7 @@ export function LiveReportingSection({
                   >
                     <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                       <span className="text-sm font-medium">
-                        {formatBediener(sk.userName, sk.name)}
+                        {formatServicekraft(sk.userName, sk.name)}
                       </span>
                       {sk.erledigt ? (
                         <span className="text-xs font-medium text-primary">
@@ -266,12 +266,9 @@ export function LiveReportingSection({
         </div>
       </div>
 
-      {/* Verkäufe pro Produkt: dieselbe Aufbereitung wie in der Abrechnung */}
-      <div className="rounded-xl border p-5">
-        <VerkaufStatistik produktStatistik={liveData.produktStatistik} />
-      </div>
-
-      {/* Stornierungen: eingeklappte Zeile, Aufklappen zeigt die Detail-Liste */}
+      {/* Stornierungen: eingeklappte Zeile, Aufklappen zeigt die Detail-Liste.
+          Bewusst über der Produktstatistik — Stornos sind das Kontroll-Signal,
+          das zuerst auffallen soll. */}
       {liveData.stornierungen.length > 0 && (
         <Collapsible>
           <div className="rounded-lg border">
@@ -316,6 +313,11 @@ export function LiveReportingSection({
           </div>
         </Collapsible>
       )}
+
+      {/* Verkäufe pro Produkt: dieselbe Aufbereitung wie in der Abrechnung */}
+      <div className="rounded-xl border p-5">
+        <VerkaufStatistik produktStatistik={liveData.produktStatistik} />
+      </div>
     </div>
   )
 }

--- a/frontend/src/admin/reporting/ReportingResults.tsx
+++ b/frontend/src/admin/reporting/ReportingResults.tsx
@@ -7,7 +7,7 @@ import { formatEuro } from '@/lib/utils'
 import { StornoItem } from './StornoItem'
 import { StornoMarker } from './StornoServicekraft'
 import type { AbgeschlosseneSitzung, ReportingData } from './types'
-import { formatBediener, formatDatumLang, formatLocalTime } from './utils'
+import { formatDatumLang, formatLocalTime, formatServicekraft } from './utils'
 import { VerkaufStatistik } from './VerkaufStatistik'
 
 // Berichtskopf-Zeile: Datum, Eröffnungs-/Abschlusszeit, abschließender Benutzer
@@ -189,7 +189,7 @@ export function ReportingResults({
                     className="flex items-center justify-between gap-2 border-b py-2 last:border-b-0"
                   >
                     <span className="flex flex-col">
-                      {formatBediener(sk.userName, sk.name)}
+                      {formatServicekraft(sk.userName, sk.name)}
                       {stornoAnzahl > 0 && (
                         <StornoMarker anzahl={stornoAnzahl} />
                       )}

--- a/frontend/src/admin/reporting/StornoItem.tsx
+++ b/frontend/src/admin/reporting/StornoItem.tsx
@@ -3,10 +3,10 @@ import { Item, ItemContent } from '@/components/ui/item'
 import { formatEuro, formatPositionName } from '@/lib/utils'
 
 import type { StornierungDetail } from './types'
-import { formatBediener, formatLocalTime } from './utils'
+import { formatLocalTime, formatServicekraft } from './utils'
 
 // StornoItem rendert einen einzelnen Stornierungs-Eintrag einheitlich für das
-// Live-Dashboard und die Kassenberichte: Tisch/Direktverkauf + Bediener, Uhrzeit
+// Live-Dashboard und die Kassenberichte: Tisch/Direktverkauf + Servicekraft, Uhrzeit
 // (HH:MM), Bar-Rückgabe-Status, Betrag und die stornierten Positionen.
 export function StornoItem({ storno }: { storno: StornierungDetail }) {
   return (
@@ -18,7 +18,7 @@ export function StornoItem({ storno }: { storno: StornierungDetail }) {
               {storno.quelle === 'direktverkauf'
                 ? 'Direktverkauf'
                 : storno.tischName}{' '}
-              · {formatBediener(storno.userName, storno.name)}
+              · {formatServicekraft(storno.userName, storno.name)}
             </p>
             <p className="mt-0.5 text-xs text-muted-foreground">
               {formatLocalTime(storno.zeitpunkt)}

--- a/frontend/src/admin/reporting/StornoServicekraft.tsx
+++ b/frontend/src/admin/reporting/StornoServicekraft.tsx
@@ -3,7 +3,7 @@ import { Ban } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 import type { StornierungServicekraft } from './types'
-import { formatBediener } from './utils'
+import { formatServicekraft } from './utils'
 
 // StornoMarker markiert eine Servicekraft-Zeile mit Stornos als rotes
 // Kontroll-Signal ("N Storno"). Wird nur bei ≥ 1 Storno gerendert.
@@ -32,7 +32,7 @@ export function StornoAggregat({
       {eintraege
         .map(
           (e) =>
-            `${formatBediener(e.userName, e.name)} ${String(e.anzahlStornierungen)}`,
+            `${formatServicekraft(e.userName, e.name)} ${String(e.anzahlStornierungen)}`,
         )
         .join(' · ')}
     </p>

--- a/frontend/src/admin/reporting/VerkaufStatistik.tsx
+++ b/frontend/src/admin/reporting/VerkaufStatistik.tsx
@@ -50,10 +50,12 @@ function StatistikZeile({
 
 // VerkaufStatistik zeigt die Verkäufe je Produkt und Variante einer
 // Kassensitzung, in Kategorie-Abschnitte (Essen → Getränke → Sonstiges)
-// gegliedert. Zwei bewusst getrennte Zahlen: ausgegebene Menge (Produktion) und
-// Umsatz (Einnahmen) — nicht ineinander umrechenbar. Ein-Varianten-Produkte
-// erscheinen als eine Zeile; sonst Produkt-Zwischensumme mit eingerückten
-// Varianten. Das Backend liefert die Liste fertig gruppiert und sortiert.
+// gegliedert. Beide Zahlen ruhen auf den aufgenommenen Bestellungen: die
+// ausgegebene Menge und der Umsatz (Bestellwert derselben Portionen zu
+// Bestellzeit-Preisen). Ein-Varianten-Produkte erscheinen als eine Zeile; sonst
+// Produkt-Zwischensumme mit eingerückten Varianten. Das Backend liefert die
+// Liste fertig gruppiert und sortiert. Bei vielen Produkten scrollt die Liste
+// innerhalb eines gedeckelten Bereichs, statt die Seite zu überlängen.
 export function VerkaufStatistik({
   produktStatistik,
 }: {
@@ -63,18 +65,16 @@ export function VerkaufStatistik({
     <div className="max-w-4xl">
       <div className="mb-2 text-sm font-semibold">Verkäufe pro Produkt</div>
       <p className="mb-2 text-xs text-muted-foreground">
-        „Ausgegeben" zählt zubereitete Portionen (bestellt minus Korrekturen,
-        inklusive Direktverkauf); „Umsatz" zählt die Einnahmen (kassiert und
-        Direktverkauf minus Storno). Die beiden Zahlen ruhen auf
-        unterschiedlichen Grundlagen und sind nicht ineinander umrechenbar.
+        Zahlen basieren auf den aufgenommenen Bestellungen, nicht auf kassierten
+        Zahlungen.
       </p>
       {produktStatistik.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           Keine Verkäufe in dieser Kassensitzung.
         </p>
       ) : (
-        <div className="overflow-hidden rounded-lg border">
-          <div className="grid grid-cols-[1.6fr_1fr_1fr] gap-x-3 bg-sidebar px-3 py-2 text-xs font-semibold text-muted-foreground">
+        <div className="max-h-[60vh] overflow-y-auto rounded-lg border">
+          <div className="sticky top-0 z-10 grid grid-cols-[1.6fr_1fr_1fr] gap-x-3 bg-sidebar px-3 py-2 text-xs font-semibold text-muted-foreground">
             <span>Produkt</span>
             <span className="text-right">Ausgegeben</span>
             <span className="text-right">Umsatz</span>

--- a/frontend/src/admin/reporting/utils.ts
+++ b/frontend/src/admin/reporting/utils.ts
@@ -1,6 +1,6 @@
 // Admin-Auswertungen zeigen den eingefrorenen Username, ergänzt um den live
 // aufgelösten Klarnamen: "username (Klarname)". Fehlt der Klarname, nur Username.
-export function formatBediener(userName: string, name: string): string {
+export function formatServicekraft(userName: string, name: string): string {
   return name ? `${userName} (${name})` : userName
 }
 

--- a/frontend/src/admin/tables/EditTischDialog.tsx
+++ b/frontend/src/admin/tables/EditTischDialog.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -103,17 +104,19 @@ export function EditTischDialog(props: EditTischDialogProps) {
             Du kannst den Namen des Tisches ändern.
           </DialogDescription>
         </DialogHeader>
-        <form
-          id="table-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-            void form.handleSubmit(onSubmit)()
-          }}
-        >
-          <FieldGroup>
-            <NameField form={form} withLabel />
-          </FieldGroup>
-        </form>
+        <DialogBody>
+          <form
+            id="table-form"
+            onSubmit={(e) => {
+              e.preventDefault()
+              void form.handleSubmit(onSubmit)()
+            }}
+          >
+            <FieldGroup>
+              <NameField form={form} withLabel />
+            </FieldGroup>
+          </form>
+        </DialogBody>
 
         <DialogFooter className="mt-4 sm:justify-between">
           {hatSaldo ? (

--- a/frontend/src/admin/tables/NewTischDialog.tsx
+++ b/frontend/src/admin/tables/NewTischDialog.tsx
@@ -8,6 +8,7 @@ import { NameField } from '@/components/common/FormFields'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -77,17 +78,19 @@ export function NewTischDialog(props: NewTischDialogProps) {
             Den Namen kannst du später jederzeit ändern.
           </DialogDescription>
         </DialogHeader>
-        <form
-          id="table-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-            void form.handleSubmit(onSubmit)()
-          }}
-        >
-          <FieldGroup>
-            <NameField form={form} withLabel placeholder="z.B. Tisch 34" />
-          </FieldGroup>
-        </form>
+        <DialogBody>
+          <form
+            id="table-form"
+            onSubmit={(e) => {
+              e.preventDefault()
+              void form.handleSubmit(onSubmit)()
+            }}
+          >
+            <FieldGroup>
+              <NameField form={form} withLabel placeholder="z.B. Tisch 34" />
+            </FieldGroup>
+          </form>
+        </DialogBody>
 
         <DialogFooter className="mt-4">
           <DialogClose asChild>

--- a/frontend/src/admin/users/AdminUsersPage.tsx
+++ b/frontend/src/admin/users/AdminUsersPage.tsx
@@ -110,7 +110,7 @@ export function AdminUsersPage() {
             created={(user, onetimePassword) => {
               invalidateUsers()
               setUserCreatedState({ user, onetimePassword, open: true })
-              toast.success(`Neuer Benutzer "${user.name}" wurde erstellt.`)
+              toast.success(`Neuer Helfer "${user.name}" wurde erstellt.`)
             }}
           />
         }
@@ -130,7 +130,7 @@ export function AdminUsersPage() {
           onResetPassword={resetPassword}
           onDeleted={() => {
             invalidateUsers()
-            toast.success('Benutzer wurde gelöscht.')
+            toast.success('Helfer wurde gelöscht.')
           }}
         />
         <HelferPanels />

--- a/frontend/src/admin/users/EditUserDialog.tsx
+++ b/frontend/src/admin/users/EditUserDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -48,7 +49,7 @@ export function EditUserDialog(props: EditUserDialogProps) {
 
   const { loading, run: runSave } = useFormActionSubmit({
     form,
-    actionLabel: 'Benutzer speichern',
+    actionLabel: 'Helfer speichern',
     fieldErrorsByCode: {
       username_already_exists: {
         username: 'Dieser Benutzername ist bereits vergeben.',
@@ -81,22 +82,24 @@ export function EditUserDialog(props: EditUserDialogProps) {
         <DialogHeader className="mb-4">
           <DialogTitle>{props.user.name}</DialogTitle>
           <DialogDescription>
-            Du kannst Name, Benutzername und Rolle des Benutzers ändern.
+            Du kannst Name, Benutzername und Rolle des Helfers ändern.
           </DialogDescription>
         </DialogHeader>
-        <form
-          id="user-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-            void form.handleSubmit(onSubmit)()
-          }}
-        >
-          <FieldGroup>
-            <NameField form={form} withLabel />
-            <UsernameField form={form} withLabel />
-            <RoleField form={form} withLabel />
-          </FieldGroup>
-        </form>
+        <DialogBody>
+          <form
+            id="user-form"
+            onSubmit={(e) => {
+              e.preventDefault()
+              void form.handleSubmit(onSubmit)()
+            }}
+          >
+            <FieldGroup>
+              <NameField form={form} withLabel />
+              <UsernameField form={form} withLabel />
+              <RoleField form={form} withLabel />
+            </FieldGroup>
+          </form>
+        </DialogBody>
         <DialogFooter className="mt-4">
           <DialogClose asChild>
             <Button variant="outline" disabled={loading}>

--- a/frontend/src/admin/users/NewUserDialog.tsx
+++ b/frontend/src/admin/users/NewUserDialog.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -45,7 +46,7 @@ export function NewUserDialog(props: NewUserDialogProps) {
 
   const { loading, run } = useFormActionSubmit({
     form,
-    actionLabel: 'Benutzer anlegen',
+    actionLabel: 'Helfer anlegen',
     fieldErrorsByCode: {
       username_already_exists: {
         username: 'Dieser Benutzername ist bereits vergeben.',
@@ -84,24 +85,26 @@ export function NewUserDialog(props: NewUserDialogProps) {
       </DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader className="mb-4">
-          <DialogTitle>Neuen Benutzer anlegen</DialogTitle>
+          <DialogTitle>Neuen Helfer anlegen</DialogTitle>
           <DialogDescription>
-            Das Passwort kann der Benutzer später selbst festlegen.
+            Das Passwort kann der Helfer später selbst festlegen.
           </DialogDescription>
         </DialogHeader>
-        <form
-          id="user-form"
-          onSubmit={(e) => {
-            e.preventDefault()
-            void form.handleSubmit(onSubmit)()
-          }}
-        >
-          <FieldGroup>
-            <NameField form={form} withLabel />
-            <UsernameField form={form} withLabel />
-            <RoleField form={form} withLabel />
-          </FieldGroup>
-        </form>
+        <DialogBody>
+          <form
+            id="user-form"
+            onSubmit={(e) => {
+              e.preventDefault()
+              void form.handleSubmit(onSubmit)()
+            }}
+          >
+            <FieldGroup>
+              <NameField form={form} withLabel />
+              <UsernameField form={form} withLabel />
+              <RoleField form={form} withLabel />
+            </FieldGroup>
+          </form>
+        </DialogBody>
         <DialogFooter className="mt-4">
           <DialogClose asChild>
             <Button
@@ -119,7 +122,7 @@ export function NewUserDialog(props: NewUserDialogProps) {
             form="user-form"
             disabled={loading || !form.formState.isValid}
           >
-            {loading ? <Spinner /> : null} Benutzer anlegen
+            {loading ? <Spinner /> : null} Helfer anlegen
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/admin/users/PasswordResetDialog.tsx
+++ b/frontend/src/admin/users/PasswordResetDialog.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -29,23 +30,25 @@ export function PasswordResetDialog(props: PasswordResetDialogProps) {
           <DialogTitle>Passwort zurückgesetzt!</DialogTitle>
           <DialogDescription>
             Das Passwort für {props.username} wurde zurückgesetzt. Beim nächsten
-            Anmelden muss der Benutzer mit dem untenstehenden Code sein neues
+            Anmelden muss der Helfer mit dem untenstehenden Code sein neues
             Passwort setzen.
           </DialogDescription>
         </DialogHeader>
-        <Field className="gap-1">
-          <FieldLabel>Benutzername</FieldLabel>
-          <p className="text-3xl">{props.username}</p>
-        </Field>
-        <Field className="gap-1">
-          <FieldLabel>Code</FieldLabel>
-          <p
-            data-testid="onetime-password"
-            className="text-3xl tracking-widest"
-          >
-            {props.onetimePassword}
-          </p>
-        </Field>
+        <DialogBody className="flex flex-col gap-6">
+          <Field className="gap-1">
+            <FieldLabel>Benutzername</FieldLabel>
+            <p className="text-3xl">{props.username}</p>
+          </Field>
+          <Field className="gap-1">
+            <FieldLabel>Code</FieldLabel>
+            <p
+              data-testid="onetime-password"
+              className="text-3xl tracking-widest"
+            >
+              {props.onetimePassword}
+            </p>
+          </Field>
+        </DialogBody>
         <DialogFooter className="mt-4">
           <DialogClose asChild>
             <Button>Okay</Button>

--- a/frontend/src/admin/users/UserCreatedDialog.tsx
+++ b/frontend/src/admin/users/UserCreatedDialog.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -28,26 +29,28 @@ export function UserCreatedDialog(props: UserCreatedDialogProps) {
     <Dialog open={props.open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Benutzer wurde angelegt!</DialogTitle>
+          <DialogTitle>Helfer wurde angelegt!</DialogTitle>
           <DialogDescription>
-            Für {props.user?.name} wurde ein {props.user?.role}-Benutzer
-            angelegt. Beim erstmaligen Anmelden muss der Benutzer mit dem
-            untenstehenden Code sein Passwort setzen.
+            Für {props.user?.name} wurde ein {props.user?.role}-Helfer angelegt.
+            Beim erstmaligen Anmelden muss der Helfer mit dem untenstehenden
+            Code sein Passwort setzen.
           </DialogDescription>
         </DialogHeader>
-        <Field className="gap-1">
-          <FieldLabel>Benutzername</FieldLabel>
-          <p className="text-3xl">{props.user?.username}</p>
-        </Field>
-        <Field className="gap-1">
-          <FieldLabel>Code</FieldLabel>
-          <p
-            data-testid="onetime-password"
-            className="text-3xl tracking-widest"
-          >
-            {props.onetimePassword}
-          </p>
-        </Field>
+        <DialogBody className="flex flex-col gap-6">
+          <Field className="gap-1">
+            <FieldLabel>Benutzername</FieldLabel>
+            <p className="text-3xl">{props.user?.username}</p>
+          </Field>
+          <Field className="gap-1">
+            <FieldLabel>Code</FieldLabel>
+            <p
+              data-testid="onetime-password"
+              className="text-3xl tracking-widest"
+            >
+              {props.onetimePassword}
+            </p>
+          </Field>
+        </DialogBody>
         <DialogFooter className="mt-4">
           <DialogClose asChild>
             <Button>Okay</Button>

--- a/frontend/src/admin/users/UserRow.tsx
+++ b/frontend/src/admin/users/UserRow.tsx
@@ -69,9 +69,7 @@ export function UserRow(props: UserRowProps) {
       <span className="flex items-center gap-2 text-xs text-muted-foreground">
         <Switch
           className="cursor-pointer"
-          aria-label={
-            isActive ? 'Benutzer deaktivieren' : 'Benutzer aktivieren'
-          }
+          aria-label={isActive ? 'Helfer deaktivieren' : 'Helfer aktivieren'}
           disabled={props.loading}
           checked={isActive}
           onCheckedChange={(checked) => {
@@ -90,7 +88,7 @@ export function UserRow(props: UserRowProps) {
           size="icon-sm"
           variant="ghost"
           className="cursor-pointer rounded-full"
-          aria-label="Benutzer bearbeiten"
+          aria-label="Helfer bearbeiten"
           onClick={() => {
             props.onEdit(props.user.id)
           }}
@@ -136,9 +134,9 @@ export function UserRow(props: UserRowProps) {
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Benutzer löschen?</AlertDialogTitle>
+            <AlertDialogTitle>Helfer löschen?</AlertDialogTitle>
             <AlertDialogDescription>
-              Der Benutzer &ldquo;{props.user.name}&rdquo; wird unwiderruflich
+              Der Helfer &ldquo;{props.user.name}&rdquo; wird unwiderruflich
               gelöscht.
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/frontend/src/admin/users/Users.tsx
+++ b/frontend/src/admin/users/Users.tsx
@@ -23,13 +23,13 @@ interface UsersProps {
 // und Aktionen. Ersetzt das frühere Kachel-Grid.
 export function Users(props: UsersProps) {
   const { loading: activateLoading, run: runActivate } = useActionSubmit({
-    actionLabel: 'Benutzer aktivieren',
+    actionLabel: 'Helfer aktivieren',
   })
   const { loading: deactivateLoading, run: runDeactivate } = useActionSubmit({
-    actionLabel: 'Benutzer deaktivieren',
+    actionLabel: 'Helfer deaktivieren',
   })
   const { loading: deleteLoading, run: runDelete } = useActionSubmit({
-    actionLabel: 'Benutzer löschen',
+    actionLabel: 'Helfer löschen',
   })
 
   const loading = activateLoading || deactivateLoading || deleteLoading
@@ -59,8 +59,8 @@ export function Users(props: UsersProps) {
     return (
       <EmptyState
         icon={UsersIcon}
-        title="Keine Benutzer vorhanden"
-        description="Erstelle einen neuen Benutzer, um loszulegen."
+        title="Keine Helfer vorhanden"
+        description="Erstelle einen neuen Helfer, um loszulegen."
       />
     )
   }

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -56,7 +56,10 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          // flex-col + Höhen-Cap: mit AlertDialogBody als einzigem Scrollbereich
+          // bleiben Header und Footer (Bestätigen/Abbrechen) auch bei langer
+          // Vorschau gepinnt. Autofokus bleibt Radix-Standard (Button-Fokus).
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 flex max-h-[85dvh] w-full -translate-x-1/2 -translate-y-1/2 flex-col gap-6 rounded-xl bg-popover p-6 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}
@@ -92,6 +95,22 @@ function AlertDialogFooter({
         "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
         className
       )}
+      {...props}
+    />
+  )
+}
+
+// AlertDialogBody ist der einzige Scrollbereich des Alert-Dialogs. Header und
+// Footer bleiben als direkte Flex-Kinder von AlertDialogContent gepinnt, damit
+// die Aktionsschaltflächen bei langer Vorschau erreichbar bleiben.
+function AlertDialogBody({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-body"
+      className={cn("-mx-6 min-h-0 overflow-y-auto px-6", className)}
       {...props}
     />
   )
@@ -184,6 +203,7 @@ function AlertDialogCancel({
 export {
   AlertDialog,
   AlertDialogAction,
+  AlertDialogBody,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -61,11 +61,15 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
-        // Kein Auto-Fokus beim Öffnen: auf dem Handy soll sich nicht ungefragt
-        // die Tastatur öffnen (der Nutzer tippt selbst das gewünschte Feld an).
-        // Fokus-Trap, Escape und Fokusrückgabe bleiben unberührt.
+        // Kein Auto-Fokus auf ein Eingabefeld beim Öffnen (keine ungefragte
+        // Tastatur auf dem Handy). Der Fokus wandert stattdessen auf den
+        // Dialog-Container (tabIndex -1 via Radix FocusScope), damit Fokus-Trap,
+        // Escape und Fokusrückgabe unverändert greifen.
         onOpenAutoFocus={(event) => {
           event.preventDefault()
+          if (event.currentTarget instanceof HTMLElement) {
+            event.currentTarget.focus({ preventScroll: true })
+          }
           onOpenAutoFocus?.(event)
         }}
         className={cn(

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -51,6 +51,7 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  onOpenAutoFocus,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
@@ -60,8 +61,17 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
+        // Kein Auto-Fokus beim Öffnen: auf dem Handy soll sich nicht ungefragt
+        // die Tastatur öffnen (der Nutzer tippt selbst das gewünschte Feld an).
+        // Fokus-Trap, Escape und Fokusrückgabe bleiben unberührt.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          onOpenAutoFocus?.(event)
+        }}
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          // flex-col + Höhen-Cap: mit DialogBody als einzigem Scrollbereich
+          // bleiben DialogHeader und DialogFooter gepinnt (Vorbild: drawer.tsx).
+          "fixed top-1/2 left-1/2 z-50 flex max-h-[85dvh] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col gap-6 rounded-xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}
@@ -90,6 +100,20 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="dialog-header"
       className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+// DialogBody ist der einzige Scrollbereich des Dialogs. DialogHeader und
+// DialogFooter sind direkte Flex-Kinder von DialogContent und bleiben dadurch
+// bei beliebig langem Inhalt sichtbar — die Aktionen im Footer bleiben auch bei
+// geöffneter Tastatur erreichbar. Analog zu DrawerBody in drawer.tsx.
+function DialogBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-body"
+      className={cn("-mx-6 min-h-0 overflow-y-auto px-6", className)}
       {...props}
     />
   )
@@ -153,6 +177,7 @@ function DialogDescription({
 
 export {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -82,10 +82,15 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         data-pending={pending || undefined}
-        // Kein Auto-Fokus beim Öffnen (keine ungefragte Tastatur auf dem Handy).
-        // Fokus-Trap, Escape und Fokusrückgabe bleiben unberührt.
+        // Kein Auto-Fokus auf ein Eingabefeld beim Öffnen (keine ungefragte
+        // Tastatur auf dem Handy). Der Fokus wandert stattdessen auf den
+        // Drawer-Container (tabIndex -1 via Radix FocusScope), damit Fokus-Trap,
+        // Escape und Fokusrückgabe unverändert greifen.
         onOpenAutoFocus={(event) => {
           event.preventDefault()
+          if (event.currentTarget instanceof HTMLElement) {
+            event.currentTarget.focus({ preventScroll: true })
+          }
           onOpenAutoFocus?.(event)
         }}
         onEscapeKeyDown={(event) => {

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -59,6 +59,7 @@ function DrawerContent({
   pending = false,
   onEscapeKeyDown,
   onInteractOutside,
+  onOpenAutoFocus,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Content> & {
   // Laufender Submit: Escape und Backdrop-Tap schließen den Drawer nicht,
@@ -81,6 +82,12 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         data-pending={pending || undefined}
+        // Kein Auto-Fokus beim Öffnen (keine ungefragte Tastatur auf dem Handy).
+        // Fokus-Trap, Escape und Fokusrückgabe bleiben unberührt.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          onOpenAutoFocus?.(event)
+        }}
         onEscapeKeyDown={(event) => {
           if (pendingRef.current) event.preventDefault()
           onEscapeKeyDown?.(event)

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -48,6 +48,7 @@ function SheetContent({
   children,
   side = "right",
   showCloseButton = true,
+  onOpenAutoFocus,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left"
@@ -59,6 +60,12 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         data-side={side}
+        // Kein Auto-Fokus beim Öffnen (keine ungefragte Tastatur auf dem Handy).
+        // Fokus-Trap, Escape und Fokusrückgabe bleiben unberührt.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          onOpenAutoFocus?.(event)
+        }}
         className={cn(
           "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
           className

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -60,10 +60,15 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         data-side={side}
-        // Kein Auto-Fokus beim Öffnen (keine ungefragte Tastatur auf dem Handy).
-        // Fokus-Trap, Escape und Fokusrückgabe bleiben unberührt.
+        // Kein Auto-Fokus auf ein Eingabefeld beim Öffnen (keine ungefragte
+        // Tastatur auf dem Handy). Der Fokus wandert stattdessen auf den
+        // Sheet-Container (tabIndex -1 via Radix FocusScope), damit Fokus-Trap,
+        // Escape und Fokusrückgabe unverändert greifen.
         onOpenAutoFocus={(event) => {
           event.preventDefault()
+          if (event.currentTarget instanceof HTMLElement) {
+            event.currentTarget.focus({ preventScroll: true })
+          }
           onOpenAutoFocus?.(event)
         }}
         className={cn(

--- a/frontend/src/service/TableSelectionPage.test.tsx
+++ b/frontend/src/service/TableSelectionPage.test.tsx
@@ -1,0 +1,120 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { AktiverTischMitFavorit, TischSession } from './table/Tisch'
+import { TableSelectionPage } from './TableSelectionPage'
+
+const navigate = vi.fn()
+vi.mock('react-router', () => ({
+  useNavigate: () => navigate,
+}))
+
+let meineTische: TischSession[] = []
+let alleTische: AktiverTischMitFavorit[] = []
+
+vi.mock('./table/hooks', () => ({
+  useMeineTischeState: () => ({ tische: meineTische, isPending: false }),
+  useAktiveTischeMitFavoriten: () => ({ tische: alleTische }),
+  useEigeneUebersicht: () => ({
+    uebersicht: {
+      anzahlBestellungen: 0,
+      bestellungenCents: 0,
+      anzahlZahlungen: 0,
+      zahlungenCents: 0,
+    },
+    isPending: false,
+  }),
+}))
+
+// Kindkomponenten auf Stubs reduzieren: der Test prüft die Such-/Favoriten-Logik
+// der Seite, nicht das Rendern der Karten oder des Drawers.
+vi.mock('./components/EigeneUebersicht', () => ({
+  EigeneUebersichtKarten: () => null,
+}))
+vi.mock('./components/MeinTischCard', () => ({
+  MeinTischCard: ({ state }: { state: TischSession }) => (
+    <div>{state.tischName}</div>
+  ),
+}))
+vi.mock('./components/TischAuswahlDrawer', () => ({
+  TischAuswahlDrawer: () => null,
+}))
+
+function tischSession(
+  tischId: number,
+  tischName: string,
+  offen: boolean,
+): TischSession {
+  return {
+    tischId,
+    tischName,
+    saldoCents: offen ? 500 : 0,
+    unbezahltePositionen: offen
+      ? // Nur die Länge zählt für die Offen/Erledigt-Gruppierung.
+        ([{ positionId: 'p1' }] as TischSession['unbezahltePositionen'])
+      : [],
+    gesamtZahlungenCents: 0,
+    fuerMichErledigt: !offen,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  meineTische = []
+  alleTische = []
+})
+
+describe('TableSelectionPage', () => {
+  it('zeigt bei leerem Suchfeld die Favoriten („Meine Tische")', () => {
+    meineTische = [tischSession(1, 'Stammtisch', true)]
+    alleTische = [
+      { id: 1, name: 'Stammtisch', istFavorit: true, saldoCents: 500 },
+      { id: 2, name: 'Bar', istFavorit: false, saldoCents: 300 },
+    ]
+    render(<TableSelectionPage />)
+
+    expect(screen.getByText('Noch offen · 1')).toBeInTheDocument()
+    expect(screen.getByText('Stammtisch')).toBeInTheDocument()
+    // Nicht favorisierte Tische erscheinen ohne Suche nicht.
+    expect(screen.queryByText('Bar')).not.toBeInTheDocument()
+  })
+
+  it('findet einen nicht favorisierten aktiven Tisch über die Hauptsuche', async () => {
+    meineTische = [tischSession(1, 'Stammtisch', true)]
+    alleTische = [
+      { id: 1, name: 'Stammtisch', istFavorit: true, saldoCents: 500 },
+      { id: 2, name: 'Bar', istFavorit: false, saldoCents: 300 },
+    ]
+    const user = userEvent.setup()
+    render(<TableSelectionPage />)
+
+    await user.type(
+      screen.getByPlaceholderText('Tisch suchen — Name oder Nummer'),
+      'Bar',
+    )
+
+    // Der nicht favorisierte Tisch erscheint als Treffer …
+    expect(screen.getByText('Bar')).toBeInTheDocument()
+    // … und ein Treffer öffnet den Tisch direkt.
+    await user.click(screen.getByText('Bar'))
+    expect(navigate).toHaveBeenCalledWith('/service/tische/2')
+  })
+
+  it('meldet, wenn kein aktiver Tisch zur Suche passt', async () => {
+    meineTische = [tischSession(1, 'Stammtisch', true)]
+    alleTische = [
+      { id: 1, name: 'Stammtisch', istFavorit: true, saldoCents: 500 },
+    ]
+    const user = userEvent.setup()
+    render(<TableSelectionPage />)
+
+    await user.type(
+      screen.getByPlaceholderText('Tisch suchen — Name oder Nummer'),
+      'Zelt',
+    )
+
+    expect(screen.getByText(/Kein aktiver Tisch passt zu/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/service/TableSelectionPage.test.tsx
+++ b/frontend/src/service/TableSelectionPage.test.tsx
@@ -90,15 +90,16 @@ describe('TableSelectionPage', () => {
     const user = userEvent.setup()
     render(<TableSelectionPage />)
 
-    await user.type(
-      screen.getByPlaceholderText('Tisch suchen — Name oder Nummer'),
-      'Bar',
-    )
+    // Suchfeld und Treffer werden genau so angesprochen wie im e2e-Helper
+    // (support/servicekraft.ts oeffneTisch): Platzhalter-Teilstring plus
+    // Button-Name „<Name> … <Saldo> €".
+    await user.type(screen.getByPlaceholderText(/Tisch suchen/), 'Bar')
 
     // Der nicht favorisierte Tisch erscheint als Treffer …
-    expect(screen.getByText('Bar')).toBeInTheDocument()
+    const treffer = screen.getByRole('button', { name: /^Bar\b.*€/ })
+    expect(treffer).toBeInTheDocument()
     // … und ein Treffer öffnet den Tisch direkt.
-    await user.click(screen.getByText('Bar'))
+    await user.click(treffer)
     expect(navigate).toHaveBeenCalledWith('/service/tische/2')
   })
 

--- a/frontend/src/service/TableSelectionPage.tsx
+++ b/frontend/src/service/TableSelectionPage.tsx
@@ -1,17 +1,23 @@
-import { Lamp, Search, TableIcon } from 'lucide-react'
+import { ChevronRight, Lamp, Search, TableIcon } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router'
 
 import { EmptyState } from '@/components/common/EmptyState'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useErstAufbau } from '@/hooks/use-erst-aufbau'
+import { formatEuro } from '@/lib/utils'
 
 import { EigeneUebersichtKarten } from './components/EigeneUebersicht'
 import { MeinTischCard } from './components/MeinTischCard'
 import { TischAuswahlDrawer } from './components/TischAuswahlDrawer'
-import { useEigeneUebersicht, useMeineTischeState } from './table/hooks'
-import type { TischSession } from './table/Tisch'
+import {
+  useAktiveTischeMitFavoriten,
+  useEigeneUebersicht,
+  useMeineTischeState,
+} from './table/hooks'
+import type { AktiverTischMitFavorit, TischSession } from './table/Tisch'
 
 const fussleisteFreiraum = 'pb-[calc(6rem+env(safe-area-inset-bottom,0px))]'
 
@@ -19,27 +25,37 @@ export function TableSelectionPage() {
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [suche, setSuche] = useState('')
   const { tische, isPending: tischeLoading } = useMeineTischeState()
+  // Die Suche greift über alle aktiven Tische, nicht nur die favorisierten
+  // „Meine Tische" — so findet der Nutzer auch einen nicht markierten Tisch und
+  // öffnet ihn per Treffer direkt.
+  const { tische: alleTische } = useAktiveTischeMitFavoriten()
   const { uebersicht, isPending: uebersichtLoading } = useEigeneUebersicht()
 
-  const gefilterteTische = useMemo(
-    () =>
-      tische.filter((state) =>
-        state.tischName.toLowerCase().includes(suche.trim().toLowerCase()),
-      ),
-    [tische, suche],
-  )
-  const offeneTische = gefilterteTische.filter(
+  const sucheGetrimmt = suche.trim()
+  const sucheAktiv = sucheGetrimmt.length > 0
+
+  const offeneTische = tische.filter(
     (state) => state.unbezahltePositionen.length > 0,
   )
-  const erledigteTische = gefilterteTische.filter(
+  const erledigteTische = tische.filter(
     (state) => state.unbezahltePositionen.length === 0,
   )
 
-  // Der Listen-Eintritt staffelt nur beim ersten Aufbau mit Daten (nicht beim
-  // Skeleton, nicht bei späteren Refetches). Beide Gruppen teilen sich eine
-  // fortlaufende Staffelung: „Erledigt" setzt hinter „Noch offen" fort.
+  // Treffer der Hauptsuche über alle aktiven Tische, nach Name sortiert.
+  const suchTreffer = useMemo(() => {
+    if (!sucheAktiv) return []
+    const q = sucheGetrimmt.toLowerCase()
+    return alleTische
+      .filter((t) => t.name.toLowerCase().includes(q))
+      .sort((a, b) => a.name.localeCompare(b.name, 'de'))
+  }, [alleTische, sucheAktiv, sucheGetrimmt])
+
+  // Der Listen-Eintritt staffelt nur beim ersten Aufbau der Favoritenliste mit
+  // Daten (nicht beim Skeleton, nicht bei späteren Refetches, nicht in der
+  // Suchtrefferliste). Beide Gruppen teilen sich eine fortlaufende Staffelung:
+  // „Erledigt" setzt hinter „Noch offen" fort.
   const erstAufbau = useErstAufbau(
-    !tischeLoading && gefilterteTische.length > 0,
+    !tischeLoading && !sucheAktiv && tische.length > 0,
   )
 
   return (
@@ -49,7 +65,7 @@ export function TableSelectionPage() {
         loading={uebersichtLoading}
       />
 
-      {tische.length > 0 && (
+      {alleTische.length > 0 && (
         <div className="relative mb-4">
           <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -63,7 +79,15 @@ export function TableSelectionPage() {
         </div>
       )}
 
-      {tischeLoading ? (
+      {sucheAktiv ? (
+        suchTreffer.length === 0 ? (
+          <div className="py-8 text-center text-muted-foreground">
+            <p>Kein aktiver Tisch passt zu „{sucheGetrimmt}“.</p>
+          </div>
+        ) : (
+          <SuchTrefferListe treffer={suchTreffer} />
+        )
+      ) : tischeLoading ? (
         <TischListSkeleton />
       ) : tische.length === 0 ? (
         <EmptyState
@@ -81,18 +105,6 @@ export function TableSelectionPage() {
             </Button>
           }
         />
-      ) : gefilterteTische.length === 0 ? (
-        <div className="py-8 text-center text-muted-foreground">
-          <p>Kein markierter Tisch passt zu „{suche.trim()}“.</p>
-          <Button
-            variant="link"
-            onClick={() => {
-              setDrawerOpen(true)
-            }}
-          >
-            In allen Tischen suchen
-          </Button>
-        </div>
       ) : (
         <div className="space-y-6">
           {offeneTische.length > 0 && (
@@ -128,6 +140,45 @@ export function TableSelectionPage() {
       </div>
 
       <TischAuswahlDrawer open={drawerOpen} onOpenChange={setDrawerOpen} />
+    </div>
+  )
+}
+
+// SuchTrefferListe zeigt die Treffer der Hauptsuche über alle aktiven Tische.
+// Ein Tippen öffnet den Tisch direkt — auch einen nicht favorisierten.
+function SuchTrefferListe({ treffer }: { treffer: AktiverTischMitFavorit[] }) {
+  const navigate = useNavigate()
+  return (
+    <div className="flex flex-col gap-2">
+      {treffer.map((tisch) => (
+        <button
+          key={tisch.id}
+          type="button"
+          onClick={() => {
+            void navigate(`/service/tische/${tisch.id.toString()}`)
+          }}
+          className="flex w-full items-center gap-3 rounded-xl bg-card p-4 text-left ring-1 ring-foreground/10 transition-colors hover:bg-accent/50"
+        >
+          <div className="min-w-0 flex-1">
+            <div className="text-base font-semibold">{tisch.name}</div>
+            {tisch.istFavorit && (
+              <div className="text-[13px] text-muted-foreground">
+                Meine Tische
+              </div>
+            )}
+          </div>
+          <span
+            className={
+              tisch.saldoCents < 0
+                ? 'text-sm font-medium text-destructive'
+                : 'text-sm text-muted-foreground'
+            }
+          >
+            {formatEuro(tisch.saldoCents)}
+          </span>
+          <ChevronRight className="size-5 shrink-0 text-muted-foreground" />
+        </button>
+      ))}
     </div>
   )
 }

--- a/frontend/src/service/components/TischAuswahlDrawer.test.tsx
+++ b/frontend/src/service/components/TischAuswahlDrawer.test.tsx
@@ -61,16 +61,15 @@ function renderDrawer() {
 }
 
 describe('TischAuswahlDrawer', () => {
-  it('zeigt die Tisch-Liste im DrawerBody, das Suchfeld scrollt nicht mit', () => {
+  it('zeigt die Tisch-Liste im DrawerBody ohne eigenes Suchfeld', () => {
     renderDrawer()
 
     const dialog = screen.getByRole('dialog')
     const body = dialog.querySelector('[data-slot="drawer-body"]')
     expect(body).not.toBeNull()
     expect(body).toContainElement(screen.getByText('Stammtisch'))
-    expect(body).not.toContainElement(
-      screen.getByPlaceholderText('Tisch suchen...'),
-    )
+    // Die Suche liegt jetzt auf der Hauptseite — der Drawer hat kein Suchfeld.
+    expect(screen.queryByPlaceholderText('Tisch suchen...')).toBeNull()
   })
 
   it('invalidiert nach Favoriten-Toggle beide Query-Caches', async () => {

--- a/frontend/src/service/components/TischAuswahlDrawer.tsx
+++ b/frontend/src/service/components/TischAuswahlDrawer.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import {
@@ -9,10 +8,9 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/components/ui/drawer'
-import { Input } from '@/components/ui/input'
 import { useActionSubmit } from '@/hooks/use-action-submit'
 import { BackendSingleton } from '@/lib/Backend'
-import { formatCents } from '@/lib/utils'
+import { formatEuro } from '@/lib/utils'
 
 import {
   AKTIVE_TISCHE_MIT_FAVORITEN_KEY,
@@ -47,15 +45,14 @@ export function TischAuswahlDrawer({
 }: TischAuswahlDrawerProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const [suche, setSuche] = useState('')
   const { tische } = useAktiveTischeMitFavoriten()
   const { loading: favoritLoading, run: runToggleFavorit } = useActionSubmit({
     actionLabel: 'Favorit ändern',
   })
 
-  const gefilterteTische = tische
-    .filter((t) => t.name.toLowerCase().includes(suche.toLowerCase()))
-    .sort(sortiereTische)
+  // Reine Durchblätter-/Favorisier-Liste — die Suche über alle Tische liegt
+  // jetzt auf der Hauptseite (TableSelectionPage), kein zweites Suchfeld hier.
+  const sortierteTische = [...tische].sort(sortiereTische)
 
   const favoritMutation = useMutation({
     mutationFn: (tisch: AktiverTischMitFavorit) =>
@@ -82,18 +79,8 @@ export function TischAuswahlDrawer({
         <DrawerHeader>
           <DrawerTitle>Alle Tische</DrawerTitle>
         </DrawerHeader>
-        {/* Suchfeld außerhalb von DrawerBody, damit es beim Scrollen der Liste sichtbar bleibt. */}
-        <div className="px-4 pb-3">
-          <Input
-            placeholder="Tisch suchen..."
-            value={suche}
-            onChange={(e) => {
-              setSuche(e.target.value)
-            }}
-          />
-        </div>
         <DrawerBody className="flex flex-col gap-0 px-4 pb-6">
-          {gefilterteTische.map((tisch) => (
+          {sortierteTische.map((tisch) => (
             <div
               key={tisch.id}
               className="flex items-center border-b last:border-b-0"
@@ -130,7 +117,7 @@ export function TischAuswahlDrawer({
                       : 'text-sm text-muted-foreground'
                   }
                 >
-                  {formatCents(tisch.saldoCents)} €
+                  {formatEuro(tisch.saldoCents)}
                 </span>
               </button>
             </div>

--- a/frontend/src/service/components/table/BestellungDrawer.test.tsx
+++ b/frontend/src/service/components/table/BestellungDrawer.test.tsx
@@ -106,7 +106,7 @@ describe('BestellungDrawer', () => {
     await user.click(
       screen.getByRole('button', { name: /Bestellung überprüfen/ }),
     )
-    await screen.findByRole('dialog')
+    const dialog = await screen.findByRole('dialog')
 
     // Das optionale Kommentarfeld ist das erste Feld im Drawer. Beim Öffnen darf
     // KEIN Eingabefeld den Fokus erhalten — sonst öffnet sich auf dem Handy
@@ -116,6 +116,9 @@ describe('BestellungDrawer', () => {
     const active = document.activeElement
     expect(active?.tagName).not.toBe('INPUT')
     expect(active?.tagName).not.toBe('TEXTAREA')
+    // Der Fokus liegt aber IM Dialog (auf dem Container), damit Fokus-Falle,
+    // Escape und Fokusrückgabe weiter funktionieren.
+    expect(active === dialog || dialog.contains(active)).toBe(true)
   })
 
   it('zeigt den Tischnamen als dominante Überschrift ohne Prosa-Description', async () => {

--- a/frontend/src/service/components/table/BestellungDrawer.test.tsx
+++ b/frontend/src/service/components/table/BestellungDrawer.test.tsx
@@ -99,6 +99,25 @@ describe('BestellungDrawer', () => {
     })
   })
 
+  it('öffnet ohne Auto-Fokus auf ein Eingabefeld (keine ungefragte Tastatur)', async () => {
+    const user = userEvent.setup()
+    renderDrawer({ 1: 2 })
+
+    await user.click(
+      screen.getByRole('button', { name: /Bestellung überprüfen/ }),
+    )
+    await screen.findByRole('dialog')
+
+    // Das optionale Kommentarfeld ist das erste Feld im Drawer. Beim Öffnen darf
+    // KEIN Eingabefeld den Fokus erhalten — sonst öffnet sich auf dem Handy
+    // ungefragt die Tastatur (zentrale onOpenAutoFocus-Unterdrückung im Drawer).
+    const kommentar = screen.getByPlaceholderText(/Kommentar/)
+    expect(kommentar).not.toHaveFocus()
+    const active = document.activeElement
+    expect(active?.tagName).not.toBe('INPUT')
+    expect(active?.tagName).not.toBe('TEXTAREA')
+  })
+
   it('zeigt den Tischnamen als dominante Überschrift ohne Prosa-Description', async () => {
     const user = userEvent.setup()
     renderDrawer({ 1: 2 })


### PR DESCRIPTION
Mobile-first UI-Verfeinerungen für ehrenamtliche Helfer. Umsetzung des Plans `docs/plans/plan-ui-refinements.md` (alle 5 Phasen, alle Akzeptanzkriterien erfüllt).

## Änderungen

**Phase 1 – Dashboard & Produktstatistik**
- Auf der Live-Übersicht steht der Stornierungen-Block jetzt **über** der Produktstatistik.
- Die Produktstatistik-Liste ist höhengedeckelt mit internem Scroll und gepinntem Spaltenkopf (`VerkaufStatistik` – wirkt auf Übersicht **und** „Berichte & Export").

**Phase 2 – Produkt-Umsatz auf Bestellbasis**
- `GetProduktStatistik` liefert den Umsatz jetzt bestellbasiert (`bestellung-aufgenommen` +, `bestellung-korrigiert` −, `direktverkauf-getaetigt` +) — der Euro-Wert der ausgegebenen Portionen zu Bestellzeit-Preisen. Nachträgliche Zahlungen und Stornierungen ändern den Produkt-Umsatz **nicht** mehr.
- **Bewusst kassenbasiert unverändert:** „Kassierter Umsatz"-KPI, Umsatz je Servicekraft und die Steuer-/DSFinV-K-Größen (`GetUmsatzPositionszeilen`).
- `dbgen` per `make sqlc` neu generiert; Beschreibungstext gekürzt; Repository-Tests angepasst.

**Phase 3 – Overlays: Autofokus & scrollbare Dialoge**
- Kein Auto-Fokus mehr beim Öffnen von Drawer/Dialog/Sheet (keine ungefragte Mobil-Tastatur); `AlertDialog`-Bestätigungen bleiben button-fokussiert.
- `Dialog`/`AlertDialog` erhalten einen Höhen-Cap plus scrollbaren `DialogBody`/`AlertDialogBody`, sodass die Fußleiste (Absende-Aktion) gepinnt und erreichbar bleibt. Die Admin-Formulardialoge (Zählhilfe, Kassenabschluss, Produkt-/Tisch-/Benutzer-/Geldtransit-Dialoge) sind entsprechend umgestellt.

**Phase 4 – Vereinheitlichte Tischsuche**
- Die Hauptsuche im Service greift jetzt über **alle aktiven Tische** (nicht nur Favoriten) und öffnet einen Treffer direkt.
- Das zweite Suchfeld im „Alle Tische"-Drawer entfällt.

**Phase 5 – Politur**
- Größere Zählhilfe-Touch-Ziele (`h-11`, ≈ 44 px).
- `formatEuro` (geschütztes Leerzeichen) für Admin-Beträge.
- Person in der Helfer-Verwaltung durchgängig „Helfer" (Feld „Benutzername" bleibt); `formatBediener` → `formatServicekraft` umbenannt; `docs/language.md` angeglichen.

## Hinweise für den Reviewer
- **Produkt-Umsatz ≠ Kassierter Umsatz bei Stornos** ist beabsichtigt. Die frühere Test-Invariante, die beide gleichsetzte, wurde entfernt; der DSFinV-K-/Steuer-Konsistenztest läuft über eine andere Query und ist nicht betroffen.
- Overlay-Änderungen liegen zentral in den `components/ui`-Primitiven; die Autofokus-Unterdrückung lässt Fokus-Trap, Escape und Fokusrückgabe unberührt (Test am Bestell-Drawer belegt: kein Eingabefeld erhält beim Öffnen den Fokus).

## Tests / Checks
- Backend: `go vet`, `build`, `golangci-lint --build-tags=integration`, Unit-Tests mit `-race`, Reporting-Integrationstests — grün.
- Frontend: `tsc`, `eslint --max-warnings=0`, `prettier --check`, vollständige vitest-Suite (418 Tests inkl. neuer All-Tables-Suche und Bestell-Drawer-Autofokus) — grün.