### PR TITLE
refactor(service): lift table order/payment selection into TablePage

### DIFF
--- a/docs/plans/plan-ux-quick-wins.md
+++ b/docs/plans/plan-ux-quick-wins.md
@@ -288,13 +288,13 @@ Auf den beiden Modus-Startrouten ersetzt eine Segmented Control „Tische | Thek
 
 ### Acceptance criteria
 
-- [ ] Auf `/service/tische` und `/service/direktverkauf` zeigt der Header die Segmented Control; ein Tap navigiert in beide Richtungen (neuer `ServiceLayout.test.tsx` — bisher existiert keiner: Navigation und aktiver Zustand)
-- [ ] Der aktive Zustand entspricht der Route (`aria-current` oder äquivalentes sichtbares Merkmal, im Test prüfbar)
-- [ ] Tisch-Detailseite zeigt weiterhin den Backlink, keinen Switcher
-- [ ] Nach Navigation über die Control ist der Arbeitsmodus persistiert (bestehende Loader-Tests in `routes.test.ts` bleiben grün)
-- [ ] Benutzermenü-Eintrag funktioniert unverändert (`UserDropdown.test.ts` grün)
-- [ ] Empty-State-Text erwähnt das Benutzermenü nicht mehr; E2E-Specs, die auf die alten Header-Titel matchen, sind angepasst
-- [ ] Tap-Ziele der Segmente ≥ 44 px; `make check` grün
+- [x] Auf `/service/tische` und `/service/direktverkauf` zeigt der Header die Segmented Control; ein Tap navigiert in beide Richtungen (neuer `ServiceLayout.test.tsx` — bisher existiert keiner: Navigation und aktiver Zustand)
+- [x] Der aktive Zustand entspricht der Route (`aria-current` oder äquivalentes sichtbares Merkmal, im Test prüfbar)
+- [x] Tisch-Detailseite zeigt weiterhin den Backlink, keinen Switcher
+- [x] Nach Navigation über die Control ist der Arbeitsmodus persistiert (bestehende Loader-Tests in `routes.test.ts` bleiben grün)
+- [x] Benutzermenü-Eintrag funktioniert unverändert (`UserDropdown.test.ts` grün)
+- [x] Empty-State-Text erwähnt das Benutzermenü nicht mehr; E2E-Specs, die auf die alten Header-Titel matchen, sind angepasst
+- [x] Tap-Ziele der Segmente ≥ 44 px; `make check` grün
 
 ---
 

--- a/docs/plans/plan-ux-quick-wins.md
+++ b/docs/plans/plan-ux-quick-wins.md
@@ -75,7 +75,7 @@ E2E:
 - **Label-Helfer**: `formatAlleAuswaehlenLabel` bekommt einen Varianten-Parameter statt eines zweiten Helfers; Singular der Meine-Variante: „Meine Position auswählen · X €". Der Toggle-Zustand „Auswahl aufheben" bleibt unverändert.
 - **Amber-Soft-Tint als Badge-Variante mit festen Amber-Klassen** (z. B. `bg-amber-500/15 text-amber-700 dark:bg-amber-500/20 dark:text-amber-400`): Der Status-Punkt in `MeinTischCard` nutzt bereits feste Amber-Klassen; ein neues Soft-Amber-Token-Paar nur für einen Badge wäre Over-Engineering. Zentralisiert als Variante in `badge.tsx`, nicht ad hoc an der Call-Site.
 - **Neutraler Status-Punkt** („nur fremde offene Positionen"): `bg-muted-foreground` (Token), grün bleibt `bg-green-600`, amber bleibt `bg-amber-500`.
-- **Vorzeichen-Helfer**: „+" nur bei Werten > 0; 0 bleibt „0,00 €"; das Minus negativer Beträge liefert die bestehende `formatCents`-Formatierung. Alle Anzeigen der Kassensturz-Differenz nutzen den Helfer; die Farblogik (rot nur bei Fehlbetrag) bleibt.
+- **Vorzeichen-Helfer**: „+" nur bei Werten > 0; 0 bleibt „0,00 €"; das Minus negativer Beträge liefert die bestehende `formatCents`-Formatierung. Der Helfer setzt Ist − Soll voraus (positiv = Überschuss) und wird nur in `KasseAbschliessenSection` (live + Bestätigung) angewendet, wo genau diese Konvention gilt. Der Tagesbericht (`ReportingResults`) bleibt bei `formatEuro`: sein `kassensturzDifferenzCents` stammt aus dem `kassensturz-durchgefuehrt:v1`-Event und ist Soll − Ist (positiv = Fehlbetrag); ein „+" würde dort einen Fehlbetrag fälschlich als Überschuss lesen. Die Farblogik (rot nur bei Fehlbetrag) bleibt.
 - **Chips-Ableitung liefert immer genau zwei Vorschläge**: das kleinste 1-€-Vielfache echt über dem Gesamtbetrag und das kleinste 5-€-Vielfache echt über dem Gesamtbetrag; fallen beide zusammen, ersetzt das übernächste 5-€-Vielfache den Doppelgänger. Beispiele: 12,30 € → [13 €, 15 €]; 13,00 € → [14 €, 15 €]; 4,50 € → [5 €, 10 €]. Das deckt „zwei bis drei glatte Beträge, Duplikate entfernt, bei glattem Betrag die nächsthöheren" aus dem PRD deterministisch ab.
 - **Kein Verhaltens-Reset beim Tab-Wechsel, aber pro Tisch**: `TablePage` bleibt bei einem `:tischId`-Wechsel gemountet (react-router ändert nur den Param). Der gehobene Mengen-State wird deshalb pro Tisch zurückgesetzt (z. B. `key={tischId}` auf dem State-tragenden Teilbaum oder Reset-Effekt auf `tischId`).
 
@@ -235,13 +235,13 @@ Ein gebündelter Sweep ohne Verhaltensänderung: ehrliches Kassieren-Label „Me
 
 ### Acceptance criteria
 
-- [ ] Kassieren-Button sagt „Meine N Positionen auswählen · X €" (Test angepasst); Umbuchungs-Drawer sagt weiter „Alle …"
-- [ ] Live-Reporting-Refresh heißt „Aktualisieren" (Test in `LiveReportingSection.test.tsx` angepasst)
-- [ ] Produkt-Dropdown-Eintrag heißt „Bearbeiten"; in `ProductItem.tsx` kommt „Umbenennen" nicht mehr vor (der Hinweistext der Tische-Verwaltung nutzt das Wort legitim weiter)
-- [ ] „Zum Service-Bereich" nutzt `ArrowRightLeft`; `LogOut` erscheint nur noch bei Abmelden-Aktionen
-- [ ] Kassensturz-Differenz zeigt bei Überschuss „+…" (Unit-Test für `formatEuroMitVorzeichen`: positiv, negativ, null); rot bleibt nur der Fehlbetrag
-- [ ] Tischseite lädt mit Skeletons; die Strings „Tisch ??" und der Saldo-Platzhalter „?" existieren nicht mehr; `warteAufTischGeladen` (E2E) funktioniert unverändert
-- [ ] Betroffene E2E-Assertions (grep nach den alten Labels) angepasst; `make check` grün
+- [x] Kassieren-Button sagt „Meine N Positionen auswählen · X €" (Test angepasst); Umbuchungs-Drawer sagt weiter „Alle …"
+- [x] Live-Reporting-Refresh heißt „Aktualisieren" (Test in `LiveReportingSection.test.tsx` angepasst)
+- [x] Produkt-Dropdown-Eintrag heißt „Bearbeiten"; in `ProductItem.tsx` kommt „Umbenennen" nicht mehr vor (der Hinweistext der Tische-Verwaltung nutzt das Wort legitim weiter)
+- [x] „Zum Service-Bereich" nutzt `ArrowRightLeft`; `LogOut` erscheint nur noch bei Abmelden-Aktionen
+- [x] Kassensturz-Differenz zeigt bei Überschuss „+…" (Unit-Test für `formatEuroMitVorzeichen`: positiv, negativ, null); rot bleibt nur der Fehlbetrag
+- [x] Tischseite lädt mit Skeletons; die Strings „Tisch ??" und der Saldo-Platzhalter „?" existieren nicht mehr; `warteAufTischGeladen` (E2E) funktioniert unverändert
+- [x] Betroffene E2E-Assertions (grep nach den alten Labels) angepasst; `make check` grün
 
 ---
 

--- a/docs/plans/plan-ux-quick-wins.md
+++ b/docs/plans/plan-ux-quick-wins.md
@@ -342,8 +342,8 @@ Der „Alle Tische"-Drawer sortiert durchgehend nach Tischname mit numerischem V
 
 ### Acceptance criteria
 
-- [ ] Drawer-Sortierung: „Tisch 2" vor „Tisch 10", Favoriten nicht mehr vorgezogen (Test in `TischAuswahlDrawer.test.tsx` angepasst)
-- [ ] Favoriten-Stern und Saldo pro Zeile funktionieren unverändert
-- [ ] Nach erfolgreichem IP-Speichern erscheint für ~2 Sekunden eine Inline-Bestätigung am Feld; der Toast bleibt (Test)
-- [ ] Bei Validierungsfehler der IP erscheint keine Erfolgs-Bestätigung
-- [ ] `make check` grün
+- [x] Drawer-Sortierung: „Tisch 2" vor „Tisch 10", Favoriten nicht mehr vorgezogen (Test in `TischAuswahlDrawer.test.tsx` angepasst)
+- [x] Favoriten-Stern und Saldo pro Zeile funktionieren unverändert
+- [x] Nach erfolgreichem IP-Speichern erscheint für ~2 Sekunden eine Inline-Bestätigung am Feld; der Toast bleibt (Test)
+- [x] Bei Validierungsfehler der IP erscheint keine Erfolgs-Bestätigung
+- [x] `make check` grün

--- a/docs/plans/plan-ux-quick-wins.md
+++ b/docs/plans/plan-ux-quick-wins.md
@@ -132,12 +132,12 @@ Stornierung und Umbuchung der Tischseite sowie der Direktverkauf-Storno werden a
 
 ### Acceptance criteria
 
-- [ ] Nach erfolgreicher Stornierung (Tischseite) erscheint der ErfolgsPop mit „Stornierung gebucht."; der Drawer ist zu (Test in `HistorieStornierungDrawer.test.tsx`/`TischHistorie.test.tsx`)
-- [ ] Nach erfolgreicher Umbuchung erscheint „Auf {Zielname} umgebucht."; kein Toast mehr (Test angepasst)
-- [ ] Nach erfolgreichem Direktverkauf-Storno erscheint der Pop mit „Stornierung gebucht."
-- [ ] Refetch (Tisch-State/Historie) läuft erst beim Schließen des Pops, nicht schon beim Buchungserfolg
-- [ ] Betroffene E2E-Specs (`stornierung-serviceleitung.mobile.spec.ts`, `umbuchung.mobile.spec.ts`, `direktverkauf-storno.mobile.spec.ts`) matchen auf die Pop-Texte statt Toast/kommentarloses Schließen
-- [ ] `make check` grün
+- [x] Nach erfolgreicher Stornierung (Tischseite) erscheint der ErfolgsPop mit „Stornierung gebucht."; der Drawer ist zu (Test in `HistorieStornierungDrawer.test.tsx`/`TischHistorie.test.tsx`)
+- [x] Nach erfolgreicher Umbuchung erscheint „Auf {Zielname} umgebucht."; kein Toast mehr (Test angepasst)
+- [x] Nach erfolgreichem Direktverkauf-Storno erscheint der Pop mit „Stornierung gebucht."
+- [x] Refetch (Tisch-State/Historie) läuft erst beim Schließen des Pops, nicht schon beim Buchungserfolg
+- [x] Betroffene E2E-Specs (`stornierung-serviceleitung.mobile.spec.ts`, `umbuchung.mobile.spec.ts`, `direktverkauf-storno.mobile.spec.ts`) matchen auf die Pop-Texte statt Toast/kommentarloses Schließen
+- [x] `make check` grün
 
 ---
 

--- a/docs/plans/plan-ux-quick-wins.md
+++ b/docs/plans/plan-ux-quick-wins.md
@@ -262,11 +262,11 @@ Neue Badge-Variante `warn` nach dem Soft-Tint-Muster der `destructive`-Variante,
 
 ### Acceptance criteria
 
-- [ ] „N unbezahlt"-Badge nutzt die neue `warn`-Variante, nicht mehr `destructive` (Test angepasst)
-- [ ] Status-Punkt: eigene offene → amber, nur fremde offene → neutral, alles erledigt → grün (`MeinTischCard.test.tsx` angepasst)
-- [ ] `bg-destructive` kommt in `MeinTischCard` und `StatusBadgeInhalt` nicht mehr vor
-- [ ] „Alles bezahlt"-Badge und übrige Badge-Verwendungen unverändert
-- [ ] `make check` grün
+- [x] „N unbezahlt"-Badge nutzt die neue `warn`-Variante, nicht mehr `destructive` (Test angepasst)
+- [x] Status-Punkt: eigene offene → amber, nur fremde offene → neutral, alles erledigt → grün (`MeinTischCard.test.tsx` angepasst)
+- [x] `bg-destructive` kommt in `MeinTischCard` und `StatusBadgeInhalt` nicht mehr vor
+- [x] „Alles bezahlt"-Badge und übrige Badge-Verwendungen unverändert
+- [x] `make check` grün
 
 ---
 

--- a/docs/plans/plan-ux-quick-wins.md
+++ b/docs/plans/plan-ux-quick-wins.md
@@ -315,14 +315,14 @@ Neue gemeinsame Komponente `AufrundenChips` (unter `frontend/src/service/compone
 
 ### Acceptance criteria
 
-- [ ] `aufrundenVorschlaege`: Unit-Tests für die Beispiele 12,30 → [13, 15]; 13,00 → [14, 15]; 4,50 → [5, 10] (Dedup-Fall)
-- [ ] Chip-Tap setzt den Zielbetrag, Trinkgeld- und Rückgeld-Zeilen rechnen wie bisher clientseitig; erneuter Tap wählt ab (Tests)
-- [ ] „Anderer …" blendet das Euro-Feld ein; freie Beträge funktionieren wie bisher
-- [ ] Der dreizeilige Zielbetrag-Hinweistext existiert nicht mehr; der Trinkgeld-Buchungshinweis bleibt
-- [ ] Direktverkauf zeigt erstmals Trinkgeld bei aufgerundetem Zielbetrag (Test in `DirektverkaufAbschluss.test.tsx`)
-- [ ] Kassieren- und Direktverkauf-Payloads unverändert (bestehende Submit-Tests grün, kein neues Feld)
-- [ ] warLeer-Reset leert auch den Chip-/Zielbetrag-Zustand beim Start eines neuen Vorgangs
-- [ ] Chips ≥ 44 px hoch, Ziffern tabular; `make check` grün
+- [x] `aufrundenVorschlaege`: Unit-Tests für die Beispiele 12,30 → [13, 15]; 13,00 → [14, 15]; 4,50 → [5, 10] (Dedup-Fall)
+- [x] Chip-Tap setzt den Zielbetrag, Trinkgeld- und Rückgeld-Zeilen rechnen wie bisher clientseitig; erneuter Tap wählt ab (Tests)
+- [x] „Anderer …" blendet das Euro-Feld ein; freie Beträge funktionieren wie bisher
+- [x] Der dreizeilige Zielbetrag-Hinweistext existiert nicht mehr; der Trinkgeld-Buchungshinweis bleibt
+- [x] Direktverkauf zeigt erstmals Trinkgeld bei aufgerundetem Zielbetrag (Test in `DirektverkaufAbschluss.test.tsx`)
+- [x] Kassieren- und Direktverkauf-Payloads unverändert (bestehende Submit-Tests grün, kein neues Feld)
+- [x] warLeer-Reset leert auch den Chip-/Zielbetrag-Zustand beim Start eines neuen Vorgangs
+- [x] Chips ≥ 44 px hoch, Ziffern tabular; `make check` grün
 
 ---
 

--- a/docs/plans/plan-ux-quick-wins.md
+++ b/docs/plans/plan-ux-quick-wins.md
@@ -179,11 +179,11 @@ Beide Submit-Buttons sind nur noch während des Ladens deaktiviert (`disabled={l
 
 ### Acceptance criteria
 
-- [ ] Tap auf „Anmelden" bei leerem/ungültigem Formular zeigt die Feldfehler; der Login-Backend-Aufruf wird nicht ausgelöst (neuer `LoginForm.test.tsx` — bisher existiert keiner)
-- [ ] Analog für „Passwort festlegen" (neuer `PasswordForm.test.tsx`)
-- [ ] Während des Ladens ist der Button deaktiviert (kein Doppel-Submit)
-- [ ] Gültige Eingaben submitten weiterhin erfolgreich (Happy Path im Test)
-- [ ] `make check` grün
+- [x] Tap auf „Anmelden" bei leerem/ungültigem Formular zeigt die Feldfehler; der Login-Backend-Aufruf wird nicht ausgelöst (neuer `LoginForm.test.tsx` — bisher existiert keiner)
+- [x] Analog für „Passwort festlegen" (neuer `PasswordForm.test.tsx`)
+- [x] Während des Ladens ist der Button deaktiviert (kein Doppel-Submit)
+- [x] Gültige Eingaben submitten weiterhin erfolgreich (Happy Path im Test)
+- [x] `make check` grün
 
 ---
 

--- a/docs/plans/plan-ux-quick-wins.md
+++ b/docs/plans/plan-ux-quick-wins.md
@@ -105,13 +105,13 @@ Die beiden Mengen-Auswahlen (Bestell-Korb nach Variante-ID, Kassieren-Auswahl na
 
 ### Acceptance criteria
 
-- [ ] Bestell-Korb: Mengen wählen, zu Historie wechseln, zurück zu Bestellen — die Mengen sind unverändert da (neuer Test in `TablePage.test.tsx` oder `Bestellung.test.tsx`)
-- [ ] Kassieren-Auswahl: analog über einen Tab-Wechsel hinweg erhalten (neuer Test)
-- [ ] Nach erfolgreichem Bestellen bzw. Kassieren ist die jeweilige Auswahl weiterhin geleert (bestehende Tests bleiben grün, ADR-08-Querschnittskriterium)
-- [ ] Bei Wechsel des Tisches (`:tischId`) startet die Auswahl leer
-- [ ] Kein `forceMount`; `animate-fade-up` läuft weiterhin bei Tab-Aktivierung
-- [ ] Sheet (< 1024 px) und Abschluss-Spalte (≥ 1024 px) verhalten sich identisch (bestehende Drawer-/Abschluss-Tests angepasst, nicht gelöscht)
-- [ ] `make check` grün
+- [x] Bestell-Korb: Mengen wählen, zu Historie wechseln, zurück zu Bestellen — die Mengen sind unverändert da (neuer Test in `TablePage.test.tsx` oder `Bestellung.test.tsx`)
+- [x] Kassieren-Auswahl: analog über einen Tab-Wechsel hinweg erhalten (neuer Test)
+- [x] Nach erfolgreichem Bestellen bzw. Kassieren ist die jeweilige Auswahl weiterhin geleert (bestehende Tests bleiben grün, ADR-08-Querschnittskriterium)
+- [x] Bei Wechsel des Tisches (`:tischId`) startet die Auswahl leer
+- [x] Kein `forceMount`; `animate-fade-up` läuft weiterhin bei Tab-Aktivierung
+- [x] Sheet (< 1024 px) und Abschluss-Spalte (≥ 1024 px) verhalten sich identisch (bestehende Drawer-/Abschluss-Tests angepasst, nicht gelöscht)
+- [x] `make check` grün
 
 ---
 

--- a/docs/plans/plan-ux-quick-wins.md
+++ b/docs/plans/plan-ux-quick-wins.md
@@ -206,11 +206,11 @@ Neuer Button-Variant `destructive-solid`: solide destruktive Fläche (`bg-destru
 
 ### Acceptance criteria
 
-- [ ] Variant `destructive-solid` existiert mit Token-getragenem Kontrast in Light und Dark (≥ 4,5:1)
-- [ ] Alle fünf Call-Sites nutzen den Variant; `grep -r "bg-destructive text-white" frontend/src` liefert nichts mehr
-- [ ] `admin-kontrast-axe.spec.ts` öffnet die Lösch-Dialoge Produkt, Variante, Tisch und Helfer und findet in beiden Themes keine color-contrast-Verstöße
-- [ ] Bestehende axe-Prüfungen (drei Seiten, beide Themes) bleiben grün
-- [ ] `make check` grün
+- [x] Variant `destructive-solid` existiert mit Token-getragenem Kontrast in Light und Dark (≥ 4,5:1)
+- [x] Alle fünf Call-Sites nutzen den Variant; `grep -r "bg-destructive text-white" frontend/src` liefert nichts mehr
+- [x] `admin-kontrast-axe.spec.ts` öffnet die Lösch-Dialoge Produkt, Variante, Tisch und Helfer und findet in beiden Themes keine color-contrast-Verstöße
+- [x] Bestehende axe-Prüfungen (drei Seiten, beide Themes) bleiben grün
+- [x] `make check` grün
 
 ---
 

--- a/docs/plans/plan-ux-quick-wins.md
+++ b/docs/plans/plan-ux-quick-wins.md
@@ -156,10 +156,10 @@ Das Debounce-Reformat entfällt ersatzlos: Timer-Ref, Cleanup-Effect und Timeout
 
 ### Acceptance criteria
 
-- [ ] Pause-Fall: „1" tippen, über eine Sekunde warten (Fake-Timer), Feld zeigt weiter „1"; danach „5" tippen ergibt „15"; Blur normalisiert zu „15,00" (neuer Test)
-- [ ] Bestehende `EuroInput`-Tests (Sanitisierung, Blur-Normalisierung, Punkt-als-Komma, Dezimalstellen-Kappung) bleiben grün
-- [ ] In `EuroInput.tsx` existiert kein `setTimeout`/Timer-Ref mehr
-- [ ] `make check` grün
+- [x] Pause-Fall: „1" tippen, über eine Sekunde warten (Fake-Timer), Feld zeigt weiter „1"; danach „5" tippen ergibt „15"; Blur normalisiert zu „15,00" (neuer Test)
+- [x] Bestehende `EuroInput`-Tests (Sanitisierung, Blur-Normalisierung, Punkt-als-Komma, Dezimalstellen-Kappung) bleiben grün
+- [x] In `EuroInput.tsx` existiert kein `setTimeout`/Timer-Ref mehr
+- [x] `make check` grün
 
 ---
 

--- a/e2e/support/servicekraft.ts
+++ b/e2e/support/servicekraft.ts
@@ -254,10 +254,11 @@ export async function waehleAlleVollAus(page: Page): Promise<void> {
 }
 
 // warteAufTischGeladen wartet, bis der State-Fetch des Tisches fertig ist:
-// TablePage zeigt den Header-Saldo ([data-slot="tisch-saldo"]) während des
-// Ladens als „?" und danach als Euro-Betrag (z. B. „0,00 €"). Das ist ein
-// deterministisches Ready-Signal — erst danach ist der Tab-Inhalt gerendert und
-// Prüfungen auf Buttons/Positionszeilen lesen den fertigen DOM.
+// TablePage zeigt den Header-Saldo während des Ladens als Skeleton-Platzhalter
+// und rendert erst danach [data-slot="tisch-saldo"] mit dem Euro-Betrag (z. B.
+// „0,00 €"). Das ist ein deterministisches Ready-Signal — erst danach ist der
+// Tab-Inhalt gerendert und Prüfungen auf Buttons/Positionszeilen lesen den
+// fertigen DOM.
 async function warteAufTischGeladen(page: Page): Promise<void> {
   await expect(page.locator('[data-slot="tisch-saldo"]')).toHaveText(
     /\d,\d{2}\s*€/,
@@ -277,9 +278,9 @@ export async function settleAlleOffenenTische(page: Page): Promise<void> {
 
     // Auf das Fertigladen des Tisches warten, bevor auf Buttons/Zeilen geprüft
     // wird: TablePage rendert die Tab-Inhalte erst nach dem State-Fetch und zeigt
-    // den Header-Saldo bis dahin als „?". Ohne dieses Ready-Signal würden die
-    // isVisible()/count()-Prüfungen unten den noch leeren DOM lesen und den
-    // Kassieren-Zweig stumm überspringen (Fetch-Race).
+    // den Header-Saldo bis dahin als Skeleton-Platzhalter. Ohne dieses
+    // Ready-Signal würden die isVisible()/count()-Prüfungen unten den noch leeren
+    // DOM lesen und den Kassieren-Zweig stumm überspringen (Fetch-Race).
     await warteAufTischGeladen(page)
 
     // Alle unbezahlten Positionen kassieren (falls welche vorhanden sind). Der

--- a/e2e/tests/admin-kontrast-axe.spec.ts
+++ b/e2e/tests/admin-kontrast-axe.spec.ts
@@ -155,6 +155,13 @@ async function pruefeDialogKontrast(
   await oeffne(page)
   const dialog = page.locator('[data-slot="alert-dialog-content"]')
   await expect(dialog, `${name}: Lösch-Dialog sichtbar`).toBeVisible()
+  // Radix blendet den Dialog mit Fade-/Zoom-Animation ein; axe rechnet die
+  // momentane Opacity in die Farben ein. Erst nach Animationsende messen, sonst
+  // verfälscht der halbtransparente Zwischenzustand den Kontrast (der solide
+  // destructive-solid-Button mischt sich dann mit dem dunklen Backdrop).
+  await dialog.evaluate((el) =>
+    Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)),
+  )
 
   const ergebnis = await new AxeBuilder({ page })
     .include('[data-slot="alert-dialog-content"]')

--- a/e2e/tests/admin-kontrast-axe.spec.ts
+++ b/e2e/tests/admin-kontrast-axe.spec.ts
@@ -24,6 +24,87 @@ const screens = [
   { url: '/admin/kasse', sichtbar: /Kassentag/ },
 ]
 
+// Die vier per Seed erreichbaren Lösch-Bestätigungen tragen den soliden
+// destructive-solid-Button (weiße bzw. dunkelrote Schrift auf der destruktiven
+// Fläche). Jede Funktion navigiert zur passenden Admin-Seite und öffnet den
+// AlertDialog; die Kontrastmessung läuft anschließend auf den Dialog-Inhalt.
+const loeschDialoge: {
+  name: string
+  oeffne: (page: Page) => Promise<void>
+}[] = [
+  {
+    name: 'Produkt löschen',
+    oeffne: async (page) => {
+      await page.goto('/admin/produkte')
+      await page.getByRole('heading', { name: 'Produkte & Preise' }).waitFor()
+      await page.waitForLoadState('networkidle')
+      await page
+        .getByRole('button', { name: 'Weitere Aktionen' })
+        .first()
+        .click()
+      await page.getByRole('menuitem', { name: /Löschen/ }).click()
+    },
+  },
+  {
+    name: 'Variante löschen',
+    oeffne: async (page) => {
+      await page.goto('/admin/produkte')
+      await page.getByRole('heading', { name: 'Produkte & Preise' }).waitFor()
+      await page.waitForLoadState('networkidle')
+      // Ersten Varianten-Chip öffnen (Bearbeiten-Dialog), dann darin den
+      // Lösch-Einstieg tippen, der die Bestätigung einblendet.
+      await page
+        .getByRole('button', { name: /^Variante „.+" bearbeiten$/ })
+        .first()
+        .click()
+      await page.getByRole('button', { name: 'Variante löschen' }).click()
+    },
+  },
+  {
+    name: 'Tisch löschen',
+    oeffne: async (page) => {
+      await page.goto('/admin/tische')
+      await page.getByRole('heading', { name: 'Tische' }).waitFor()
+      await page.waitForLoadState('networkidle')
+      // Ein frisch angelegter Tisch trägt keinen Saldo — nur dann bietet der
+      // Bearbeiten-Dialog den aktiven Lösch-Einstieg (statt der gesperrten
+      // Variante bei offenem Saldo).
+      await page.getByRole('button', { name: 'Neuer Tisch' }).click()
+      const neuerDialog = page.getByRole('dialog')
+      await neuerDialog.getByLabel('Name').fill('Tisch 99')
+      await neuerDialog.getByRole('button', { name: 'Tisch anlegen' }).click()
+      await page.getByText('Tisch "Tisch 99" wurde angelegt.').waitFor()
+      await page.getByRole('button', { name: /Tisch 99/ }).getByText('Tisch 99').click()
+      await page
+        .getByRole('dialog')
+        .getByRole('button', { name: 'Tisch löschen' })
+        .click()
+    },
+  },
+  {
+    name: 'Helfer löschen',
+    oeffne: async (page) => {
+      await page.goto('/admin/benutzer')
+      await page.getByRole('heading', { name: 'Helfer & Zugänge' }).waitFor()
+      await page.waitForLoadState('networkidle')
+      // Das eigene Konto bietet kein Löschen — die „···"-Menüs durchgehen, bis
+      // eines den Lösch-Eintrag zeigt (ein fremder Helfer).
+      const menues = page.getByRole('button', { name: 'Weitere Aktionen' })
+      const anzahl = await menues.count()
+      for (let i = 0; i < anzahl; i++) {
+        await menues.nth(i).click()
+        const loeschen = page.getByRole('menuitem', { name: /Löschen/ })
+        if (await loeschen.isVisible().catch(() => false)) {
+          await loeschen.click()
+          return
+        }
+        await page.keyboard.press('Escape')
+      }
+      throw new Error('Kein löschbarer Helfer gefunden')
+    },
+  },
+]
+
 // pruefeKontrast lädt einen Screen im gewünschten Theme und lässt axe nur die
 // color-contrast-Regel laufen. Das Theme wird über den localStorage-Schlüssel
 // des ThemeProviders gesetzt (siehe frontend/src/components/theme-provider.tsx);
@@ -57,9 +138,41 @@ async function pruefeKontrast(
   ).toEqual([])
 }
 
+// pruefeDialogKontrast setzt das Theme, öffnet über oeffne den Lösch-Dialog und
+// misst den Kontrast ausschließlich auf dem AlertDialog-Inhalt (Titel,
+// Beschreibung, Abbrechen und der solide destructive-solid-Button). Die
+// Einschränkung auf den Dialog isoliert die geprüfte Bestätigung vom übrigen
+// Seiten- bzw. Bearbeiten-Dialog-Inhalt.
+async function pruefeDialogKontrast(
+  page: Page,
+  theme: 'light' | 'dark',
+  name: string,
+  oeffne: (page: Page) => Promise<void>,
+): Promise<void> {
+  await page.evaluate((t) => {
+    localStorage.setItem('vite-ui-theme', t)
+  }, theme)
+  await oeffne(page)
+  const dialog = page.locator('[data-slot="alert-dialog-content"]')
+  await expect(dialog, `${name}: Lösch-Dialog sichtbar`).toBeVisible()
+
+  const ergebnis = await new AxeBuilder({ page })
+    .include('[data-slot="alert-dialog-content"]')
+    .withRules(['color-contrast'])
+    .analyze()
+
+  const befunde = ergebnis.violations.flatMap((v) =>
+    v.nodes.map((n) => `${n.target.join(' ')} :: ${n.failureSummary ?? ''}`),
+  )
+  expect(
+    befunde,
+    `${theme} ${name}: Kontrast-Verstöße\n${befunde.join('\n')}`,
+  ).toEqual([])
+}
+
 test.describe('WCAG-AA-Kontrast auf Recovery-/Compliance-Screens', () => {
   for (const theme of ['light', 'dark'] as const) {
-    test(`${theme}: Druckstationen, Finanzamt, Kassenabschluss erfüllen AA`, async ({
+    test(`${theme}: Screens und Lösch-Dialoge erfüllen AA`, async ({
       page,
       request,
     }) => {
@@ -68,6 +181,10 @@ test.describe('WCAG-AA-Kontrast auf Recovery-/Compliance-Screens', () => {
 
       for (const { url, sichtbar } of screens) {
         await pruefeKontrast(page, theme, url, sichtbar)
+      }
+
+      for (const { name, oeffne } of loeschDialoge) {
+        await pruefeDialogKontrast(page, theme, name, oeffne)
       }
     })
   }

--- a/e2e/tests/admin-kontrast-axe.spec.ts
+++ b/e2e/tests/admin-kontrast-axe.spec.ts
@@ -156,11 +156,12 @@ async function pruefeDialogKontrast(
   const dialog = page.locator('[data-slot="alert-dialog-content"]')
   await expect(dialog, `${name}: Lösch-Dialog sichtbar`).toBeVisible()
   // Radix blendet den Dialog mit Fade-/Zoom-Animation ein; axe rechnet die
-  // momentane Opacity in die Farben ein. Erst nach Animationsende messen, sonst
-  // verfälscht der halbtransparente Zwischenzustand den Kontrast (der solide
-  // destructive-solid-Button mischt sich dann mit dem dunklen Backdrop).
-  await dialog.evaluate((el) =>
-    Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)),
+  // momentane Opacity in die Farben ein. Erst bei voller Deckkraft messen,
+  // sonst verfälscht der halbtransparente Zwischenzustand den Kontrast (der
+  // solide destructive-solid-Button mischt sich dann mit dem dunklen Backdrop).
+  await expect(dialog, `${name}: Einblend-Animation beendet`).toHaveCSS(
+    'opacity',
+    '1',
   )
 
   const ergebnis = await new AxeBuilder({ page })

--- a/e2e/tests/admin-live-reporting.spec.ts
+++ b/e2e/tests/admin-live-reporting.spec.ts
@@ -33,7 +33,7 @@ test.describe('Admin sieht das Live-Dashboard', () => {
     // Aktualitäts-Anzeige und manueller Refresh sind vorhanden.
     await expect(liveSection.getByText(/aktualisiert \d{2}:\d{2}/)).toBeVisible()
     await expect(
-      liveSection.getByRole('button', { name: 'Jetzt' }),
+      liveSection.getByRole('button', { name: 'Aktualisieren' }),
     ).toBeVisible()
 
     // Offene Tische aus dem Seed-Drehbuch sind gelistet.

--- a/e2e/tests/direktverkauf-storno.mobile.spec.ts
+++ b/e2e/tests/direktverkauf-storno.mobile.spec.ts
@@ -60,6 +60,10 @@ test.describe('Servicekraft tätigt einen Direktverkauf und storniert ihn', () =
       .fill('Kind doch nicht mit')
     await drawer.getByRole('button', { name: 'Stornierung erteilen' }).click()
 
+    // Der Storno bestätigt über den Erfolgs-Pop (statt kommentarlosem
+    // Schließen); der Refetch der Historie folgt beim Schließen des Pops.
+    await expect(page.getByText('Stornierung gebucht.')).toBeVisible()
+
     // Der Verkauf zeigt nun den stornierten Anteil neben dem Gesamtbetrag.
     await expect(page.getByText(/3,00\s*€\s*storniert/)).toBeVisible()
   })

--- a/e2e/tests/stornierung-serviceleitung.mobile.spec.ts
+++ b/e2e/tests/stornierung-serviceleitung.mobile.spec.ts
@@ -59,6 +59,10 @@ test.describe('Serviceleitung storniert geldneutral und mit Warenrücknahme', ()
       .fill('Falsch bestellt, storniert')
     await drawer.getByRole('button', { name: 'Stornierung erteilen' }).click()
 
+    // Die Stornierung bestätigt über den Erfolgs-Pop (statt kommentarlosem
+    // Schließen); der Refetch des Tisch-States folgt beim Schließen des Pops.
+    await expect(page.getByText('Stornierung gebucht.')).toBeVisible()
+
     // Die geldneutrale Korrektur gleicht den Saldo aus — der Tisch ist wieder
     // bei 0,00 €.
     await expect(page.getByText('0,00 €').first()).toBeVisible()
@@ -77,6 +81,8 @@ test.describe('Serviceleitung storniert geldneutral und mit Warenrücknahme', ()
       .getByPlaceholder('Kommentar (erforderlich)')
       .fill('Brezel reklamiert, Warenrücknahme')
     await drawer.getByRole('button', { name: 'Stornierung erteilen' }).click()
+
+    await expect(page.getByText('Stornierung gebucht.')).toBeVisible()
 
     // Die Warenrücknahme lässt den Tisch-Saldo unverändert (die Position war
     // bereits bezahlt) und erscheint als eigener „Warenrücknahme"-Eintrag mit

--- a/e2e/tests/tischservice-lange-bestellung.mobile.spec.ts
+++ b/e2e/tests/tischservice-lange-bestellung.mobile.spec.ts
@@ -59,13 +59,15 @@ test.describe('Drawer-Sticky-Footer bei langer Positionsliste', () => {
 
     // Trinkgeld und Erhalten eintragen: Die zusätzlichen Rückgeld-/
     // Trinkgeld-Zeilen samt Hinweistext verlängern den Drawer-Inhalt weiter.
+    // Der freie Zielbetrag steckt hinter dem „Anderer …"-Aufrunden-Chip.
     const zahlungsDrawer = page.getByRole('dialog')
+    await zahlungsDrawer.getByRole('button', { name: 'Anderer …' }).click()
     await zahlungsDrawer.getByLabel('Zahlbetrag inkl. Trinkgeld').fill('55,00')
     await zahlungsDrawer.getByLabel('Erhalten').fill('60,00')
+    // exact: der Trinkgeld-Buchungshinweis enthält das Wort ebenfalls.
     await expect(
       zahlungsDrawer.getByText('Trinkgeld', { exact: true }),
     ).toBeVisible()
-    // exact: der Hilfetext zum Zahlbetrag-Feld enthält das Wort ebenfalls.
     await expect(
       zahlungsDrawer.getByText('Rückgeld', { exact: true }),
     ).toBeVisible()

--- a/e2e/tests/umbuchung.mobile.spec.ts
+++ b/e2e/tests/umbuchung.mobile.spec.ts
@@ -65,7 +65,11 @@ test.describe('Servicekraft bucht eine Bestellung auf einen anderen Tisch um', (
     await drawer.getByRole('combobox').selectOption({ label: ZIEL_TISCH })
     await expect(ausfuehren).toBeEnabled()
     await ausfuehren.click()
-    await expect(page.getByText('Bestellung umgebucht.')).toBeVisible()
+    // Die Umbuchung bestätigt über den Erfolgs-Pop mit dem Ziel-Tischnamen
+    // (statt eines Toasts); der Refetch folgt beim Schließen des Pops.
+    await expect(
+      page.getByText(`Auf ${ZIEL_TISCH} umgebucht.`),
+    ).toBeVisible()
 
     // Der Quelltisch ist danach ausgeglichen …
     await expect(page.getByText('0,00 €').first()).toBeVisible()

--- a/e2e/website/screenshots.mjs
+++ b/e2e/website/screenshots.mjs
@@ -95,9 +95,9 @@ async function captureApp() {
     const phone = await browser.newContext({ baseURL: BASE, ...devices['Pixel 7'] })
     const p = await login(phone, zugangsdaten.service)
 
-    // Tischübersicht („Meine Tische")
+    // Tischübersicht („Tische")
     await p.goto('/service/tische')
-    await p.getByText('Meine Tische').first().waitFor()
+    await p.getByRole('link', { name: 'Tische', exact: true }).waitFor()
     await p.getByText('Noch offen', { exact: false }).first().waitFor()
     await captureLightDark(p, 'tischuebersicht')
 

--- a/frontend/src/admin/AdminSidebar.tsx
+++ b/frontend/src/admin/AdminSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowRightLeft,
   FileText,
   Lamp,
   Landmark,
@@ -162,7 +163,7 @@ export function AdminSidebar() {
     {
       title: 'Zum Service-Bereich',
       url: '/service/tische',
-      icon: LogOut,
+      icon: ArrowRightLeft,
     },
   ]
 

--- a/frontend/src/admin/kasse/KasseAbschliessenSection.tsx
+++ b/frontend/src/admin/kasse/KasseAbschliessenSection.tsx
@@ -22,7 +22,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { BackendError } from '@/lib/Backend'
 import { getActionErrorMessage } from '@/lib/errorMessages'
-import { cn, formatEuro } from '@/lib/utils'
+import { cn, formatEuro, formatEuroMitVorzeichen } from '@/lib/utils'
 
 import { kasseBackend, useKassenbestand } from './hooks'
 import {
@@ -246,7 +246,7 @@ export function KasseAbschliessenSection({
                 )}
               >
                 {liveDifferenzCents !== null
-                  ? formatEuro(liveDifferenzCents)
+                  ? formatEuroMitVorzeichen(liveDifferenzCents)
                   : '—'}
               </div>
             </div>
@@ -301,7 +301,9 @@ export function KasseAbschliessenSection({
               <div className="flex justify-between gap-4 font-medium">
                 <dt>Differenz</dt>
                 <dd>
-                  {differenzCents !== null ? formatEuro(differenzCents) : '—'}
+                  {differenzCents !== null
+                    ? formatEuroMitVorzeichen(differenzCents)
+                    : '—'}
                 </dd>
               </div>
             </dl>

--- a/frontend/src/admin/kasse/KassensitzungPage.test.tsx
+++ b/frontend/src/admin/kasse/KassensitzungPage.test.tsx
@@ -373,7 +373,8 @@ describe('KasseAbschliessenSection', () => {
     // 342,50 € gezählt bei Soll 340,00 € → Differenz +2,50 € (Überschuss),
     // nicht rot.
     await user.type(screen.getByLabelText('Gezählter Ist-Bestand'), '342,50')
-    const ueberschuss = screen.getByText('2,50 €')
+    // Überschuss trägt das Plus-Vorzeichen (+2,50 €), bleibt aber ohne Rot.
+    const ueberschuss = screen.getByText('+2,50 €')
     expect(ueberschuss).toBeInTheDocument()
     expect(ueberschuss).not.toHaveClass('text-destructive')
   })

--- a/frontend/src/admin/products/EditVariantDialog.tsx
+++ b/frontend/src/admin/products/EditVariantDialog.tsx
@@ -171,7 +171,7 @@ export function EditVariantDialog(props: EditVariantDialogProps) {
           <AlertDialogFooter>
             <AlertDialogCancel>Abbrechen</AlertDialogCancel>
             <AlertDialogAction
-              className="bg-destructive text-white hover:bg-destructive/90"
+              variant="destructive-solid"
               onClick={(e) => {
                 e.preventDefault()
                 void onDelete()

--- a/frontend/src/admin/products/ProductItem.tsx
+++ b/frontend/src/admin/products/ProductItem.tsx
@@ -173,7 +173,7 @@ export function ProductItem(props: ProductItemProps) {
                 props.onEdit(props.product.id)
               }}
             >
-              <Pen /> Umbenennen
+              <Pen /> Bearbeiten
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={activeVarianten.length === 0 || variantLoading}

--- a/frontend/src/admin/products/ProductItem.tsx
+++ b/frontend/src/admin/products/ProductItem.tsx
@@ -206,7 +206,7 @@ export function ProductItem(props: ProductItemProps) {
           <AlertDialogFooter>
             <AlertDialogCancel>Abbrechen</AlertDialogCancel>
             <AlertDialogAction
-              className="bg-destructive text-white hover:bg-destructive/90"
+              variant="destructive-solid"
               onClick={(e) => {
                 e.preventDefault()
                 void handleDelete()

--- a/frontend/src/admin/reporting/LiveReportingSection.test.tsx
+++ b/frontend/src/admin/reporting/LiveReportingSection.test.tsx
@@ -215,7 +215,7 @@ describe('LiveReportingSection — Übersicht', () => {
     expect(screen.getByText('Tisch 9 · felix (Felix W.)')).toBeInTheDocument()
   })
 
-  it('zeigt „Live · aktualisiert HH:MM" und löst den Jetzt-Button aus', async () => {
+  it('zeigt „Live · aktualisiert HH:MM" und löst den Aktualisieren-Button aus', async () => {
     const user = userEvent.setup()
     const onRefresh = vi.fn()
     const stand = new Date('2026-06-18T14:05:00Z').getTime()
@@ -233,7 +233,7 @@ describe('LiveReportingSection — Übersicht', () => {
       screen.getByText(/^Live · aktualisiert \d{2}:\d{2}$/),
     ).toBeInTheDocument()
 
-    await user.click(screen.getByRole('button', { name: 'Jetzt' }))
+    await user.click(screen.getByRole('button', { name: 'Aktualisieren' }))
     expect(onRefresh).toHaveBeenCalledTimes(1)
   })
 

--- a/frontend/src/admin/reporting/LiveReportingSection.tsx
+++ b/frontend/src/admin/reporting/LiveReportingSection.tsx
@@ -112,7 +112,7 @@ export function LiveReportingSection({
             </span>
             <Button variant="outline" size="sm" onClick={onRefresh}>
               <RefreshCw className="size-4" />
-              Jetzt
+              Aktualisieren
             </Button>
           </>
         }

--- a/frontend/src/admin/settings/DruckstationConfigPage.test.tsx
+++ b/frontend/src/admin/settings/DruckstationConfigPage.test.tsx
@@ -1,4 +1,9 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import {
+  cleanup,
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { toast } from 'sonner'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -222,7 +227,28 @@ describe('DruckstationConfigPage — Stationskarten', () => {
     )
   })
 
-  it('speichert eine unveränderte IP nicht und zeigt bei ungültiger IP einen Fehler', async () => {
+  it('zeigt nach erfolgreichem IP-Speichern eine Inline-Bestätigung, die nach ~2 Sekunden verschwindet', async () => {
+    druckstationenState.druckstationen = [
+      makeStation({ kategorie: 'essen', druckerIp: '192.168.1.50' }),
+    ]
+    const user = userEvent.setup()
+    render(<DruckstationConfigPage />)
+
+    const input = screen.getByLabelText('Drucker-IP')
+    await user.clear(input)
+    await user.type(input, '192.168.1.99')
+    await user.tab()
+
+    // Inline-Bestätigung am Feld zusätzlich zum Toast.
+    expect(await screen.findByText('Gespeichert')).toBeInTheDocument()
+
+    // Nach ~2 Sekunden verschwindet die Bestätigung wieder.
+    await waitForElementToBeRemoved(() => screen.queryByText('Gespeichert'), {
+      timeout: 3000,
+    })
+  })
+
+  it('speichert eine unveränderte IP nicht und zeigt bei ungültiger IP einen Fehler ohne Inline-Bestätigung', async () => {
     druckstationenState.druckstationen = [
       makeStation({ kategorie: 'essen', druckerIp: '192.168.1.50' }),
     ]
@@ -236,6 +262,7 @@ describe('DruckstationConfigPage — Stationskarten', () => {
 
     expect(updateDruckstation).not.toHaveBeenCalled()
     expect(screen.getByText('Ungültige IPv4-Adresse')).toBeInTheDocument()
+    expect(screen.queryByText('Gespeichert')).not.toBeInTheDocument()
   })
 
   it('fasst nicht konfigurierte Stationen als gestrichelte Karte mit "Drucker zuweisen" zusammen', async () => {

--- a/frontend/src/admin/settings/DruckstationConfigPage.tsx
+++ b/frontend/src/admin/settings/DruckstationConfigPage.tsx
@@ -395,7 +395,7 @@ function AlleVerwerfenDialog({
         <AlertDialogFooter>
           <AlertDialogCancel>Abbrechen</AlertDialogCancel>
           <AlertDialogAction
-            className="bg-destructive text-white hover:bg-destructive/90"
+            variant="destructive-solid"
             onClick={() =>
               void run(async () => {
                 const verworfen = await alleVerwerfen()

--- a/frontend/src/admin/settings/DruckstationConfigPage.tsx
+++ b/frontend/src/admin/settings/DruckstationConfigPage.tsx
@@ -1,4 +1,4 @@
-import { Printer } from 'lucide-react'
+import { Check, Printer } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
@@ -134,6 +134,7 @@ function DruckstationCard({
   const zeigtBonmodus = hatBonmodus(config.kategorie)
   const [druckerIp, setDruckerIp] = useState(config.druckerIp)
   const [ipError, setIpError] = useState<string | null>(null)
+  const [ipGespeichert, setIpGespeichert] = useState(false)
   const { loading: saving, run: runSave } = useActionSubmit({
     actionLabel: 'Drucker-IP speichern',
   })
@@ -160,6 +161,12 @@ function DruckstationCard({
     await runSave(async () => {
       await onUpdate({ ...config, druckerIp })
       toast.success(`Drucker-IP für „${info.label}“ gespeichert.`)
+      // Kurze Inline-Bestätigung am Feld für ~2 Sekunden (Muster der TSE-
+      // Kopier-Bestätigung); der Toast bleibt zusätzlich bestehen.
+      setIpGespeichert(true)
+      setTimeout(() => {
+        setIpGespeichert(false)
+      }, 2000)
     })
   }
 
@@ -189,6 +196,12 @@ function DruckstationCard({
             className="text-muted-foreground"
           >
             Drucker-IP
+            {ipGespeichert && (
+              <span className="flex items-center gap-1 text-primary">
+                <Check className="size-3.5" aria-hidden />
+                Gespeichert
+              </span>
+            )}
           </Label>
           <Input
             id={`ip-${config.kategorie}`}
@@ -198,6 +211,9 @@ function DruckstationCard({
               setDruckerIp(e.target.value)
               if (ipError !== null) {
                 setIpError(null)
+              }
+              if (ipGespeichert) {
+                setIpGespeichert(false)
               }
             }}
             onBlur={() => void speichereIp()}

--- a/frontend/src/admin/tables/EditTischDialog.tsx
+++ b/frontend/src/admin/tables/EditTischDialog.tsx
@@ -159,7 +159,7 @@ export function EditTischDialog(props: EditTischDialogProps) {
                 <AlertDialogFooter>
                   <AlertDialogCancel>Abbrechen</AlertDialogCancel>
                   <AlertDialogAction
-                    className="bg-destructive text-white hover:bg-destructive/90"
+                    variant="destructive-solid"
                     onClick={(e) => {
                       e.preventDefault()
                       void onDelete()

--- a/frontend/src/admin/users/UserRow.tsx
+++ b/frontend/src/admin/users/UserRow.tsx
@@ -143,7 +143,7 @@ export function UserRow(props: UserRowProps) {
           <AlertDialogFooter>
             <AlertDialogCancel>Abbrechen</AlertDialogCancel>
             <AlertDialogAction
-              className="bg-destructive text-white hover:bg-destructive/90"
+              variant="destructive-solid"
               onClick={(e) => {
                 e.preventDefault()
                 void props.onDelete(props.user.id).then(() => {

--- a/frontend/src/components/common/EuroInput.test.tsx
+++ b/frontend/src/components/common/EuroInput.test.tsx
@@ -1,7 +1,7 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { EuroInput } from './EuroInput'
 
@@ -12,6 +12,7 @@ function Harness({ initial = '' }: { initial?: string }) {
 
 afterEach(() => {
   cleanup()
+  vi.useRealTimers()
 })
 
 describe('EuroInput', () => {
@@ -68,6 +69,31 @@ describe('EuroInput', () => {
     await user.tab()
 
     expect(input).toHaveValue('4,50')
+  })
+
+  it('formatiert während einer Tipp-Pause nicht um (kein Debounce-Reformat)', () => {
+    // Fake-Timer vor der Eingabe aktivieren, damit ein etwaiger Debounce-Timer
+    // aus onChange unter der Fake-Uhr geplant würde und vom advanceTimersByTime
+    // unten tatsächlich feuern könnte — sonst wäre der Test wirkungslos.
+    // fireEvent (synchron, ohne eigene Timer) statt userEvent, das unter
+    // Fake-Timern hängt.
+    vi.useFakeTimers()
+    render(<Harness />)
+    const input = screen.getByPlaceholderText('0,00')
+
+    fireEvent.change(input, { target: { value: '1' } })
+
+    // Über eine Sekunde warten: früher hätte der Debounce hier zu „1,00" umformatiert.
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+    expect(input).toHaveValue('1')
+
+    fireEvent.change(input, { target: { value: '15' } })
+    expect(input).toHaveValue('15')
+
+    fireEvent.blur(input)
+    expect(input).toHaveValue('15,00')
   })
 
   it('leert das Feld beim Verlassen, wenn kein gültiger Betrag eingegeben wurde', async () => {

--- a/frontend/src/components/common/EuroInput.tsx
+++ b/frontend/src/components/common/EuroInput.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useRef } from 'react'
-
 import { Input } from '@/components/ui/input'
 import { cn, formatCents, parseCents } from '@/lib/utils'
 
@@ -40,8 +38,8 @@ interface EuroInputProps {
 /**
  * The canonical money input: a `€` sign inside the field, the decimal
  * keypad on mobile, input sanitised to digits and a comma, and normalisation to
- * two decimals on blur (and after a typing pause). String in, string out — wrap
- * it in a form field for cents-based state.
+ * two decimals on blur. String in, string out — wrap it in a form field for
+ * cents-based state.
  */
 export function EuroInput({
   value,
@@ -53,15 +51,6 @@ export function EuroInput({
   disabled,
   'aria-invalid': ariaInvalid,
 }: EuroInputProps) {
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  // Clear any pending normalisation when the input unmounts.
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current)
-    }
-  }, [])
-
   return (
     <div className="relative">
       <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2.5 text-sm text-muted-foreground">
@@ -79,17 +68,9 @@ export function EuroInput({
         aria-invalid={ariaInvalid}
         value={value}
         onChange={(e) => {
-          const cleaned = cleanInput(e.target.value)
-          onValueChange(cleaned)
-
-          // Debounce the reformat so the cursor does not jump while typing.
-          if (debounceRef.current) clearTimeout(debounceRef.current)
-          debounceRef.current = setTimeout(() => {
-            onValueChange(formatBlur(cleaned))
-          }, 1000)
+          onValueChange(cleanInput(e.target.value))
         }}
         onBlur={() => {
-          if (debounceRef.current) clearTimeout(debounceRef.current)
           onValueChange(formatBlur(value))
           onBlur?.()
         }}

--- a/frontend/src/components/common/LoginForm.test.tsx
+++ b/frontend/src/components/common/LoginForm.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { LoginForm } from './LoginForm'
+
+// AuthSingleton dekodiert echte JWTs; im Happy-Path-Test wird der Token-Schritt
+// neutralisiert, damit der Test nur den Formular-Submit prüft.
+const authState = vi.hoisted<{ isAdmin: boolean }>(() => ({ isAdmin: false }))
+
+vi.mock('@/lib/Auth', () => ({
+  AuthSingleton: {
+    validateAndSetToken: vi.fn(),
+    get isAdmin() {
+      return authState.isAdmin
+    },
+  },
+}))
+
+afterEach(() => {
+  cleanup()
+  authState.isAdmin = false
+})
+
+function renderLogin(login = vi.fn()) {
+  render(
+    <MemoryRouter>
+      <LoginForm backend={{ login }} />
+    </MemoryRouter>,
+  )
+  return login
+}
+
+describe('LoginForm', () => {
+  it('zeigt bei leerem Formular die Feldfehler und löst keinen Login aus', async () => {
+    const user = userEvent.setup()
+    const login = renderLogin()
+
+    await user.click(screen.getByRole('button', { name: /Anmelden/ }))
+
+    expect(
+      await screen.findByText(
+        'Benutzername muss mindestens 3 Zeichen lang sein.',
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Passwort muss mindestens 6 Zeichen lang sein.'),
+    ).toBeInTheDocument()
+    expect(login).not.toHaveBeenCalled()
+  })
+
+  it('deaktiviert den Button während des Ladens (kein Doppel-Submit)', async () => {
+    const user = userEvent.setup()
+    // Login hängt, damit der Ladezustand während der Assertion aktiv bleibt.
+    const login = vi.fn(
+      () =>
+        new Promise<string>(() => {
+          /* bleibt pending */
+        }),
+    )
+    renderLogin(login)
+
+    await user.type(screen.getByPlaceholderText('Benutzername'), 'anna')
+    await user.type(screen.getByPlaceholderText('Passwort'), 'geheim1')
+    await user.click(screen.getByRole('button', { name: /Anmelden/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Anmelden/ })).toBeDisabled()
+    })
+    expect(login).toHaveBeenCalledTimes(1)
+  })
+
+  it('submittet gültige Eingaben und ruft den Login-Backend-Aufruf auf', async () => {
+    const user = userEvent.setup()
+    const login = vi.fn().mockResolvedValue('token')
+    renderLogin(login)
+
+    await user.type(screen.getByPlaceholderText('Benutzername'), 'anna')
+    await user.type(screen.getByPlaceholderText('Passwort'), 'geheim1')
+    await user.click(screen.getByRole('button', { name: /Anmelden/ }))
+
+    await waitFor(() => {
+      expect(login).toHaveBeenCalledWith('anna', 'geheim1')
+    })
+  })
+})

--- a/frontend/src/components/common/LoginForm.tsx
+++ b/frontend/src/components/common/LoginForm.tsx
@@ -88,7 +88,7 @@ export function LoginForm(props: LoginFormProps) {
           type="submit"
           form="login-form"
           className="w-full"
-          disabled={loading || !form.formState.isValid}
+          disabled={loading}
         >
           {loading ? <Spinner /> : null} Anmelden
         </Button>

--- a/frontend/src/components/common/PasswordForm.test.tsx
+++ b/frontend/src/components/common/PasswordForm.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { PasswordForm } from './PasswordForm'
+
+// input-otp registriert intern einen ResizeObserver; jsdom bringt keinen mit.
+class ResizeObserverStub {
+  observe() {
+    /* no-op */
+  }
+  unobserve() {
+    /* no-op */
+  }
+  disconnect() {
+    /* no-op */
+  }
+}
+
+beforeAll(() => {
+  globalThis.ResizeObserver = ResizeObserverStub
+  // input-otp ruft nach Fokus/Eingabe in einem Timer document.elementFromPoint
+  // auf; jsdom implementiert es nicht.
+  document.elementFromPoint = () => null
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+function otpInput(container: HTMLElement): HTMLInputElement {
+  const input = container.querySelector('[data-input-otp]')
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error('OTP-Eingabefeld nicht gefunden')
+  }
+  return input
+}
+
+function renderPassword(setPassword = vi.fn()) {
+  const result = render(
+    <MemoryRouter>
+      <PasswordForm backend={{ setPassword }} />
+    </MemoryRouter>,
+  )
+  return { setPassword, ...result }
+}
+
+describe('PasswordForm', () => {
+  it('zeigt bei leerem Formular die Feldfehler und löst keinen Aufruf aus', async () => {
+    const user = userEvent.setup()
+    const { setPassword } = renderPassword()
+
+    await user.click(screen.getByRole('button', { name: /Passwort festlegen/ }))
+
+    expect(
+      await screen.findByText(
+        'Benutzername muss mindestens 3 Zeichen lang sein.',
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Passwort muss mindestens 6 Zeichen lang sein.'),
+    ).toBeInTheDocument()
+    expect(setPassword).not.toHaveBeenCalled()
+  })
+
+  it('deaktiviert den Button während des Ladens (kein Doppel-Submit)', async () => {
+    const user = userEvent.setup()
+    // setPassword hängt, damit der Ladezustand während der Assertion aktiv bleibt.
+    const setPassword = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          /* bleibt pending */
+        }),
+    )
+    const { container } = renderPassword(setPassword)
+
+    await user.type(screen.getByPlaceholderText('Benutzername'), 'anna')
+    await user.type(screen.getByPlaceholderText('Neues Passwort'), 'geheim1')
+    await user.type(otpInput(container), '123456')
+    await user.click(screen.getByRole('button', { name: /Passwort festlegen/ }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /Passwort festlegen/ }),
+      ).toBeDisabled()
+    })
+    expect(setPassword).toHaveBeenCalledTimes(1)
+  })
+
+  it('submittet gültige Eingaben und ruft den Backend-Aufruf auf', async () => {
+    const user = userEvent.setup()
+    const setPassword = vi.fn().mockResolvedValue(undefined)
+    const { container } = renderPassword(setPassword)
+
+    await user.type(screen.getByPlaceholderText('Benutzername'), 'anna')
+    await user.type(screen.getByPlaceholderText('Neues Passwort'), 'geheim1')
+    await user.type(otpInput(container), '123456')
+    await user.click(screen.getByRole('button', { name: /Passwort festlegen/ }))
+
+    await waitFor(() => {
+      expect(setPassword).toHaveBeenCalledWith('anna', 'geheim1', '123456')
+    })
+  })
+})

--- a/frontend/src/components/common/PasswordForm.tsx
+++ b/frontend/src/components/common/PasswordForm.tsx
@@ -89,7 +89,7 @@ export function PasswordForm(props: PasswordFormProps) {
           type="submit"
           form="password-form"
           className="w-full"
-          disabled={loading || !form.formState.isValid}
+          disabled={loading}
         >
           {loading ? <Spinner /> : null} Passwort festlegen
         </Button>

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -14,6 +14,7 @@ const badgeVariants = cva(
           "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        warn: "bg-amber-500/15 text-amber-700 focus-visible:ring-amber-500/20 dark:bg-amber-500/20 dark:text-amber-400 dark:focus-visible:ring-amber-500/40 [a]:hover:bg-amber-500/25",
         outline:
           "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost:

--- a/frontend/src/components/ui/button.test.tsx
+++ b/frontend/src/components/ui/button.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Button, buttonVariants } from './button'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Button destructive-solid variant', () => {
+  // Der solide destructive-Button trägt seinen AA-Kontrast über das Token
+  // --destructive-solid-foreground (Light: Weiß, Dark: red-950 auf der
+  // aufgehellten Fläche). jsdom kennt keine berechneten Farben — der reale
+  // Kontrast wird im axe-E2E-Gate (admin-kontrast-axe.spec.ts) gemessen; hier
+  // wird nur verankert, dass der Variant existiert und die Token-Flächen- und
+  // -Textklassen verdrahtet.
+  it('applies the solid destructive surface and the foreground token class', () => {
+    const classes = buttonVariants({ variant: 'destructive-solid' })
+    expect(classes).toContain('bg-destructive')
+    expect(classes).toContain('text-destructive-solid-foreground')
+  })
+
+  it('renders through the Button component', () => {
+    render(<Button variant="destructive-solid">Löschen</Button>)
+    const button = screen.getByRole('button', { name: 'Löschen' })
+    expect(button).toHaveAttribute('data-variant', 'destructive-solid')
+    expect(button.className).toContain('bg-destructive')
+    expect(button.className).toContain('text-destructive-solid-foreground')
+  })
+})

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -33,6 +33,13 @@ const buttonVariants = cva(
         // „irreversibel", nicht „gefährlich" — distinkt von destructive-Rot und
         // primär-Grün. Verbindliches Muster: ADR 04.
         warn: "bg-warn text-warn-foreground shadow-xs hover:bg-warn/90 disabled:opacity-50",
+        // Destructive-solid: solide destruktive Fläche für die Bestätigung
+        // irreversibler Lösch-Aktionen im AlertDialog. Die Textfarbe trägt das
+        // Token --destructive-solid-foreground ihren AA-Kontrast selbst (Light:
+        // Weiß auf der dunklen Fläche; Dark: red-950 auf der aufgehellten
+        // Fläche) — analog zum warn-Muster (ADR 04).
+        "destructive-solid":
+          "bg-destructive text-destructive-solid-foreground shadow-xs hover:bg-destructive/90 disabled:opacity-50",
         link: "text-primary underline-offset-4 hover:underline disabled:opacity-50",
       },
       size: {

--- a/frontend/src/hooks/use-mengen.ts
+++ b/frontend/src/hooks/use-mengen.ts
@@ -1,6 +1,19 @@
 import { useState } from 'react'
 
 /**
+ * Return shape of {@link useMengen}. Exposed so callers can lift the selection
+ * state and pass the whole controller down as a single prop (e.g. TablePage
+ * hoists the order cart and payment selection so they survive tab switches).
+ */
+export interface MengenSteuerung<K extends string | number> {
+  mengen: Record<K, number>
+  add: (key: K) => void
+  remove: (key: K) => void
+  reset: () => void
+  setAll: (next: Record<K, number>) => void
+}
+
+/**
  * Quantity-selector state keyed by id (variant id for ordering/direct sale,
  * position id for payment). `add` increments, `remove` decrements but never
  * below zero, `reset` clears the whole selection, `setAll` replaces the whole
@@ -8,7 +21,9 @@ import { useState } from 'react'
  * responsible for staying within the cap). Pass `max` to cap a key's quantity
  * on `add` (e.g. the still-unpaid amount of a position).
  */
-export function useMengen<K extends string | number>(max?: (key: K) => number) {
+export function useMengen<K extends string | number>(
+  max?: (key: K) => number,
+): MengenSteuerung<K> {
   const [mengen, setMengen] = useState<Record<K, number>>(
     () => ({}) as Record<K, number>,
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,7 @@
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-destructive-solid-foreground: var(--destructive-solid-foreground);
   --color-disabled: var(--disabled);
   --color-disabled-foreground: var(--disabled-foreground);
   --color-warn: var(--warn);
@@ -85,6 +86,9 @@
   --destructive: oklch(0.53 0.238 27.325);
   /* red-600 abgedunkelt: text-destructive erreicht WCAG AA (4,5:1) auch auf den
      weichen destructive/4- und destructive/10-Tints (z. B. WarnKarte) */
+  --destructive-solid-foreground: oklch(1 0 0);
+  /* Weiss: die dunkle Light-Destructive-Flaeche traegt AA-Kontrast (5,6:1) fuer
+     den soliden destructive-solid-Button (irreversible Loesch-Bestaetigung) */
   --disabled: oklch(0.9 0.004 106.5);
   /* olive-200, neutrale Flaeche fuer deaktivierte Primaeraktionen */
   --disabled-foreground: oklch(0.47 0.012 106.5);
@@ -181,6 +185,9 @@
   /* olive-50 */
   --destructive: oklch(0.74 0.191 22.216);
   /* red-400, aufgehellt fuer Dark-Mode-Lesbarkeit von destructive-Text und Soft-Flaechen */
+  --destructive-solid-foreground: oklch(0.258 0.092 26.042);
+  /* red-950: dunkler Text auf der aufgehellten Dark-Destructive-Flaeche traegt
+     AA-Kontrast (6:1) fuer den soliden destructive-solid-Button */
   --disabled: oklch(0.33 0.008 107.4);
   /* olive-800, neutrale Flaeche fuer deaktivierte Primaeraktionen */
   --disabled-foreground: oklch(0.74 0.016 106.9);

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  formatAlleAuswaehlenLabel,
   formatCents,
   formatEuro,
+  formatEuroMitVorzeichen,
   formatPositionName,
   formatRelativeTime,
   parseCents,
@@ -35,6 +37,41 @@ describe('formatEuro', () => {
   it('trennt Betrag und € mit geschütztem Leerzeichen (U+00A0)', () => {
     expect(formatEuro(1250)).toBe('12,50\u00A0€')
     expect(formatEuro(1250)).not.toContain('12,50 €')
+  })
+})
+
+describe('formatEuroMitVorzeichen', () => {
+  it('setzt ein Plus nur bei positiven Beträgen', () => {
+    expect(formatEuroMitVorzeichen(1250)).toBe(`+${formatEuro(1250)}`)
+    expect(formatEuroMitVorzeichen(1)).toBe(`+${formatEuro(1)}`)
+  })
+
+  it('lässt Null ohne Vorzeichen', () => {
+    expect(formatEuroMitVorzeichen(0)).toBe(formatEuro(0))
+  })
+
+  it('behält das Minus negativer Beträge', () => {
+    expect(formatEuroMitVorzeichen(-350)).toBe(formatEuro(-350))
+  })
+})
+
+describe('formatAlleAuswaehlenLabel', () => {
+  it('nutzt „Alle …" mit Plural und „1 Position" im Singular (Standard-Variante)', () => {
+    expect(formatAlleAuswaehlenLabel(3, 1250)).toBe(
+      `Alle 3 Positionen auswählen · ${formatEuro(1250)}`,
+    )
+    expect(formatAlleAuswaehlenLabel(1, 700)).toBe(
+      `1 Position auswählen · ${formatEuro(700)}`,
+    )
+  })
+
+  it('nutzt „Meine …" in der Kassieren-Variante, Singular ohne Zahl', () => {
+    expect(formatAlleAuswaehlenLabel(2, 1250, 'meine')).toBe(
+      `Meine 2 Positionen auswählen · ${formatEuro(1250)}`,
+    )
+    expect(formatAlleAuswaehlenLabel(1, 700, 'meine')).toBe(
+      `Meine Position auswählen · ${formatEuro(700)}`,
+    )
   })
 })
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -31,19 +31,42 @@ export function formatEuro(cents: number): string {
 }
 
 /**
- * Label of the "Alle auswählen" button in Kassieren and Umbuchung: correct
- * grammatical number (singular "1 Position", plural "N Positionen") plus the
- * selection sum. With exactly one position the plural-implying "Alle" is dropped.
+ * Label of the bulk-select button in Kassieren and Umbuchung: correct
+ * grammatical number (singular one position, plural "N Positionen") plus the
+ * selection sum. The variant chooses the leading word: `'alle'` (Umbuchung —
+ * every position) says "Alle N Positionen auswählen" / "1 Position auswählen";
+ * `'meine'` (Kassieren — only the caller's own positions) says "Meine N
+ * Positionen auswählen" / "Meine Position auswählen".
  */
 export function formatAlleAuswaehlenLabel(
   anzahl: number,
   summeCents: number,
+  variante: 'alle' | 'meine' = 'alle',
 ): string {
-  const auswahl =
-    anzahl === 1
-      ? '1 Position auswählen'
-      : `Alle ${anzahl.toString()} Positionen auswählen`
+  let auswahl: string
+  if (variante === 'meine') {
+    auswahl =
+      anzahl === 1
+        ? 'Meine Position auswählen'
+        : `Meine ${anzahl.toString()} Positionen auswählen`
+  } else {
+    auswahl =
+      anzahl === 1
+        ? '1 Position auswählen'
+        : `Alle ${anzahl.toString()} Positionen auswählen`
+  }
   return `${auswahl} · ${formatEuro(summeCents)}`
+}
+
+/**
+ * Like {@link formatEuro} but prefixes a "+" for a positive amount, so a surplus
+ * reads as "+12,50 €". Zero stays "0,00 €" (no sign) and a negative amount keeps
+ * the leading minus of the default formatting ("-3,50 €"). For difference
+ * displays where a positive value means a surplus (e.g. the Kassensturz-Differenz
+ * as Ist − Soll).
+ */
+export function formatEuroMitVorzeichen(cents: number): string {
+  return cents > 0 ? `+${formatEuro(cents)}` : formatEuro(cents)
 }
 
 /**

--- a/frontend/src/service/DirektverkaufPage.tsx
+++ b/frontend/src/service/DirektverkaufPage.tsx
@@ -23,9 +23,9 @@ export function DirektverkaufPage() {
     refetch: reloadHistorie,
   } = useDirektverkaufHistorie()
 
-  // Erfolgs-Pop: Der abgeschlossene Verkauf öffnet ihn mit seiner Meldung (statt
-  // eines Erfolgs-Toasts). Der Refetch der Historie läuft erst beim Schließen,
-  // damit der neue Eintrag dem Pop folgt. Der Storno-Pfad lädt weiterhin sofort.
+  // Erfolgs-Pop: Der abgeschlossene Verkauf und der Storno öffnen ihn mit ihrer
+  // Meldung (statt eines Erfolgs-Toasts). Der Refetch der Historie läuft erst
+  // beim Schließen, damit die Änderung dem Pop folgt.
   const [erfolg, setErfolg] = useState({ open: false, text: '' })
   const zeigeErfolg = useCallback((nachricht: string) => {
     setErfolg({ open: true, text: nachricht })
@@ -59,9 +59,7 @@ export function DirektverkaufPage() {
       historie={historie}
       historieLoading={historieLoading}
       backend={direktverkaufBackend}
-      onStorniert={() => {
-        void reloadHistorie()
-      }}
+      onErfolg={zeigeErfolg}
     />
   )
 

--- a/frontend/src/service/ServiceLayout.test.tsx
+++ b/frontend/src/service/ServiceLayout.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ServiceLayout } from './ServiceLayout'
+
+// UserDropdown zieht Auth-Singleton und Theme-Provider herein; für den
+// Layout-Test der Modus-Umschaltung reicht ein Stub.
+vi.mock('@/components/common/UserDropdown', () => ({
+  UserDropdown: () => null,
+}))
+
+function renderLayout(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/service" element={<ServiceLayout />}>
+          <Route path="tische" element={<div>Tischauswahl-Seite</div>} />
+          <Route path="direktverkauf" element={<div>Theke-Seite</div>} />
+          <Route
+            path="tische/:tischId"
+            element={<div>Tischdetail-Seite</div>}
+          />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ServiceLayout — Modus-Umschaltung', () => {
+  it('zeigt auf der Tischauswahl die Segmented Control mit aktivem „Tische"', () => {
+    renderLayout('/service/tische')
+
+    const tische = screen.getByRole('link', { name: 'Tische' })
+    const theke = screen.getByRole('link', { name: 'Theke' })
+    expect(tische).toHaveAttribute('aria-current', 'page')
+    expect(theke).not.toHaveAttribute('aria-current')
+  })
+
+  it('zeigt im Direktverkauf die Segmented Control mit aktivem „Theke"', () => {
+    renderLayout('/service/direktverkauf')
+
+    const tische = screen.getByRole('link', { name: 'Tische' })
+    const theke = screen.getByRole('link', { name: 'Theke' })
+    expect(theke).toHaveAttribute('aria-current', 'page')
+    expect(tische).not.toHaveAttribute('aria-current')
+  })
+
+  it('navigiert über die Control von Tischen zur Theke und zurück', async () => {
+    const user = userEvent.setup()
+    renderLayout('/service/tische')
+
+    expect(screen.getByText('Tischauswahl-Seite')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('link', { name: 'Theke' }))
+    expect(screen.getByText('Theke-Seite')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Theke' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
+
+    await user.click(screen.getByRole('link', { name: 'Tische' }))
+    expect(screen.getByText('Tischauswahl-Seite')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Tische' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
+  })
+
+  it('zeigt auf der Tisch-Detailseite den Backlink statt der Control', () => {
+    renderLayout('/service/tische/7')
+
+    expect(screen.getByText('Tischdetail-Seite')).toBeInTheDocument()
+    // Backlink „Meine Tische" ist vorhanden, aber kein Theke-Segment.
+    expect(
+      screen.getByRole('link', { name: /Meine Tische/ }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Theke' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('macht die Tap-Ziele der Segmente mindestens 44 px hoch', () => {
+    renderLayout('/service/tische')
+
+    expect(screen.getByRole('link', { name: 'Tische' })).toHaveClass('h-11')
+    expect(screen.getByRole('link', { name: 'Theke' })).toHaveClass('h-11')
+  })
+})

--- a/frontend/src/service/ServiceLayout.tsx
+++ b/frontend/src/service/ServiceLayout.tsx
@@ -2,11 +2,39 @@ import { ChevronLeft } from 'lucide-react'
 import { Link, Outlet, useMatch } from 'react-router'
 
 import { UserDropdown } from '@/components/common/UserDropdown'
+import { cn } from '@/lib/utils'
+
+// Ein Segment der Modus-Umschaltung: react-router-Link in Tabs-Optik (abgeleitet
+// aus tabsListVariants/TabsTrigger). Der aktive Zustand kommt aus der Route, das
+// aktive Segment trägt aria-current="page". Höhe 44 px als Tap-Ziel.
+function ModusSegment({
+  to,
+  label,
+  aktiv,
+}: {
+  to: string
+  label: string
+  aktiv: boolean
+}) {
+  return (
+    <Link
+      to={to}
+      aria-current={aktiv ? 'page' : undefined}
+      className={cn(
+        'inline-flex h-11 min-w-20 items-center justify-center rounded-md px-4 text-sm font-medium transition-all focus-visible:outline-1 focus-visible:outline-ring',
+        aktiv
+          ? 'bg-background text-foreground shadow-sm dark:bg-input/30 dark:text-foreground'
+          : 'text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground',
+      )}
+    >
+      {label}
+    </Link>
+  )
+}
 
 export function ServiceLayout() {
   const onTableDetail = useMatch('/service/tische/:tischId')
   const onDirektverkauf = useMatch('/service/direktverkauf')
-  const titel = onDirektverkauf ? 'Direktverkauf' : 'Meine Tische'
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -21,7 +49,21 @@ export function ServiceLayout() {
               Meine Tische
             </Link>
           ) : (
-            <span className="text-sm font-bold">{titel}</span>
+            <nav
+              aria-label="Arbeitsmodus"
+              className="inline-flex items-center rounded-lg bg-muted p-[3px] text-muted-foreground"
+            >
+              <ModusSegment
+                to="/service/tische"
+                label="Tische"
+                aktiv={onDirektverkauf === null}
+              />
+              <ModusSegment
+                to="/service/direktverkauf"
+                label="Theke"
+                aktiv={onDirektverkauf !== null}
+              />
+            </nav>
           )}
         </div>
         <UserDropdown />

--- a/frontend/src/service/TablePage.test.tsx
+++ b/frontend/src/service/TablePage.test.tsx
@@ -181,8 +181,11 @@ describe('TablePage', () => {
     getTischHistorie.mockResolvedValue([])
     renderPage()
 
-    expect(await screen.findByText('2 unbezahlt')).toBeInTheDocument()
+    const badge = await screen.findByText('2 unbezahlt')
     expect(screen.queryByText('Alles bezahlt')).not.toBeInTheDocument()
+    // "Unbezahlt" wartet auf die Servicekraft, ist aber kein Gefahrenzustand:
+    // Amber-Warn-Variante statt des Gefahren-Rots (destructive).
+    expect(badge).toHaveAttribute('data-variant', 'warn')
   })
 
   // A1: Der gehobene Auswahl-State überlebt das Aus- und Wiedereinhängen der

--- a/frontend/src/service/TablePage.test.tsx
+++ b/frontend/src/service/TablePage.test.tsx
@@ -241,6 +241,86 @@ describe('TablePage', () => {
     )
   })
 
+  // A1: Der useMengen-`max` deckelt nur beim `add`. Schrumpft die unbezahlte
+  // Menge einer bereits ausgewählten Position (Storno-Refetch, der erst beim
+  // Schließen des Erfolgs-Pops eintrifft), muss die gehobene Auswahl auf die
+  // neue Obergrenze sinken; eine verschwundene Position fällt heraus.
+  it('deckelt die Kassieren-Auswahl, wenn ein Refetch kleinere unbezahlte Mengen liefert', async () => {
+    const posMehr = { ...position('p1'), menge: 2 }
+    const posWeg = position('p2')
+    getTischState
+      .mockResolvedValueOnce({
+        ...stammtisch,
+        unbezahltePositionen: [posMehr, posWeg],
+      })
+      .mockResolvedValue({
+        ...stammtisch,
+        unbezahltePositionen: [{ ...posMehr, menge: 1 }],
+      })
+    getTischHistorie.mockResolvedValue([
+      {
+        art: 'bestellung',
+        id: '00000000-0000-0000-0000-000000000001',
+        userId: 1,
+        userName: 'Tester',
+        tischId: 1,
+        positionen: [posMehr],
+        gesamtPreisCents: 700,
+        kommentar: '',
+        aufgenommenAm: '2026-06-18T12:00:00Z',
+        stornierbarePositionen: [posMehr],
+        umbuchbarePositionen: [],
+      },
+    ])
+    stornierungErteilen.mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Stammtisch')
+
+    // Kassieren: p1 voll (2 von 2) und p2 (1 von 1) auswählen.
+    await user.click(screen.getByRole('tab', { name: 'Kassieren' }))
+    await user.click(
+      screen.getAllByRole('button', { name: 'Produkt hinzufügen' })[0],
+    )
+    await user.click(
+      screen.getAllByRole('button', { name: 'Produkt hinzufügen' })[0],
+    )
+    await user.click(
+      screen.getAllByRole('button', { name: 'Produkt hinzufügen' })[1],
+    )
+    expect(screen.getByRole('button', { name: /Kassieren/ })).toHaveTextContent(
+      '10,50',
+    )
+
+    // Storno auf der Historie; der Refetch läuft erst beim Schließen des Pops.
+    await user.click(screen.getByRole('tab', { name: 'Historie' }))
+    await user.click(screen.getByRole('button', { name: /Bestellung/ }))
+    await user.click(screen.getByRole('button', { name: /Stornieren…/ }))
+    await user.click(screen.getByRole('button', { name: /hinzufügen/ }))
+    await user.type(
+      screen.getByPlaceholderText('Kommentar (erforderlich)'),
+      'Falsch gebucht',
+    )
+    await user.click(
+      screen.getByRole('button', { name: 'Stornierung erteilen' }),
+    )
+    await screen.findByText('Stornierung gebucht.')
+    await user.click(screen.getByRole('status'))
+
+    // Zurück auf Kassieren: p1 ist auf die neue Obergrenze (1) gedeckelt statt
+    // der kaputten Über-Deckelung „2 von 1", p2 ist ganz verschwunden.
+    await user.click(screen.getByRole('tab', { name: 'Kassieren' }))
+    expect(await screen.findByText(/1 von 1 ausgewählt/)).toBeInTheDocument()
+    expect(screen.queryByText(/2 von 1 ausgewählt/)).not.toBeInTheDocument()
+    expect(
+      screen.getAllByRole('button', { name: 'Produkt hinzufügen' }),
+    ).toHaveLength(1)
+    expect(screen.getByRole('button', { name: /Kassieren/ })).toHaveTextContent(
+      '3,50',
+    )
+  })
+
   it('startet die Auswahl bei einem Tischwechsel leer', async () => {
     testState.produkte = [testProdukt]
     getTischState.mockResolvedValue(stammtisch)

--- a/frontend/src/service/TablePage.test.tsx
+++ b/frontend/src/service/TablePage.test.tsx
@@ -68,24 +68,29 @@ vi.mock('@/lib/Backend', () => ({
   BackendSingleton: {},
 }))
 
-// Die eigene Servicekraft (für die „Meine Positionen"-Filterung in Zahlung).
+// Die eigene Servicekraft (für die „Meine Positionen"-Filterung in Zahlung);
+// canCancel/canRebook, damit der Storno-/Umbuchen-Pfad der Historie greift.
 vi.mock('@/lib/Auth', () => ({
-  AuthSingleton: { userId: 1 },
+  AuthSingleton: { userId: 1, canCancel: true, canRebook: true },
 }))
 
 vi.mock('./product/hooks', () => ({
   useAktiveProdukte: () => ({ produkte: testState.produkte, isPending: false }),
 }))
 
-const { getTischState, getTischHistorie } = vi.hoisted(() => ({
-  getTischState: vi.fn<() => Promise<TischSession>>(),
-  getTischHistorie: vi.fn<() => Promise<unknown[]>>(),
-}))
+const { getTischState, getTischHistorie, stornierungErteilen } = vi.hoisted(
+  () => ({
+    getTischState: vi.fn<() => Promise<TischSession>>(),
+    getTischHistorie: vi.fn<() => Promise<unknown[]>>(),
+    stornierungErteilen: vi.fn<() => Promise<void>>(),
+  }),
+)
 
 vi.mock('./table/TischBackend', () => ({
   TischBackend: class {
     getTischState = getTischState
     getTischHistorie = getTischHistorie
+    stornierungErteilen = stornierungErteilen
   },
 }))
 
@@ -268,6 +273,55 @@ describe('TablePage', () => {
       expect(
         screen.getByRole('button', { name: /Bestellung überprüfen/ }),
       ).toBeDisabled()
+    })
+  })
+
+  // A2: Eine Stornierung bestätigt über den Erfolgs-Pop; der Refetch des
+  // Tisch-States läuft erst beim Schließen des Pops, nicht schon beim Erfolg.
+  it('zeigt nach der Stornierung den Erfolgs-Pop und lädt erst beim Schließen neu', async () => {
+    getTischState.mockResolvedValue(stammtisch)
+    getTischHistorie.mockResolvedValue([
+      {
+        art: 'bestellung',
+        id: '00000000-0000-0000-0000-000000000001',
+        userId: 1,
+        userName: 'Tester',
+        tischId: 1,
+        positionen: [position('p1')],
+        gesamtPreisCents: 350,
+        kommentar: '',
+        aufgenommenAm: '2026-06-18T12:00:00Z',
+        stornierbarePositionen: [position('p1')],
+        umbuchbarePositionen: [],
+      },
+    ])
+    stornierungErteilen.mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Stammtisch')
+    const ladeCalls = getTischState.mock.calls.length
+
+    await user.click(screen.getByRole('tab', { name: 'Historie' }))
+    await user.click(screen.getByRole('button', { name: /Bestellung/ }))
+    await user.click(screen.getByRole('button', { name: /Stornieren…/ }))
+    await user.click(screen.getByRole('button', { name: /hinzufügen/ }))
+    await user.type(
+      screen.getByPlaceholderText('Kommentar (erforderlich)'),
+      'Falsch gebucht',
+    )
+    await user.click(
+      screen.getByRole('button', { name: 'Stornierung erteilen' }),
+    )
+
+    // Der Pop erscheint; bis zum Schließen läuft kein Refetch des Tisch-States.
+    await screen.findByText('Stornierung gebucht.')
+    expect(getTischState.mock.calls.length).toBe(ladeCalls)
+
+    // Pop schließen (Tap auf das Overlay) → jetzt lädt der Tisch-State neu.
+    await user.click(screen.getByRole('status'))
+    await waitFor(() => {
+      expect(getTischState.mock.calls.length).toBeGreaterThan(ladeCalls)
     })
   })
 })

--- a/frontend/src/service/TablePage.test.tsx
+++ b/frontend/src/service/TablePage.test.tsx
@@ -1,8 +1,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { Produkt } from './product/Produkt'
 import type { Position } from './table/Bestellung'
 import type { TischSession } from './table/Tisch'
 import { TablePage } from './TablePage'
@@ -22,8 +23,34 @@ function position(positionId: string): Position {
   }
 }
 
+const testProdukt: Produkt = {
+  id: 1,
+  name: 'Bratwurst',
+  kategorie: 'essen',
+  status: 'active',
+  varianten: [
+    {
+      id: 1,
+      name: 'Normal',
+      preisCents: 350,
+      status: 'active',
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    },
+  ],
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+}
+
+// Steuerbarer Testzustand: `tischId` bildet den :tischId-Param nach (Tischwechsel
+// ohne Remount), `produkte` speist die Bestell-Tab-Auswahl.
+const testState = vi.hoisted(() => ({
+  tischId: '1',
+  produkte: [] as Produkt[],
+}))
+
 vi.mock('react-router', () => ({
-  useParams: () => ({ tischId: '1' }),
+  useParams: () => ({ tischId: testState.tischId }),
 }))
 
 vi.mock('sonner', () => ({
@@ -41,8 +68,13 @@ vi.mock('@/lib/Backend', () => ({
   BackendSingleton: {},
 }))
 
+// Die eigene Servicekraft (für die „Meine Positionen"-Filterung in Zahlung).
+vi.mock('@/lib/Auth', () => ({
+  AuthSingleton: { userId: 1 },
+}))
+
 vi.mock('./product/hooks', () => ({
-  useAktiveProdukte: () => ({ produkte: [], isPending: false }),
+  useAktiveProdukte: () => ({ produkte: testState.produkte, isPending: false }),
 }))
 
 const { getTischState, getTischHistorie } = vi.hoisted(() => ({
@@ -70,6 +102,8 @@ const stammtisch: TischSession = {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  testState.tischId = '1'
+  testState.produkte = []
 })
 
 function renderPage() {
@@ -144,5 +178,96 @@ describe('TablePage', () => {
 
     expect(await screen.findByText('2 unbezahlt')).toBeInTheDocument()
     expect(screen.queryByText('Alles bezahlt')).not.toBeInTheDocument()
+  })
+
+  // A1: Der gehobene Auswahl-State überlebt das Aus- und Wiedereinhängen der
+  // Radix-Tab-Inhalte (inaktive Tabs werden ausgehängt). Ohne das Heben nach
+  // TablePage ginge die Auswahl beim Tab-Wechsel verloren.
+  it('behält den Bestell-Korb über einen Tab-Wechsel hinweg', async () => {
+    testState.produkte = [testProdukt]
+    getTischState.mockResolvedValue(stammtisch)
+    getTischHistorie.mockResolvedValue([])
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Stammtisch')
+    // Bestellen ist der Default-Tab: eine Variante in den Korb legen.
+    await user.click(
+      screen.getByRole('button', { name: 'Variante hinzufügen' }),
+    )
+    expect(
+      screen.getByRole('button', { name: /Bestellung überprüfen/ }),
+    ).toHaveTextContent('3,50')
+
+    // Zur Historie und zurück — der Bestellen-Tab wird zwischenzeitlich ausgehängt.
+    await user.click(screen.getByRole('tab', { name: 'Historie' }))
+    await user.click(screen.getByRole('tab', { name: 'Bestellen' }))
+
+    expect(
+      screen.getByRole('button', { name: /Bestellung überprüfen/ }),
+    ).toHaveTextContent('3,50')
+  })
+
+  it('behält die Kassieren-Auswahl über einen Tab-Wechsel hinweg', async () => {
+    getTischState.mockResolvedValue({
+      ...stammtisch,
+      unbezahltePositionen: [position('p1')],
+    })
+    getTischHistorie.mockResolvedValue([])
+    const user = userEvent.setup()
+    renderPage()
+
+    await screen.findByText('Stammtisch')
+    await user.click(screen.getByRole('tab', { name: 'Kassieren' }))
+    // Die eigene Position auswählen (Auth-userId 1).
+    await user.click(screen.getByRole('button', { name: 'Produkt hinzufügen' }))
+    expect(screen.getByRole('button', { name: /Kassieren/ })).toHaveTextContent(
+      '3,50',
+    )
+
+    await user.click(screen.getByRole('tab', { name: 'Historie' }))
+    await user.click(screen.getByRole('tab', { name: 'Kassieren' }))
+
+    expect(screen.getByRole('button', { name: /Kassieren/ })).toHaveTextContent(
+      '3,50',
+    )
+  })
+
+  it('startet die Auswahl bei einem Tischwechsel leer', async () => {
+    testState.produkte = [testProdukt]
+    getTischState.mockResolvedValue(stammtisch)
+    getTischHistorie.mockResolvedValue([])
+    const user = userEvent.setup()
+    // Eigener QueryClient, damit Re-Renders die Provider-Instanz teilen; jeder
+    // Aufruf liefert ein frisches Element, sonst überspringt React das
+    // Neurendern (referenzgleiche Props).
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const renderUi = () => (
+      <QueryClientProvider client={queryClient}>
+        <TablePage />
+      </QueryClientProvider>
+    )
+    const { rerender } = render(renderUi())
+
+    await screen.findByText('Stammtisch')
+    await user.click(
+      screen.getByRole('button', { name: 'Variante hinzufügen' }),
+    )
+    expect(
+      screen.getByRole('button', { name: /Bestellung überprüfen/ }),
+    ).toHaveTextContent('3,50')
+
+    // Anderer Tisch: nur der :tischId-Param wechselt, TablePage bleibt gemountet.
+    testState.tischId = '2'
+    rerender(renderUi())
+
+    // Nach dem Laden des neuen Tisches ist der Korb leer (Aktionsbutton deaktiviert).
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /Bestellung überprüfen/ }),
+      ).toBeDisabled()
+    })
   })
 })

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -23,6 +23,33 @@ import { TischBackend } from './table/TischBackend'
 
 const tischBackend = new TischBackend(BackendSingleton)
 
+// Deckelt die gehobene Kassieren-Auswahl auf die noch unbezahlte Menge je
+// Position: Einträge über ihrer Obergrenze sinken auf die Obergrenze, Einträge
+// für verschwundene Positionen (Obergrenze 0) fallen heraus. Gibt `null`
+// zurück, wenn nichts zu deckeln ist — damit der State-Abgleich im Render nur
+// bei echter Änderung ein setAll auslöst und keine Render-Schleife dreht.
+function deckeleAuswahl(
+  auswahl: Record<string, number>,
+  obergrenzen: Record<string, number>,
+): Record<string, number> | null {
+  let geaendert = false
+  const gedeckelt: Record<string, number> = {}
+  for (const [positionId, menge] of Object.entries(auswahl)) {
+    const obergrenze = obergrenzen[positionId] || 0
+    if (obergrenze <= 0) {
+      geaendert = true
+      continue
+    }
+    if (menge > obergrenze) {
+      gedeckelt[positionId] = obergrenze
+      geaendert = true
+    } else {
+      gedeckelt[positionId] = menge
+    }
+  }
+  return geaendert ? gedeckelt : null
+}
+
 // Das Status-Badge poppt bei jedem Wertwechsel (Motion-Inventar „Statuswechsel",
 // 350 ms), aber nicht beim ersten Aufbau. Der key-Wechsel auf den Zählwert
 // remountet StatusBadgeInhalt, das seine Pop-Entscheidung beim Mount erfasst:
@@ -118,6 +145,20 @@ export function TablePage() {
     setAktiverTisch(tischId)
     bestellKorb.reset()
     kassierenAuswahl.reset()
+  }
+
+  // Der useMengen-`max` deckelt nur beim `add`, nicht die schon gespeicherte
+  // Auswahl. Schrumpft die unbezahlte Menge einer bereits ausgewählten Position,
+  // während die Auswahl bestehen bleibt (z. B. eine Stornierung auf der
+  // Historie, deren Refetch erst beim Schließen des Erfolgs-Pops eintrifft),
+  // wird die gespeicherte Auswahl beim Eintreffen der kleineren Obergrenzen im
+  // Render abgeglichen — React-idiomatischer State-Sync wie beim Tischwechsel.
+  const gedeckelteAuswahl = deckeleAuswahl(
+    kassierenAuswahl.mengen,
+    unbezahlteMengen,
+  )
+  if (gedeckelteAuswahl) {
+    kassierenAuswahl.setAll(gedeckelteAuswahl)
   }
 
   // Expliziter Fehlerzustand statt der Leer-Defaults (Saldo 0,00 €) — sonst

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useCountUp } from '@/hooks/use-count-up'
 import { useErstAufbau } from '@/hooks/use-erst-aufbau'
+import { useMengen } from '@/hooks/use-mengen'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { BackendSingleton } from '@/lib/Backend'
 import { formatEuro } from '@/lib/utils'
@@ -95,6 +96,29 @@ export function TablePage() {
     reload()
   }, [reload])
 
+  // Bestell-Korb (Variante-ID → Menge) und Kassieren-Auswahl (Position-ID →
+  // Menge) liegen hier, damit sie das Aus- und Wiedereinhängen der Radix-Tab-
+  // Inhalte überstehen; ein Tab-Wechsel würde die Auswahl sonst verlieren. Die
+  // Kassieren-Auswahl ist auf die noch unbezahlte Menge je Position gedeckelt.
+  const bestellKorb = useMengen<number>()
+  const unbezahlteMengen: Record<string, number> = {}
+  state.unbezahltePositionen.forEach((position) => {
+    unbezahlteMengen[position.positionId] = position.menge
+  })
+  const kassierenAuswahl = useMengen<string>(
+    (positionId) => unbezahlteMengen[positionId] || 0,
+  )
+
+  // Beim Tischwechsel bleibt TablePage gemountet (nur der :tischId-Param
+  // ändert sich), daher wird die gehobene Auswahl pro Tisch zurückgesetzt.
+  // React-idiomatisches Zurücksetzen von State bei Prop-Wechsel im Render.
+  const [aktiverTisch, setAktiverTisch] = useState(tischId)
+  if (tischId !== aktiverTisch) {
+    setAktiverTisch(tischId)
+    bestellKorb.reset()
+    kassierenAuswahl.reset()
+  }
+
   // Expliziter Fehlerzustand statt der Leer-Defaults (Saldo 0,00 €) — sonst
   // wirkt der Tisch bei Netzabbruch abgerechnet.
   if (stateError || historieError) {
@@ -169,6 +193,7 @@ export function TablePage() {
       tisch={tisch}
       products={produkte}
       productsLoading={isPending}
+      mengenSteuerung={bestellKorb}
       onErfolg={zeigeErfolg}
     />
   )
@@ -177,6 +202,7 @@ export function TablePage() {
       backend={tischBackend}
       tisch={tisch}
       positionen={state.unbezahltePositionen}
+      mengenSteuerung={kassierenAuswahl}
       onErfolg={zeigeErfolg}
     />
   )

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -83,10 +83,10 @@ export function TablePage() {
     void reloadHistorie()
   }, [reloadState, reloadHistorie])
 
-  // Erfolgs-Pop: Bestellen und Kassieren öffnen ihn mit ihrer Meldung (statt
-  // eines Erfolgs-Toasts). Der nachgelagerte Refetch (reload) läuft erst beim
-  // Schließen, damit sichtbare Statuswechsel (Saldo, Badge, Listen) dem Pop
-  // folgen. Der Stornierungs-/Umbuchungspfad der Historie lädt weiterhin sofort.
+  // Erfolgs-Pop: Bestellen, Kassieren, Stornieren und Umbuchen öffnen ihn mit
+  // ihrer Meldung (statt eines Erfolgs-Toasts). Der nachgelagerte Refetch
+  // (reload) läuft erst beim Schließen, damit sichtbare Statuswechsel (Saldo,
+  // Badge, Listen) dem Pop folgen.
   const [erfolg, setErfolg] = useState({ open: false, text: '' })
   const zeigeErfolg = useCallback((nachricht: string) => {
     setErfolg({ open: true, text: nachricht })
@@ -212,8 +212,7 @@ export function TablePage() {
       historieLoading={historieLoading}
       tisch={tisch}
       backend={tischBackend}
-      onStornierungErteilt={reload}
-      onBestellungUmgebucht={reload}
+      onErfolg={zeigeErfolg}
     />
   )
 

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -50,7 +50,7 @@ function StatusBadgeInhalt({
   const popKlasse = poppen ? 'animate-pop' : undefined
 
   return anzahlUnbezahlt > 0 ? (
-    <Badge variant="destructive" className={popKlasse}>
+    <Badge variant="warn" className={popKlasse}>
       {anzahlUnbezahlt} unbezahlt
     </Badge>
   ) : (

--- a/frontend/src/service/TablePage.tsx
+++ b/frontend/src/service/TablePage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router'
 
 import { LadefehlerAlert } from '@/components/common/LadefehlerAlert'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useCountUp } from '@/hooks/use-count-up'
 import { useErstAufbau } from '@/hooks/use-erst-aufbau'
@@ -142,9 +143,13 @@ export function TablePage() {
   const kopf = (
     <div className="flex items-start justify-between gap-4">
       <div>
-        <h1 className="font-heading text-[22px] font-semibold leading-tight">
-          {stateLoading ? 'Tisch ??' : tisch.name}
-        </h1>
+        {stateLoading ? (
+          <Skeleton className="h-7 w-40" />
+        ) : (
+          <h1 className="font-heading text-[22px] font-semibold leading-tight">
+            {tisch.name}
+          </h1>
+        )}
         {!stateLoading && (
           <div className="mt-1.5 flex flex-wrap items-center gap-2">
             <TischStatusBadge anzahlUnbezahlt={anzahlUnbezahlt} />
@@ -160,9 +165,16 @@ export function TablePage() {
         <div className="text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground">
           Offen
         </div>
-        <div data-slot="tisch-saldo" className="text-xl font-bold tabular-nums">
-          {stateLoading ? '?' : formatEuro(animierterSaldo)}
-        </div>
+        {stateLoading ? (
+          <Skeleton className="ml-auto h-7 w-20" />
+        ) : (
+          <div
+            data-slot="tisch-saldo"
+            className="text-xl font-bold tabular-nums"
+          >
+            {formatEuro(animierterSaldo)}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/service/TableSelectionPage.tsx
+++ b/frontend/src/service/TableSelectionPage.tsx
@@ -93,7 +93,7 @@ export function TableSelectionPage() {
         <EmptyState
           icon={Lamp}
           title="Keine Tische markiert"
-          description="Du hast noch keine Tische markiert. Wähle Tische aus, um sie hier zu sehen. Für den Direktverkauf an der Theke wechselst du den Arbeitsmodus im Benutzermenü oben rechts."
+          description="Du hast noch keine Tische markiert. Wähle Tische aus, um sie hier zu sehen."
           action={
             <Button
               variant="outline"

--- a/frontend/src/service/components/MeinTischCard.test.tsx
+++ b/frontend/src/service/components/MeinTischCard.test.tsx
@@ -43,6 +43,15 @@ function tischSession(overrides: Partial<TischSession>): TischSession {
   }
 }
 
+// Der Status-Punkt ist das einzige aria-hidden `rounded-full`-Element der Karte.
+function statusPunkt(container: HTMLElement): HTMLElement {
+  const punkt = container.querySelector('span.rounded-full')
+  if (!(punkt instanceof HTMLElement)) {
+    throw new Error('Status-Punkt nicht gefunden')
+  }
+  return punkt
+}
+
 describe('MeinTischCard', () => {
   it('zählt offene (unbezahlte) Positionen und hebt die eigenen hervor', () => {
     const state = tischSession({
@@ -73,5 +82,35 @@ describe('MeinTischCard', () => {
 
     expect(screen.getByText('Alles bezahlt')).toBeInTheDocument()
     expect(screen.queryByText(/offen/)).not.toBeInTheDocument()
+  })
+
+  it('färbt den Status-Punkt amber bei eigenen offenen Positionen', () => {
+    const state = tischSession({
+      unbezahltePositionen: [position('p1', 1)],
+      fuerMichErledigt: false,
+    })
+
+    const { container } = render(<MeinTischCard state={state} />)
+
+    expect(statusPunkt(container)).toHaveClass('bg-amber-500')
+  })
+
+  it('färbt den Status-Punkt neutral bei nur fremden offenen Positionen', () => {
+    const state = tischSession({
+      unbezahltePositionen: [position('p1', 2)],
+      fuerMichErledigt: true,
+    })
+
+    const { container } = render(<MeinTischCard state={state} />)
+
+    expect(statusPunkt(container)).toHaveClass('bg-muted-foreground')
+  })
+
+  it('färbt den Status-Punkt grün, wenn alles erledigt ist', () => {
+    const state = tischSession({ unbezahltePositionen: [] })
+
+    const { container } = render(<MeinTischCard state={state} />)
+
+    expect(statusPunkt(container)).toHaveClass('bg-green-600')
   })
 })

--- a/frontend/src/service/components/MeinTischCard.tsx
+++ b/frontend/src/service/components/MeinTischCard.tsx
@@ -27,11 +27,14 @@ export function MeinTischCard({ state, eintrittIndex }: MeinTischCardProps) {
   const { anzahlOffen, anzahlEigeneOffen } = countOffenePositionen(state)
   const alleErledigt = anzahlOffen === 0
 
+  // Farbsemantik: eigene offene Positionen fordern zur Aktion auf (amber), nur
+  // fremde offene sind neutral wartend (muted), alles erledigt ist grün. Rot
+  // bleibt Storno-/Fehlerzuständen vorbehalten (docs/adrs/04_warn-bestaetigung.md).
   const statusFarbe = alleErledigt
     ? 'bg-green-600'
     : anzahlEigeneOffen > 0
-      ? 'bg-destructive'
-      : 'bg-amber-500'
+      ? 'bg-amber-500'
+      : 'bg-muted-foreground'
 
   return (
     <button

--- a/frontend/src/service/components/TischAuswahlDrawer.test.tsx
+++ b/frontend/src/service/components/TischAuswahlDrawer.test.tsx
@@ -92,17 +92,38 @@ describe('TischAuswahlDrawer', () => {
     })
   })
 
-  it('sortiert Favoriten zuerst, dann Saldo absteigend, dann Name', () => {
+  it('sortiert durchgehend nach Tischname mit numerischem Vergleich, Favoriten nicht vorgezogen', () => {
     mockTische = [
-      { id: 1, name: 'Bar', istFavorit: false, saldoCents: 500 },
-      { id: 2, name: 'Zelt', istFavorit: true, saldoCents: 100 },
-      { id: 3, name: 'Ausschank', istFavorit: false, saldoCents: 500 },
+      { id: 1, name: 'Tisch 10', istFavorit: false, saldoCents: 500 },
+      { id: 2, name: 'Tisch 2', istFavorit: true, saldoCents: 100 },
+      { id: 3, name: 'Tisch 1', istFavorit: false, saldoCents: 0 },
     ]
     renderDrawer()
 
-    const namen = screen
-      .getAllByText(/^(Bar|Zelt|Ausschank)$/)
-      .map((el) => el.textContent)
-    expect(namen).toEqual(['Zelt', 'Ausschank', 'Bar'])
+    const namen = screen.getAllByText(/^Tisch \d+$/).map((el) => el.textContent)
+    // „Tisch 2" vor „Tisch 10" (numerischer Vergleich); der Favorit „Tisch 2"
+    // wird nicht mehr an den Anfang gezogen.
+    expect(namen).toEqual(['Tisch 1', 'Tisch 2', 'Tisch 10'])
+  })
+
+  it('zeigt Favoriten-Stern und Saldo pro Zeile weiterhin an', () => {
+    mockTische = [
+      { id: 1, name: 'Tisch 2', istFavorit: true, saldoCents: 100 },
+      { id: 2, name: 'Tisch 10', istFavorit: false, saldoCents: 500 },
+    ]
+    renderDrawer()
+
+    // Gefüllter Stern für den Favoriten, leerer für den Nicht-Favoriten.
+    expect(
+      screen.getByRole('button', { name: 'Tisch 2 aus Favoriten entfernen' }),
+    ).toHaveTextContent('★')
+    expect(
+      screen.getByRole('button', {
+        name: 'Tisch 10 zu Favoriten hinzufügen',
+      }),
+    ).toHaveTextContent('☆')
+    // Saldo pro Zeile bleibt sichtbar.
+    expect(screen.getByText(/1,00\s*€/)).toBeInTheDocument()
+    expect(screen.getByText(/5,00\s*€/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/service/components/TischAuswahlDrawer.tsx
+++ b/frontend/src/service/components/TischAuswahlDrawer.tsx
@@ -22,16 +22,16 @@ import { TischBackend } from '../table/TischBackend'
 
 const tischBackend = new TischBackend(BackendSingleton)
 
-// Reihenfolge im Alle-Tische-Drawer: Favoriten zuerst, dann nach offenem Saldo
-// (absteigend), zuletzt nach Name. Reine Darstellungssortierung bereits
-// vollständig geladener Daten.
+// Reihenfolge im Alle-Tische-Drawer: durchgehend nach Tischname mit
+// numerischem Vergleich („Tisch 2" vor „Tisch 10"). Favoriten und Saldo
+// werden pro Zeile weiter angezeigt, aber nicht mehr zur Sortierung genutzt —
+// so bleibt die Reihenfolge stabil und vorhersehbar. Reine Darstellungs-
+// sortierung bereits vollständig geladener Daten.
 function sortiereTische(
   a: AktiverTischMitFavorit,
   b: AktiverTischMitFavorit,
 ): number {
-  if (a.istFavorit !== b.istFavorit) return a.istFavorit ? -1 : 1
-  if (a.saldoCents !== b.saldoCents) return b.saldoCents - a.saldoCents
-  return a.name.localeCompare(b.name, 'de')
+  return a.name.localeCompare(b.name, 'de', { numeric: true })
 }
 
 interface TischAuswahlDrawerProps {

--- a/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.test.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.test.tsx
@@ -73,6 +73,22 @@ describe('DirektverkaufAbschluss (Spalte)', () => {
     expect(rueckgeld).toHaveTextContent('3,00')
   })
 
+  it('zeigt Trinkgeld und Rückgeld, wenn ein Aufrunden-Chip gewählt ist', async () => {
+    const user = userEvent.setup()
+    renderSpalte()
+
+    // Gesamt 7,00 €: Chip auf 8,00 € rundet auf, Erhalten 10,00 €.
+    await user.click(screen.getByRole('button', { name: /8,00/ }))
+    await user.type(screen.getByLabelText('Erhalten'), '10,00')
+
+    expect(screen.getByText('Trinkgeld').nextElementSibling).toHaveTextContent(
+      '1,00',
+    )
+    expect(screen.getByText('Rückgeld').nextElementSibling).toHaveTextContent(
+      '2,00',
+    )
+  })
+
   it('schließt den Verkauf mit genau einem Backend-Call und erwarteter Nutzlast ab', async () => {
     const user = userEvent.setup()
     const { direktverkaufTaetigen, verkaufAbgeschlossen } = renderSpalte()

--- a/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufAbschluss.tsx
@@ -17,6 +17,7 @@ import type { VerkaufPositionInput } from '../../direktverkauf/Direktverkauf'
 import type { DirektverkaufBackend } from '../../direktverkauf/DirektverkaufBackend'
 import { AbschlussHeader } from '../table/AbschlussHeader'
 import { AbschlussLeer } from '../table/AbschlussLeer'
+import { AufrundenChips } from '../table/AufrundenChips'
 import { KommentarField } from '../table/CommentField'
 import { calculateZahlungsbetraege } from '../table/drawerUtils'
 import type { ReceiptPosition } from '../table/Receipt'
@@ -42,6 +43,8 @@ interface DirektverkaufAbschlussProps {
 // wird sowohl im Handy-Drawer als auch in der festen Spalte gerendert.
 export function DirektverkaufAbschluss(props: DirektverkaufAbschlussProps) {
   const [erhaltenEuro, setErhaltenEuro] = useState('')
+  const [zielbetragEuro, setZielbetragEuro] = useState('')
+  const [andererAktiv, setAndererAktiv] = useState(false)
   const [kommentar, setKommentar] = useState('')
 
   const noPositionenSelected = props.positionen.length === 0
@@ -60,15 +63,17 @@ export function DirektverkaufAbschluss(props: DirektverkaufAbschlussProps) {
     if (warLeerRef.current && !noPositionenSelected) {
       setVerkaufId(crypto.randomUUID())
       setErhaltenEuro('')
+      setZielbetragEuro('')
+      setAndererAktiv(false)
       setKommentar('')
     }
     warLeerRef.current = noPositionenSelected
   }, [noPositionenSelected])
 
-  const { rueckgeldCents } = calculateZahlungsbetraege(
+  const { rueckgeldCents, trinkgeldCents } = calculateZahlungsbetraege(
     props.totalCents,
     parseCents(erhaltenEuro),
-    0,
+    parseCents(zielbetragEuro),
   )
 
   const { loading, run } = useActionSubmit({
@@ -81,6 +86,8 @@ export function DirektverkaufAbschluss(props: DirektverkaufAbschlussProps) {
     },
     onSuccess: () => {
       setErhaltenEuro('')
+      setZielbetragEuro('')
+      setAndererAktiv(false)
       setKommentar('')
       props.verkaufAbgeschlossen()
     },
@@ -123,6 +130,13 @@ export function DirektverkaufAbschluss(props: DirektverkaufAbschlussProps) {
                   className="w-28"
                 />
               </div>
+              <AufrundenChips
+                gesamtCents={props.totalCents}
+                zielbetragEuro={zielbetragEuro}
+                onZielbetragEuroChange={setZielbetragEuro}
+                andererAktiv={andererAktiv}
+                onAndererAktivChange={setAndererAktiv}
+              />
               {rueckgeldCents !== null && (
                 <div className="flex items-baseline justify-between pt-1">
                   <div className="text-[15px] font-semibold">Rückgeld</div>
@@ -130,6 +144,20 @@ export function DirektverkaufAbschluss(props: DirektverkaufAbschlussProps) {
                     {formatEuro(rueckgeldCents)}
                   </div>
                 </div>
+              )}
+              {trinkgeldCents !== null && (
+                <>
+                  <div className="flex justify-between font-medium">
+                    <div>Trinkgeld</div>
+                    <div className="tabular-nums">
+                      {formatEuro(trinkgeldCents)}
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Trinkgeld wird nicht als Kasseneinnahme gebucht und gehört
+                    nicht in die Kassenlade.
+                  </p>
+                </>
               )}
             </div>
             <div className="px-4 pt-3">

--- a/frontend/src/service/components/direktverkauf/DirektverkaufHistorie.test.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufHistorie.test.tsx
@@ -88,7 +88,7 @@ describe('DirektverkaufHistorie', () => {
           direktverkaufStornieren: vi.fn().mockResolvedValue(undefined),
           kassenbelegDrucken: vi.fn().mockResolvedValue('eingereiht'),
         }}
-        onStorniert={vi.fn()}
+        onErfolg={vi.fn()}
       />,
     )
 
@@ -99,13 +99,13 @@ describe('DirektverkaufHistorie', () => {
     const user = userEvent.setup()
     const direktverkaufStornieren = vi.fn().mockResolvedValue(undefined)
     const kassenbelegDrucken = vi.fn().mockResolvedValue('eingereiht')
-    const onStorniert = vi.fn()
+    const onErfolg = vi.fn()
     render(
       <DirektverkaufHistorie
         historie={[verkauf]}
         historieLoading={false}
         backend={{ direktverkaufStornieren, kassenbelegDrucken }}
-        onStorniert={onStorniert}
+        onErfolg={onErfolg}
       />,
     )
 
@@ -131,7 +131,9 @@ describe('DirektverkaufHistorie', () => {
       positionen: [{ positionId, menge: 1 }],
       kommentar: 'Rückgabe',
     })
-    expect(onStorniert).toHaveBeenCalled()
+    // Statt sofortigem Refetch meldet der Storno den Erfolg über den Pop-Text;
+    // der Refetch folgt beim Schließen des Pops (DirektverkaufPage).
+    expect(onErfolg).toHaveBeenCalledWith('Stornierung gebucht.')
   })
 
   it('triggers kassenbeleg print for a sale with exactly one backend call', async () => {
@@ -145,7 +147,7 @@ describe('DirektverkaufHistorie', () => {
           direktverkaufStornieren: vi.fn().mockResolvedValue(undefined),
           kassenbelegDrucken,
         }}
-        onStorniert={vi.fn()}
+        onErfolg={vi.fn()}
       />,
     )
 
@@ -185,7 +187,7 @@ describe('DirektverkaufHistorie', () => {
           direktverkaufStornieren: vi.fn().mockResolvedValue(undefined),
           kassenbelegDrucken,
         }}
-        onStorniert={vi.fn()}
+        onErfolg={vi.fn()}
       />,
     )
 

--- a/frontend/src/service/components/direktverkauf/DirektverkaufHistorie.tsx
+++ b/frontend/src/service/components/direktverkauf/DirektverkaufHistorie.tsx
@@ -47,14 +47,16 @@ interface DirektverkaufHistorieProps {
     DirektverkaufBackend,
     'direktverkaufStornieren' | 'kassenbelegDrucken'
   >
-  onStorniert: () => void
+  // Storno-Erfolg meldet der Aufrufer über den Erfolgs-Pop; der nachgelagerte
+  // Refetch läuft dort beim Schließen.
+  onErfolg: (nachricht: string) => void
 }
 
 export function DirektverkaufHistorie({
   historie,
   historieLoading,
   backend,
-  onStorniert,
+  onErfolg,
 }: DirektverkaufHistorieProps) {
   const [detail, setDetail] = useState<DirektverkaufHistorieEintrag | null>(
     null,
@@ -178,7 +180,7 @@ export function DirektverkaufHistorie({
           }}
           onStorniert={() => {
             setStornoVerkauf(null)
-            onStorniert()
+            onErfolg('Stornierung gebucht.')
           }}
         />
       )}

--- a/frontend/src/service/components/table/AufrundenChips.test.tsx
+++ b/frontend/src/service/components/table/AufrundenChips.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { AufrundenChips } from './AufrundenChips'
+
+afterEach(() => {
+  cleanup()
+})
+
+// Kontrollierter Harness: die Chips halten ihren Zielbetrag-/Anderer-State beim
+// Aufrufer, deshalb spiegelt der Test genau dieses Zusammenspiel.
+function Harness({ gesamtCents = 1230 }: { gesamtCents?: number }) {
+  const [zielbetragEuro, setZielbetragEuro] = useState('')
+  const [andererAktiv, setAndererAktiv] = useState(false)
+  return (
+    <>
+      <output data-testid="ziel">{zielbetragEuro}</output>
+      <AufrundenChips
+        gesamtCents={gesamtCents}
+        zielbetragEuro={zielbetragEuro}
+        onZielbetragEuroChange={setZielbetragEuro}
+        andererAktiv={andererAktiv}
+        onAndererAktivChange={setAndererAktiv}
+      />
+    </>
+  )
+}
+
+describe('AufrundenChips', () => {
+  it('zeigt „genau", zwei Vorschläge und „Anderer …"; „genau" ist anfangs aktiv', () => {
+    render(<Harness />)
+
+    const genau = screen.getByRole('button', { name: /genau/ })
+    expect(genau).toHaveTextContent('12,30 € genau')
+    expect(genau).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /13,00/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /15,00/ })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Anderer …' }),
+    ).toBeInTheDocument()
+  })
+
+  it('setzt den Zielbetrag bei Chip-Tap und wählt bei erneutem Tap ab', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const vorschlag = screen.getByRole('button', { name: /13,00/ })
+    await user.click(vorschlag)
+    expect(screen.getByTestId('ziel')).toHaveTextContent('13,00')
+    expect(vorschlag).toHaveAttribute('aria-pressed', 'true')
+
+    // Erneuter Tap auf den aktiven Chip: zurück zu „genau".
+    await user.click(vorschlag)
+    expect(screen.getByTestId('ziel')).toHaveTextContent('')
+    expect(screen.getByRole('button', { name: /genau/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+  })
+
+  it('blendet über „Anderer …" das freie Euro-Feld ein', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    expect(
+      screen.queryByLabelText('Zahlbetrag inkl. Trinkgeld'),
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Anderer …' }))
+
+    const feld = screen.getByLabelText('Zahlbetrag inkl. Trinkgeld')
+    expect(feld).toBeInTheDocument()
+    await user.type(feld, '14,50')
+    expect(screen.getByTestId('ziel')).toHaveTextContent('14,50')
+  })
+})

--- a/frontend/src/service/components/table/AufrundenChips.tsx
+++ b/frontend/src/service/components/table/AufrundenChips.tsx
@@ -1,0 +1,109 @@
+import { EuroInput } from '@/components/common/EuroInput'
+import { Label } from '@/components/ui/label'
+import { cn, formatCents, formatEuro, parseCents } from '@/lib/utils'
+
+import { aufrundenVorschlaege } from './drawerUtils'
+
+interface AufrundenChipsProps {
+  // Gesamtbetrag des Vorgangs; Basis für den „genau"-Chip und die Vorschläge.
+  gesamtCents: number
+  // Aktueller Zielbetrag als Euro-String ('' = kein Trinkgeld, „genau").
+  zielbetragEuro: string
+  onZielbetragEuroChange: (euro: string) => void
+  // Ob das freie Euro-Feld hinter „Anderer …" eingeblendet ist.
+  andererAktiv: boolean
+  onAndererAktivChange: (aktiv: boolean) => void
+}
+
+// chipKlassen liefert die Pill-Optik eines Chips (mindestens 44 px hoch,
+// tabular-nums für die Beträge); der aktive Chip trägt die Primärfläche.
+function chipKlassen(aktiv: boolean): string {
+  return cn(
+    'inline-flex min-h-11 items-center justify-center rounded-full border px-4 text-sm font-medium tabular-nums transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50',
+    aktiv
+      ? 'border-primary bg-primary text-primary-foreground'
+      : 'border-border bg-background text-foreground hover:bg-muted',
+  )
+}
+
+// Aufrunden-Chips fürs Trinkgeld: „{Betrag} € genau" für den exakten Betrag,
+// zwei glatte Aufrunden-Vorschläge und „Anderer …" für einen freien Zielbetrag.
+// Presentation-neutral und Variant-agnostisch (Sheet wie Spalte); der
+// Zielbetrag-State liegt beim Aufrufer, damit dessen warLeer-Reset ihn miträumt.
+export function AufrundenChips(props: AufrundenChipsProps) {
+  const zielCents = parseCents(props.zielbetragEuro)
+  const [ersterVorschlag, zweiterVorschlag] = aufrundenVorschlaege(
+    props.gesamtCents,
+  )
+
+  const genauAktiv = !props.andererAktiv && zielCents === 0
+
+  const waehleGenau = () => {
+    props.onAndererAktivChange(false)
+    props.onZielbetragEuroChange('')
+  }
+
+  const waehleVorschlag = (cents: number) => {
+    props.onAndererAktivChange(false)
+    // Erneuter Tap auf den aktiven Vorschlag wählt ab, zurück zu „genau".
+    if (!props.andererAktiv && zielCents === cents) {
+      props.onZielbetragEuroChange('')
+    } else {
+      props.onZielbetragEuroChange(formatCents(cents))
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div role="group" aria-label="Aufrunden fürs Trinkgeld">
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            aria-pressed={genauAktiv}
+            className={chipKlassen(genauAktiv)}
+            onClick={waehleGenau}
+          >
+            {formatEuro(props.gesamtCents)} genau
+          </button>
+          {[ersterVorschlag, zweiterVorschlag].map((cents) => {
+            const aktiv = !props.andererAktiv && zielCents === cents
+            return (
+              <button
+                key={cents}
+                type="button"
+                aria-pressed={aktiv}
+                className={chipKlassen(aktiv)}
+                onClick={() => {
+                  waehleVorschlag(cents)
+                }}
+              >
+                {formatEuro(cents)}
+              </button>
+            )
+          })}
+          <button
+            type="button"
+            aria-pressed={props.andererAktiv}
+            className={chipKlassen(props.andererAktiv)}
+            onClick={() => {
+              props.onAndererAktivChange(true)
+            }}
+          >
+            Anderer …
+          </button>
+        </div>
+      </div>
+      {props.andererAktiv && (
+        <div className="flex items-center justify-between gap-3">
+          <Label htmlFor="zielbetrag">Zahlbetrag inkl. Trinkgeld</Label>
+          <EuroInput
+            id="zielbetrag"
+            value={props.zielbetragEuro}
+            onValueChange={props.onZielbetragEuroChange}
+            className="w-28"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/service/components/table/Bestellung.test.tsx
+++ b/frontend/src/service/components/table/Bestellung.test.tsx
@@ -1,13 +1,24 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { useMengen } from '@/hooks/use-mengen'
 import { useIsMobile } from '@/hooks/use-mobile'
 
 import type { Produkt } from '../../product/Produkt'
 import type { Tisch } from '../../table/Tisch'
 import { ServiceDock } from '../ServiceDock'
 import { Bestellung } from './Bestellung'
+
+// Der Bestell-Korb liegt seit A1 in TablePage; für die isolierten Komponenten-
+// Tests stellt dieser Harness die gehobene Steuerung bereit.
+function BestellungHarness(
+  props: Omit<ComponentProps<typeof Bestellung>, 'mengenSteuerung'>,
+) {
+  const mengenSteuerung = useMengen<number>()
+  return <Bestellung {...props} mengenSteuerung={mengenSteuerung} />
+}
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -51,7 +62,7 @@ describe('Bestellung Aktionsleiste', () => {
     const user = userEvent.setup()
     render(
       <ServiceDock leiste={null}>
-        <Bestellung
+        <BestellungHarness
           backend={{
             bestellungAufnehmen: vi.fn().mockResolvedValue(undefined),
           }}
@@ -81,7 +92,7 @@ describe('Bestellung Aktionsleiste', () => {
     const user = userEvent.setup()
     // Kein ServiceDock: die feste Spalte trägt den Aktionsbutton selbst.
     render(
-      <Bestellung
+      <BestellungHarness
         backend={{ bestellungAufnehmen: vi.fn().mockResolvedValue(undefined) }}
         tisch={tisch}
         products={[testProdukt]}

--- a/frontend/src/service/components/table/Bestellung.tsx
+++ b/frontend/src/service/components/table/Bestellung.tsx
@@ -1,4 +1,4 @@
-import { useMengen } from '@/hooks/use-mengen'
+import type { MengenSteuerung } from '@/hooks/use-mengen'
 import { useIsMobile } from '@/hooks/use-mobile'
 
 import type { Produkt } from '../../product/Produkt'
@@ -15,6 +15,9 @@ interface BestellungProps {
   tisch: Tisch
   products: Produkt[]
   productsLoading: boolean
+  // Bestell-Korb (Variante-ID → Menge), von TablePage gehoben, damit die
+  // Auswahl das Aus- und Wiedereinhängen der Tab-Inhalte überlebt.
+  mengenSteuerung: MengenSteuerung<number>
   // Meldet die erfolgreiche Buchung samt Bestätigungstext an die Seite, die den
   // Erfolgs-Pop hostet (früher ein toast.success plus direkter Refetch).
   onErfolg: (nachricht: string) => void
@@ -25,10 +28,11 @@ export function Bestellung({
   tisch,
   products,
   productsLoading,
+  mengenSteuerung,
   onErfolg,
 }: BestellungProps) {
   const isMobile = useIsMobile()
-  const { mengen, add, remove, reset } = useMengen<number>()
+  const { mengen, add, remove, reset } = mengenSteuerung
 
   if (productsLoading) {
     return <ProductListSkeleton />

--- a/frontend/src/service/components/table/HistorieUmbuchungDrawer.test.tsx
+++ b/frontend/src/service/components/table/HistorieUmbuchungDrawer.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { toast } from 'sonner'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Bestellung, Position } from '../../table/Bestellung'
@@ -192,6 +193,35 @@ describe('HistorieUmbuchungDrawer', () => {
         benutzerKommentar: 'Gast gewechselt',
       }),
     )
+  })
+
+  // A2: Der Erfolg meldet den Namen des Ziel-Tischs für den Erfolgs-Pop; der
+  // frühere „Bestellung umgebucht."-Toast entfällt.
+  it('meldet den Ziel-Tischnamen an den Aufrufer und zeigt keinen Toast', async () => {
+    const user = userEvent.setup()
+    const onBestellungUmgebucht = vi.fn()
+    render(
+      <HistorieUmbuchungDrawer
+        backend={{ bestellungUmbuchen: vi.fn().mockResolvedValue(undefined) }}
+        tisch={tisch}
+        quelle={quelle}
+        onClose={vi.fn()}
+        onBestellungUmgebucht={onBestellungUmgebucht}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: /^1 Position auswählen/ }),
+    )
+    await user.selectOptions(screen.getByRole('combobox'), 'Nebentisch')
+    await user.click(
+      screen.getByRole('button', { name: 'Umbuchung ausführen' }),
+    )
+
+    await waitFor(() => {
+      expect(onBestellungUmgebucht).toHaveBeenCalledWith('Nebentisch')
+    })
+    expect(toast.success).not.toHaveBeenCalledWith('Bestellung umgebucht.')
   })
 
   it('beschriftet den Sammel-Button bei mehreren Positionen im Plural', () => {

--- a/frontend/src/service/components/table/HistorieUmbuchungDrawer.tsx
+++ b/frontend/src/service/components/table/HistorieUmbuchungDrawer.tsx
@@ -1,6 +1,5 @@
 import { CircleCheck } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -47,7 +46,8 @@ interface HistorieUmbuchungDrawerProps {
   // werden; beschriftet den Drawer.
   quelle: Bestellung | Umbuchung
   onClose: () => void
-  onBestellungUmgebucht: () => void
+  // Meldet den Erfolg mit dem Namen des Ziel-Tischs für den Erfolgs-Pop.
+  onBestellungUmgebucht: (zielName: string) => void
 }
 
 // Volle umbuchbare Menge je Position — Basis für den „Alle auswählen"-Button.
@@ -124,8 +124,9 @@ export function HistorieUmbuchungDrawer({
         'Mindestens eine Position ist nicht mehr umbuchbar. Bitte Auswahl aktualisieren.',
     },
     onSuccess: () => {
-      toast.success('Bestellung umgebucht.')
-      onBestellungUmgebucht()
+      const zielName =
+        zielTische.find((candidate) => candidate.id === zielTischId)?.name ?? ''
+      onBestellungUmgebucht(zielName)
     },
   })
 

--- a/frontend/src/service/components/table/TischHistorie.test.tsx
+++ b/frontend/src/service/components/table/TischHistorie.test.tsx
@@ -6,6 +6,8 @@ import {
   waitFor,
   within,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { toast } from 'sonner'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Bestellung } from '../../table/Bestellung'
@@ -127,6 +129,7 @@ function umbuchung(overrides: Partial<Umbuchung> = {}): Umbuchung {
 function renderHistorie(
   historie: HistorieEintrag[],
   backend: Partial<Parameters<typeof TischHistorie>[0]['backend']> = {},
+  onErfolg: (nachricht: string) => void = vi.fn(),
 ) {
   render(
     <TischHistorie
@@ -140,8 +143,7 @@ function renderHistorie(
         stornobelegDrucken: vi.fn().mockResolvedValue('eingereiht'),
         ...backend,
       }}
-      onStornierungErteilt={vi.fn()}
-      onBestellungUmgebucht={vi.fn()}
+      onErfolg={onErfolg}
     />,
   )
 }
@@ -387,6 +389,72 @@ describe('TischHistorie', () => {
     expect(
       within(dialog).getByRole('button', { name: /Stornieren…/ }),
     ).toBeInTheDocument()
+  })
+
+  // A2: Storno und Umbuchung bestätigen über den Erfolgs-Pop (Text an den
+  // Aufrufer), nicht mehr per Toast oder kommentarlosem Schließen. Der Drawer
+  // schließt beim Erfolg; der Refetch läuft beim Pop-Schließen (TablePage).
+  it('meldet den Storno-Erfolg über den Pop-Text und schließt den Drawer', async () => {
+    const user = userEvent.setup()
+    const onErfolg = vi.fn()
+    renderHistorie(
+      [
+        bestellung({
+          id: '00000000-0000-0000-0000-000000000001',
+          stornierbarePositionen: [position()],
+        }),
+      ],
+      {},
+      onErfolg,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Bestellung/ }))
+    await user.click(screen.getByRole('button', { name: /Stornieren…/ }))
+    await user.click(screen.getByRole('button', { name: /hinzufügen/ }))
+    await user.type(
+      screen.getByPlaceholderText('Kommentar (erforderlich)'),
+      'Falsch gebucht',
+    )
+    await user.click(
+      screen.getByRole('button', { name: 'Stornierung erteilen' }),
+    )
+
+    await waitFor(() => {
+      expect(onErfolg).toHaveBeenCalledWith('Stornierung gebucht.')
+    })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('meldet die Umbuchung mit dem Ziel-Tischnamen über den Pop-Text — ohne Toast', async () => {
+    const user = userEvent.setup()
+    const bestellungUmbuchen = vi.fn().mockResolvedValue(undefined)
+    const onErfolg = vi.fn()
+    renderHistorie(
+      [
+        bestellung({
+          id: '00000000-0000-0000-0000-000000000001',
+          umbuchbarePositionen: [position()],
+        }),
+      ],
+      { bestellungUmbuchen },
+      onErfolg,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Bestellung/ }))
+    await user.click(screen.getByRole('button', { name: /Umbuchen/ }))
+    await user.click(
+      screen.getByRole('button', { name: /Position(?:en)? auswählen/ }),
+    )
+    await user.selectOptions(screen.getByRole('combobox'), 'Nebentisch')
+    await user.click(
+      screen.getByRole('button', { name: 'Umbuchung ausführen' }),
+    )
+
+    await waitFor(() => {
+      expect(onErfolg).toHaveBeenCalledWith('Auf Nebentisch umgebucht.')
+    })
+    expect(toast.success).not.toHaveBeenCalledWith('Bestellung umgebucht.')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('rendert eine geldneutrale Korrektur mit leerem Kommentar ohne Fehler', () => {

--- a/frontend/src/service/components/table/TischHistorie.tsx
+++ b/frontend/src/service/components/table/TischHistorie.tsx
@@ -124,8 +124,9 @@ interface TischHistorieProps {
     | 'belegDrucken'
     | 'stornobelegDrucken'
   >
-  onStornierungErteilt: () => void
-  onBestellungUmgebucht: () => void
+  // Buchungserfolg (Stornierung/Umbuchung) meldet der Aufrufer über den
+  // Erfolgs-Pop; der nachgelagerte Refetch läuft dort beim Schließen.
+  onErfolg: (nachricht: string) => void
 }
 
 export function TischHistorie({
@@ -133,8 +134,7 @@ export function TischHistorie({
   historieLoading,
   tisch,
   backend,
-  onStornierungErteilt,
-  onBestellungUmgebucht,
+  onErfolg,
 }: TischHistorieProps) {
   const [detail, setDetail] = useState<HistorieEintrag | null>(null)
   const [stornierenQuelle, setStornierenQuelle] = useState<Quelle | null>(null)
@@ -178,7 +178,7 @@ export function TischHistorie({
           }}
           onStornierungErteilt={() => {
             setStornierenQuelle(null)
-            onStornierungErteilt()
+            onErfolg('Stornierung gebucht.')
           }}
         />
       )}
@@ -190,9 +190,9 @@ export function TischHistorie({
           onClose={() => {
             setUmbuchenQuelle(null)
           }}
-          onBestellungUmgebucht={() => {
+          onBestellungUmgebucht={(zielName) => {
             setUmbuchenQuelle(null)
-            onBestellungUmgebucht()
+            onErfolg(`Auf ${zielName} umgebucht.`)
           }}
         />
       )}

--- a/frontend/src/service/components/table/Zahlung.test.tsx
+++ b/frontend/src/service/components/table/Zahlung.test.tsx
@@ -1,13 +1,31 @@
 import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { useMengen } from '@/hooks/use-mengen'
 import { useIsMobile } from '@/hooks/use-mobile'
 
 import type { Position } from '../../table/Bestellung'
 import type { Tisch } from '../../table/Tisch'
 import { ServiceDock } from '../ServiceDock'
 import { Zahlung } from './Zahlung'
+
+// Die Kassieren-Auswahl liegt seit A1 in TablePage; für die isolierten
+// Komponenten-Tests stellt dieser Harness die gehobene Steuerung inklusive der
+// Deckelung auf die unbezahlte Menge bereit.
+function ZahlungHarness(
+  props: Omit<ComponentProps<typeof Zahlung>, 'mengenSteuerung'>,
+) {
+  const unbezahlteMengen: Record<string, number> = {}
+  props.positionen.forEach((position) => {
+    unbezahlteMengen[position.positionId] = position.menge
+  })
+  const mengenSteuerung = useMengen<string>(
+    (positionId) => unbezahlteMengen[positionId] || 0,
+  )
+  return <Zahlung {...props} mengenSteuerung={mengenSteuerung} />
+}
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -61,7 +79,7 @@ const fremdePosition: Position = {
 function renderZahlung(positionen: Position[] = [position]) {
   render(
     <ServiceDock leiste={null}>
-      <Zahlung
+      <ZahlungHarness
         backend={{
           zahlungKassieren: vi.fn().mockResolvedValue(undefined),
         }}
@@ -79,7 +97,7 @@ describe('Zahlung feste Spalte (ab lg)', () => {
     const user = userEvent.setup()
     // Kein ServiceDock: die feste Spalte trägt Aktionsbutton und Restbetrag.
     render(
-      <Zahlung
+      <ZahlungHarness
         backend={{ zahlungKassieren: vi.fn().mockResolvedValue(undefined) }}
         tisch={tisch}
         positionen={[position]}

--- a/frontend/src/service/components/table/Zahlung.test.tsx
+++ b/frontend/src/service/components/table/Zahlung.test.tsx
@@ -193,10 +193,10 @@ describe('Zahlung „Alle auswählen"', () => {
     expect(screen.getByRole('button', { name: /Kassieren/ })).toBeDisabled()
 
     // Erster Tap: eigene Position (2× 3,50 €) voll ausgewählt, fremde nicht.
-    // Genau eine eigene Position → Singular „1 Position" (kein „Alle").
+    // Genau eine eigene Position → Singular „Meine Position auswählen".
     await user.click(
       screen.getByRole('button', {
-        name: /^1 Position auswählen · 7,00/,
+        name: /^Meine Position auswählen · 7,00/,
       }),
     )
     expect(screen.getByText('2 von 2 ausgewählt · 7,00 €')).toBeInTheDocument()
@@ -220,14 +220,14 @@ describe('Zahlung Restbetrag', () => {
     expect(screen.getByText('9,00 €')).toBeInTheDocument()
 
     await user.click(
-      screen.getByRole('button', { name: /^1 Position auswählen/ }),
+      screen.getByRole('button', { name: /^Meine Position auswählen/ }),
     )
 
     expect(screen.getByText('2,00 €')).toBeInTheDocument()
   })
 
   it('beschriftet den Sammel-Button bei mehreren eigenen Positionen im Plural', () => {
-    // Zweite eigene Position (bestellerUserId 1) → Plural „Alle 2 Positionen".
+    // Zweite eigene Position (bestellerUserId 1) → Plural „Meine 2 Positionen".
     const zweite: Position = {
       ...position,
       positionId: '00000000-0000-0000-0000-000000000003',
@@ -238,7 +238,7 @@ describe('Zahlung Restbetrag', () => {
     renderZahlung([position, zweite])
 
     expect(
-      screen.getByRole('button', { name: /^Alle 2 Positionen auswählen/ }),
+      screen.getByRole('button', { name: /^Meine 2 Positionen auswählen/ }),
     ).toBeInTheDocument()
   })
 })

--- a/frontend/src/service/components/table/Zahlung.test.tsx
+++ b/frontend/src/service/components/table/Zahlung.test.tsx
@@ -183,7 +183,7 @@ describe('Zahlung Positionsgruppen', () => {
   })
 })
 
-describe('Zahlung „Alle auswählen"', () => {
+describe('Zahlung „Meine auswählen"', () => {
   it('wählt nur eigene Positionen voll aus und leert die Auswahl beim zweiten Tap', async () => {
     const user = userEvent.setup()
     renderZahlung([position, fremdePosition])

--- a/frontend/src/service/components/table/Zahlung.tsx
+++ b/frontend/src/service/components/table/Zahlung.tsx
@@ -10,7 +10,7 @@ import {
   ItemTitle,
 } from '@/components/ui/item'
 import { useErstAufbau } from '@/hooks/use-erst-aufbau'
-import { useMengen } from '@/hooks/use-mengen'
+import type { MengenSteuerung } from '@/hooks/use-mengen'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { AuthSingleton } from '@/lib/Auth'
 import {
@@ -33,6 +33,9 @@ interface ZahlungProps {
   backend: Pick<TischBackend, 'zahlungKassieren'>
   tisch: Tisch
   positionen: Position[]
+  // Kassieren-Auswahl (Position-ID → Menge, gedeckelt auf die unbezahlte
+  // Menge), von TablePage gehoben, damit sie den Tab-Wechsel überlebt.
+  mengenSteuerung: MengenSteuerung<string>
   // Meldet die erfolgreiche Zahlung samt Bestätigungstext an die Seite, die den
   // Erfolgs-Pop hostet (früher ein toast.success plus direkter Refetch).
   onErfolg: (nachricht: string) => void
@@ -42,6 +45,7 @@ export function Zahlung({
   tisch,
   backend,
   positionen,
+  mengenSteuerung,
   onErfolg,
 }: ZahlungProps) {
   const isMobile = useIsMobile()
@@ -61,7 +65,7 @@ export function Zahlung({
     remove: onRemove,
     reset,
     setAll,
-  } = useMengen<string>((positionId) => unbezahlteMengen[positionId] || 0)
+  } = mengenSteuerung
 
   const meinePositionen = positionen.filter(
     (position) => position.bestellerUserId === AuthSingleton.userId,

--- a/frontend/src/service/components/table/Zahlung.tsx
+++ b/frontend/src/service/components/table/Zahlung.tsx
@@ -166,6 +166,7 @@ export function Zahlung({
             : formatAlleAuswaehlenLabel(
                 meinePositionen.length,
                 eigeneUnbezahltGesamt,
+                'meine',
               )}
         </button>
       )}

--- a/frontend/src/service/components/table/ZahlungAbschluss.test.tsx
+++ b/frontend/src/service/components/table/ZahlungAbschluss.test.tsx
@@ -73,18 +73,18 @@ describe('ZahlungAbschluss (Spalte)', () => {
     expect(screen.getByText('2,00 €')).toBeInTheDocument()
   })
 
-  it('rechnet Rückgeld ohne Zielbetrag und Trinkgeld mit Zielbetrag', async () => {
+  it('rechnet Rückgeld ohne Zielbetrag und Trinkgeld mit Aufrunden-Chip', async () => {
     const user = userEvent.setup()
     renderSpalte()
 
-    // Ohne Zielbetrag: Rückgeld = Erhalten − Gesamt.
+    // Ohne Zielbetrag („genau"): Rückgeld = Erhalten − Gesamt.
     await user.type(screen.getByLabelText('Erhalten'), '10,00')
     expect(screen.getByText('Rückgeld').nextElementSibling).toHaveTextContent(
       '3,00',
     )
 
-    // Mit Zielbetrag (Aufrundung): Trinkgeld = Zielbetrag − Gesamt.
-    await user.type(screen.getByLabelText('Zahlbetrag inkl. Trinkgeld'), '8,00')
+    // Aufrunden-Chip auf 8,00 € (Gesamt 7,00 €): Trinkgeld = Zielbetrag − Gesamt.
+    await user.click(screen.getByRole('button', { name: /8,00/ }))
     expect(screen.getByText('Trinkgeld').nextElementSibling).toHaveTextContent(
       '1,00',
     )

--- a/frontend/src/service/components/table/ZahlungAbschluss.tsx
+++ b/frontend/src/service/components/table/ZahlungAbschluss.tsx
@@ -18,6 +18,7 @@ import type { Tisch } from '../../table/Tisch'
 import type { TischBackend } from '../../table/TischBackend'
 import { AbschlussHeader } from './AbschlussHeader'
 import { AbschlussLeer } from './AbschlussLeer'
+import { AufrundenChips } from './AufrundenChips'
 import { KommentarField } from './CommentField'
 import {
   calculateZahlungsbetraege,
@@ -52,6 +53,7 @@ export function ZahlungAbschluss(props: ZahlungAbschlussProps) {
   const [kommentar, setKommentar] = useState('')
   const [erhaltenEuro, setErhaltenEuro] = useState('')
   const [zielbetragEuro, setZielbetragEuro] = useState('')
+  const [andererAktiv, setAndererAktiv] = useState(false)
 
   const noPositionenSelected = props.positionenToPay.length === 0
 
@@ -64,6 +66,7 @@ export function ZahlungAbschluss(props: ZahlungAbschlussProps) {
     if (warLeerRef.current && !noPositionenSelected) {
       setErhaltenEuro('')
       setZielbetragEuro('')
+      setAndererAktiv(false)
       setKommentar('')
     }
     warLeerRef.current = noPositionenSelected
@@ -84,6 +87,7 @@ export function ZahlungAbschluss(props: ZahlungAbschlussProps) {
     onSuccess: () => {
       setErhaltenEuro('')
       setZielbetragEuro('')
+      setAndererAktiv(false)
       setKommentar('')
       props.zahlungKassiert()
     },
@@ -126,24 +130,13 @@ export function ZahlungAbschluss(props: ZahlungAbschlussProps) {
                   className="w-28"
                 />
               </div>
-              <div className="flex items-center justify-between gap-3">
-                <Label htmlFor="zielbetrag">Zahlbetrag inkl. Trinkgeld</Label>
-                <EuroInput
-                  id="zielbetrag"
-                  value={zielbetragEuro}
-                  onValueChange={setZielbetragEuro}
-                  aria-describedby="zielbetrag-hinweis"
-                  className="w-28"
-                />
-              </div>
-              <p
-                id="zielbetrag-hinweis"
-                className="text-xs text-muted-foreground"
-              >
-                Nur ausfüllen, wenn der Gast aufrundet: den vollen Betrag
-                inklusive Trinkgeld eintragen, dann rechnet die Kasse das
-                Rückgeld passend.
-              </p>
+              <AufrundenChips
+                gesamtCents={props.totalCents}
+                zielbetragEuro={zielbetragEuro}
+                onZielbetragEuroChange={setZielbetragEuro}
+                andererAktiv={andererAktiv}
+                onAndererAktivChange={setAndererAktiv}
+              />
               {rueckgeldCents !== null && (
                 <div className="flex items-baseline justify-between pt-1">
                   <div className="text-[15px] font-semibold">Rückgeld</div>

--- a/frontend/src/service/components/table/ZahlungDrawer.test.tsx
+++ b/frontend/src/service/components/table/ZahlungDrawer.test.tsx
@@ -144,7 +144,7 @@ describe('ZahlungDrawer', () => {
     expect(zahlungKassiert).toHaveBeenCalled()
   })
 
-  it('zeigt den Tischnamen als Überschrift und die Felder in der Reihenfolge Erhalten, Zahlbetrag', async () => {
+  it('zeigt den Tischnamen als Überschrift, das Erhalten-Feld und die Aufrunden-Chips', async () => {
     const user = userEvent.setup()
     renderDrawer()
 
@@ -154,10 +154,16 @@ describe('ZahlungDrawer', () => {
       screen.getByRole('heading', { name: tisch.name }),
     ).toBeInTheDocument()
 
-    const labels = screen
-      .getAllByText(/^(Erhalten|Zahlbetrag inkl\. Trinkgeld)$/)
-      .map((el) => el.textContent)
-    expect(labels).toEqual(['Erhalten', 'Zahlbetrag inkl. Trinkgeld'])
+    // Erhalten bleibt ein Feld; der Zielbetrag wird über Chips gesetzt und das
+    // freie Feld erscheint erst hinter „Anderer …".
+    expect(screen.getByLabelText('Erhalten')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /genau/ })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Anderer …' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText('Zahlbetrag inkl. Trinkgeld'),
+    ).not.toBeInTheDocument()
   })
 
   it('hebt das Rückgeld als größten Betrag im Sheet hervor', async () => {

--- a/frontend/src/service/components/table/drawerUtils.test.ts
+++ b/frontend/src/service/components/table/drawerUtils.test.ts
@@ -4,6 +4,7 @@ import type { Produkt } from '@/service/product/Produkt'
 import type { Position } from '@/service/table/Bestellung'
 
 import {
+  aufrundenVorschlaege,
   calculateTotalPrice,
   calculateZahlungsbetraege,
   selectPositionen,
@@ -180,6 +181,20 @@ describe('calculateZahlungsbetraege', () => {
         trinkgeldCents: null,
       })
     })
+  })
+})
+
+describe('aufrundenVorschlaege', () => {
+  it('liefert 1-€- und 5-€-Vorschlag echt über einem Zwischenbetrag', () => {
+    expect(aufrundenVorschlaege(1230)).toEqual([1300, 1500])
+  })
+
+  it('rundet einen glatten Euro-Betrag auf den nächsten 1-€- und 5-€-Schritt', () => {
+    expect(aufrundenVorschlaege(1300)).toEqual([1400, 1500])
+  })
+
+  it('ersetzt den Doppelgänger, wenn 1-€- und 5-€-Vorschlag zusammenfallen', () => {
+    expect(aufrundenVorschlaege(450)).toEqual([500, 1000])
   })
 })
 

--- a/frontend/src/service/components/table/drawerUtils.ts
+++ b/frontend/src/service/components/table/drawerUtils.ts
@@ -101,6 +101,20 @@ export function calculateZahlungsbetraege(
   }
 }
 
+/**
+ * Two round-up suggestions (in cents) strictly above the order total, for the
+ * tip chips: the smallest whole-Euro multiple and the smallest 5-Euro multiple
+ * above `gesamtCents`. When both coincide (e.g. 4,50 € → both 5 €), the next
+ * 5-Euro multiple replaces the duplicate so the two chips always differ.
+ * Examples: 1230 → [1300, 1500]; 1300 → [1400, 1500]; 450 → [500, 1000].
+ */
+export function aufrundenVorschlaege(gesamtCents: number): number[] {
+  const einEuro = Math.floor(gesamtCents / 100) * 100 + 100
+  let fuenfEuro = Math.floor(gesamtCents / 500) * 500 + 500
+  if (fuenfEuro === einEuro) fuenfEuro += 500
+  return [einEuro, fuenfEuro]
+}
+
 export function toBestellungData(
   products: Produkt[],
   ausgewaehlteMengen: Record<number, number>,


### PR DESCRIPTION
The order cart and payment selection lived inside the Bestellung and Zahlung
tab-content components. Radix unmounts the inactive tab content, so switching
away from a tab and back cleared the in-progress selection (A1).

Hoist both useMengen instances into TablePage and pass the controllers down as
a single `mengenSteuerung` prop. TablePage derives the payment cap from the
table's unbezahltePositionen and resets both selections when the :tischId param
changes (TablePage stays mounted across tisch switches) using React's
adjust-state-during-render pattern. The existing drawer prop chain, the
post-success reset(), and the Abschluss warLeer pattern are unchanged; no
forceMount is introduced and the tab fade-up animation is preserved.

Export a MengenSteuerung<K> type from use-mengen for the lifted controller.
Add TablePage tests covering selection persistence across tab switches and the
per-tisch reset; adapt the isolated Bestellung/Zahlung component tests to
provide the lifted controller via test harnesses.